### PR TITLE
feat(iam,vm): implement IAM03 credential access and AUTH03 key access

### DIFF
--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -179,6 +179,8 @@ domains:
                 notes: ""
                 github_issues:
                   - "#248"
+                labels:
+                  - vm
       - name: Identity and Asset Mgmt (IAM)
         capabilities:
           - description: Manages users, service identities, roles, and permissions across tenants and services. Forms the security foundation of the platform.

--- a/isvctl/configs/providers/aws/config/vm.yaml
+++ b/isvctl/configs/providers/aws/config/vm.yaml
@@ -24,14 +24,16 @@
 #   3. verify_tags        - boto3: Verifies user-defined tags (test)
 #   4. serial_console     - boto3: Retrieves serial console output (test)
 #   5. console_rbac       - boto3: Simulates EC2 serial console IAM access (test)
-#   6. stop_instance      - boto3: Stops EC2, verifies stopped state (test)
-#   7. start_instance     - boto3: Starts stopped EC2, verifies recovery (test)
-#   8. reboot_instance    - boto3: Reboots EC2, validates recovery (test)
-#   9. describe_instance  - boto3: Describes current state, passes SSH info (test)
+#   6. component_key_access - boto3: AUTH03 specified-key SOL access (test)
+#   7. virtual_device_hardening - guest/hypervisor device hardening (test)
+#   8. stop_instance      - boto3: Stops EC2, verifies stopped state (test)
+#   9. start_instance     - boto3: Starts stopped EC2, verifies recovery (test)
+#  10. reboot_instance    - boto3: Reboots EC2, validates recovery (test)
+#  11. describe_instance  - boto3: Describes current state, passes SSH info (test)
 #                           (runs after reboot so IP is current; validation anchor)
-#  10. deploy_nim         - paramiko: Deploys NIM container via SSH (test)
-#  11. teardown_nim       - paramiko: Stops NIM container via SSH (teardown)
-#  12. teardown           - boto3: Terminates EC2 (teardown)
+#  12. deploy_nim         - paramiko: Deploys NIM container via SSH (test)
+#  13. teardown_nim       - paramiko: Stops NIM container via SSH (teardown)
+#  14. teardown           - boto3: Terminates EC2 (teardown)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/config/vm.yaml
@@ -101,6 +103,21 @@ commands:
         args:
           - "--instance-id"
           - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+
+      # AWS-specific: Specified key access to SOL (AUTH03); network devices provider-hidden
+      - name: component_key_access
+        phase: test
+        command: "python3 ../scripts/vm/component_key_access.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--key-name"
+          - "{{steps.launch_instance.key_name}}"
           - "--region"
           - "{{region}}"
         timeout: 120

--- a/isvctl/configs/providers/aws/scripts/common/serial_console.py
+++ b/isvctl/configs/providers/aws/scripts/common/serial_console.py
@@ -27,6 +27,7 @@ from typing import Any
 from botocore.exceptions import ClientError
 
 RETENTION_EVIDENCE_LIMITATION = "EC2 GetConsoleOutput does not prove one-month log retention"
+SERIAL_ACCESS_DISABLED_SKIP_REASON = "EC2 serial console access is disabled for this account or region"
 SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED = 30
 
 

--- a/isvctl/configs/providers/aws/scripts/iam/test_credentials.py
+++ b/isvctl/configs/providers/aws/scripts/iam/test_credentials.py
@@ -28,8 +28,8 @@ Output JSON:
     "account_id": "123456789",
     "arn": "arn:aws:iam::...",
     "tests": {
-        "sts_identity": {"passed": true},
-        "iam_access": {"passed": true}
+        "identity": {"passed": true},
+        "access": {"passed": true}
     }
 }
 """
@@ -69,9 +69,9 @@ def test_sts_identity(session: boto3.Session, result: dict) -> bool:
             result["account_id"] = identity["Account"]
             result["arn"] = identity["Arn"]
             result["user_id"] = identity["UserId"]
-            result["tests"]["sts_identity"] = {"passed": True}
+            result["tests"]["identity"] = {"passed": True}
             if attempt > 0:
-                result["tests"]["sts_identity"]["retries"] = attempt
+                result["tests"]["identity"]["retries"] = attempt
             return True
         except ClientError as e:
             last_error = e
@@ -88,7 +88,7 @@ def test_sts_identity(session: boto3.Session, result: dict) -> bool:
         error_type, error_msg = classify_aws_error(last_error)
         result["error_type"] = error_type
         result["error"] = error_msg
-        result["tests"]["sts_identity"] = {"passed": False, "error": error_msg}
+        result["tests"]["identity"] = {"passed": False, "error": error_msg}
     return False
 
 
@@ -117,19 +117,21 @@ def main() -> int:
         print(json.dumps(result, indent=2))
         return 1
 
-    # Test IAM access
+    # Test authorized resource access (IAM GetUser, or AccessDenied proving authz)
     try:
         iam = session.client("iam")
         iam.get_user()
-        result["tests"]["iam_access"] = {"passed": True}
+        result["tests"]["access"] = {"passed": True}
     except ClientError as e:
         if e.response["Error"]["Code"] == "AccessDenied":
             # Access denied means credentials work but limited permissions
-            result["tests"]["iam_access"] = {"passed": True, "note": "Access denied (expected)"}
+            result["tests"]["access"] = {"passed": True, "note": "Access denied (expected)"}
         else:
-            result["tests"]["iam_access"] = {"passed": False, "error": str(e)}
+            result["tests"]["access"] = {"passed": False, "error": str(e)}
 
-    result["success"] = result["tests"]["sts_identity"]["passed"]
+    result["success"] = (
+        result["tests"]["identity"]["passed"] and result["tests"].get("access", {}).get("passed") is True
+    )
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1
 

--- a/isvctl/configs/providers/aws/scripts/iam/test_credentials.py
+++ b/isvctl/configs/providers/aws/scripts/iam/test_credentials.py
@@ -129,9 +129,7 @@ def main() -> int:
         else:
             result["tests"]["access"] = {"passed": False, "error": str(e)}
 
-    result["success"] = (
-        result["tests"]["identity"]["passed"] and result["tests"].get("access", {}).get("passed") is True
-    )
+    result["success"] = result["tests"]["identity"]["passed"] and result["tests"]["access"]["passed"]
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1
 

--- a/isvctl/configs/providers/aws/scripts/vm/component_key_access.py
+++ b/isvctl/configs/providers/aws/scripts/vm/component_key_access.py
@@ -82,7 +82,7 @@ def _probe_sol_access(ec2: Any, eic: Any, instance_id: str, ssh_public_key: str)
         response = eic.send_serial_console_ssh_public_key(
             InstanceId=instance_id,
             SSHPublicKey=ssh_public_key,
-            SerialPort=1,
+            SerialPort=0,
         )
     except ClientError as exc:
         return {"passed": False, "error": str(exc), "probes": ["send_serial_console_ssh_public_key"]}

--- a/isvctl/configs/providers/aws/scripts/vm/component_key_access.py
+++ b/isvctl/configs/providers/aws/scripts/vm/component_key_access.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prove a specified SSH key can access SOL (serial console) on AWS EC2.
+
+AUTH03-01: after AUTH02 launches an instance with a requested key, push that
+key's public material via EC2 Instance Connect serial-console authorization.
+Tenant-visible network-device SSH is not offered on AWS, so that probe is
+marked provider-hidden.
+
+Usage:
+    python component_key_access.py --instance-id i-xxx --key-file /tmp/key.pem \\
+        --key-name isv-test-key --region us-west-2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+from common.serial_console import check_serial_access
+from paramiko import ECDSAKey, Ed25519Key, RSAKey
+from paramiko.ssh_exception import SSHException
+
+SERIAL_ACCESS_DISABLED_SKIP_REASON = "EC2 serial console access is disabled for this account or region"
+NETWORK_DEVICE_HIDDEN_MESSAGE = "AWS does not expose tenant-visible network-device SSH for key-based access"
+REQUIRED_TESTS = ("sol_access", "network_device_access")
+
+
+def _make_test_result(passed: bool, **details: Any) -> dict[str, Any]:
+    """Build a standard test result dictionary."""
+    return {"passed": passed, **details}
+
+
+def _mark_skipped(result: dict[str, Any], reason: str) -> dict[str, Any]:
+    """Mark the whole AUTH03 probe as skipped with skipped subtest evidence."""
+    result["success"] = True
+    result["skipped"] = True
+    result["skip_reason"] = reason
+    result["tests"] = {
+        name: {
+            "passed": True,
+            "skipped": True,
+            "skip_reason": reason,
+        }
+        for name in REQUIRED_TESTS
+    }
+    return result
+
+
+def _load_openssh_public_key(key_file: str) -> str:
+    """Derive an OpenSSH public-key line from a private key PEM file."""
+    path = Path(key_file)
+    if not path.is_file():
+        msg = f"Key file not found: {key_file}"
+        raise FileNotFoundError(msg)
+
+    loaders = (RSAKey, ECDSAKey, Ed25519Key)
+    last_error: Exception | None = None
+    for loader in loaders:
+        try:
+            private_key = loader.from_private_key_file(str(path))
+            return f"{private_key.get_name()} {private_key.get_base64()}"
+        except (SSHException, OSError, ValueError) as exc:
+            last_error = exc
+
+    msg = f"Unable to load private key from {key_file}: {last_error}"
+    raise ValueError(msg)
+
+
+def _probe_sol_access(ec2: Any, eic: Any, instance_id: str, ssh_public_key: str) -> dict[str, Any]:
+    """Authorize the specified public key for EC2 serial-console SSH."""
+    serial_access = check_serial_access(ec2)
+    if serial_access.get("error"):
+        return _make_test_result(False, error=serial_access["error"], probes=["serial_console_access"])
+    if serial_access.get("enabled") is not True:
+        return _make_test_result(
+            False,
+            skipped=True,
+            skip_reason=SERIAL_ACCESS_DISABLED_SKIP_REASON,
+            probes=["serial_console_access"],
+        )
+
+    try:
+        response = eic.send_serial_console_ssh_public_key(
+            InstanceId=instance_id,
+            SSHPublicKey=ssh_public_key,
+            SerialPort=1,
+        )
+    except ClientError as exc:
+        return _make_test_result(False, error=str(exc), probes=["send_serial_console_ssh_public_key"])
+
+    success = bool(response.get("Success")) if isinstance(response, dict) else False
+    request_id = ""
+    if isinstance(response, dict):
+        request_id = str(response.get("RequestId") or response.get("ResponseMetadata", {}).get("RequestId", ""))
+
+    return _make_test_result(
+        success,
+        message="Authorized specified key for EC2 serial console SSH",
+        probes=["serial_console_access", "send_serial_console_ssh_public_key"],
+        request_id=request_id or None,
+    )
+
+
+def _probe_network_device_access() -> dict[str, Any]:
+    """AWS has no tenant-visible network-device key path; mark provider-hidden."""
+    return _make_test_result(
+        True,
+        provider_hidden=True,
+        message=NETWORK_DEVICE_HIDDEN_MESSAGE,
+        probes=["network_device_ssh"],
+    )
+
+
+@handle_aws_errors
+def main() -> int:
+    """Run AUTH03 key-based component access probes and emit JSON."""
+    parser = argparse.ArgumentParser(description="Prove specified key access to SOL / network devices")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--key-file", required=True, help="Path to the instance private key PEM")
+    parser.add_argument("--key-name", required=True, help="Key pair name requested at launch (AUTH02)")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "test_name": "component_key_access",
+        "instance_id": args.instance_id,
+        "key_name": args.key_name,
+        "tests": {},
+    }
+
+    try:
+        ssh_public_key = _load_openssh_public_key(args.key_file)
+    except (OSError, ValueError) as exc:
+        result["error"] = str(exc)
+        result["tests"]["sol_access"] = _make_test_result(False, error=str(exc))
+        result["tests"]["network_device_access"] = _probe_network_device_access()
+        print(json.dumps(result, indent=2))
+        return 1
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+    eic = boto3.client("ec2-instance-connect", region_name=args.region)
+
+    sol = _probe_sol_access(ec2, eic, args.instance_id, ssh_public_key)
+    if sol.get("skipped") is True:
+        print(json.dumps(_mark_skipped(result, sol.get("skip_reason") or SERIAL_ACCESS_DISABLED_SKIP_REASON), indent=2))
+        return 0
+
+    result["tests"]["sol_access"] = sol
+    result["tests"]["network_device_access"] = _probe_network_device_access()
+    result["success"] = sol.get("passed") is True and result["tests"]["network_device_access"].get("passed") is True
+    if not result["success"] and sol.get("error"):
+        result["error"] = sol["error"]
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/vm/component_key_access.py
+++ b/isvctl/configs/providers/aws/scripts/vm/component_key_access.py
@@ -40,34 +40,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import boto3
 from botocore.exceptions import ClientError
 from common.errors import handle_aws_errors
-from common.serial_console import check_serial_access
+from common.serial_console import SERIAL_ACCESS_DISABLED_SKIP_REASON, check_serial_access
 from paramiko import ECDSAKey, Ed25519Key, RSAKey
 from paramiko.ssh_exception import SSHException
-
-SERIAL_ACCESS_DISABLED_SKIP_REASON = "EC2 serial console access is disabled for this account or region"
-NETWORK_DEVICE_HIDDEN_MESSAGE = "AWS does not expose tenant-visible network-device SSH for key-based access"
-REQUIRED_TESTS = ("sol_access", "network_device_access")
-
-
-def _make_test_result(passed: bool, **details: Any) -> dict[str, Any]:
-    """Build a standard test result dictionary."""
-    return {"passed": passed, **details}
-
-
-def _mark_skipped(result: dict[str, Any], reason: str) -> dict[str, Any]:
-    """Mark the whole AUTH03 probe as skipped with skipped subtest evidence."""
-    result["success"] = True
-    result["skipped"] = True
-    result["skip_reason"] = reason
-    result["tests"] = {
-        name: {
-            "passed": True,
-            "skipped": True,
-            "skip_reason": reason,
-        }
-        for name in REQUIRED_TESTS
-    }
-    return result
 
 
 def _load_openssh_public_key(key_file: str) -> str:
@@ -94,14 +69,14 @@ def _probe_sol_access(ec2: Any, eic: Any, instance_id: str, ssh_public_key: str)
     """Authorize the specified public key for EC2 serial-console SSH."""
     serial_access = check_serial_access(ec2)
     if serial_access.get("error"):
-        return _make_test_result(False, error=serial_access["error"], probes=["serial_console_access"])
+        return {"passed": False, "error": serial_access["error"], "probes": ["serial_console_access"]}
     if serial_access.get("enabled") is not True:
-        return _make_test_result(
-            False,
-            skipped=True,
-            skip_reason=SERIAL_ACCESS_DISABLED_SKIP_REASON,
-            probes=["serial_console_access"],
-        )
+        return {
+            "passed": False,
+            "skipped": True,
+            "skip_reason": SERIAL_ACCESS_DISABLED_SKIP_REASON,
+            "probes": ["serial_console_access"],
+        }
 
     try:
         response = eic.send_serial_console_ssh_public_key(
@@ -110,29 +85,23 @@ def _probe_sol_access(ec2: Any, eic: Any, instance_id: str, ssh_public_key: str)
             SerialPort=1,
         )
     except ClientError as exc:
-        return _make_test_result(False, error=str(exc), probes=["send_serial_console_ssh_public_key"])
+        return {"passed": False, "error": str(exc), "probes": ["send_serial_console_ssh_public_key"]}
 
-    success = bool(response.get("Success")) if isinstance(response, dict) else False
-    request_id = ""
-    if isinstance(response, dict):
-        request_id = str(response.get("RequestId") or response.get("ResponseMetadata", {}).get("RequestId", ""))
-
-    return _make_test_result(
-        success,
-        message="Authorized specified key for EC2 serial console SSH",
-        probes=["serial_console_access", "send_serial_console_ssh_public_key"],
-        request_id=request_id or None,
-    )
+    return {
+        "passed": bool(response.get("Success")),
+        "message": "Authorized specified key for EC2 serial console SSH",
+        "probes": ["serial_console_access", "send_serial_console_ssh_public_key"],
+    }
 
 
 def _probe_network_device_access() -> dict[str, Any]:
     """AWS has no tenant-visible network-device key path; mark provider-hidden."""
-    return _make_test_result(
-        True,
-        provider_hidden=True,
-        message=NETWORK_DEVICE_HIDDEN_MESSAGE,
-        probes=["network_device_ssh"],
-    )
+    return {
+        "passed": True,
+        "provider_hidden": True,
+        "message": "AWS does not expose tenant-visible network-device SSH for key-based access",
+        "probes": ["network_device_ssh"],
+    }
 
 
 @handle_aws_errors
@@ -158,8 +127,7 @@ def main() -> int:
         ssh_public_key = _load_openssh_public_key(args.key_file)
     except (OSError, ValueError) as exc:
         result["error"] = str(exc)
-        result["tests"]["sol_access"] = _make_test_result(False, error=str(exc))
-        result["tests"]["network_device_access"] = _probe_network_device_access()
+        result["tests"]["sol_access"] = {"passed": False, "error": str(exc)}
         print(json.dumps(result, indent=2))
         return 1
 
@@ -168,12 +136,15 @@ def main() -> int:
 
     sol = _probe_sol_access(ec2, eic, args.instance_id, ssh_public_key)
     if sol.get("skipped") is True:
-        print(json.dumps(_mark_skipped(result, sol.get("skip_reason") or SERIAL_ACCESS_DISABLED_SKIP_REASON), indent=2))
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = sol["skip_reason"]
+        print(json.dumps(result, indent=2))
         return 0
 
     result["tests"]["sol_access"] = sol
     result["tests"]["network_device_access"] = _probe_network_device_access()
-    result["success"] = sol.get("passed") is True and result["tests"]["network_device_access"].get("passed") is True
+    result["success"] = all(test["passed"] for test in result["tests"].values())
     if not result["success"] and sol.get("error"):
         result["error"] = sol["error"]
 

--- a/isvctl/configs/providers/aws/scripts/vm/console_rbac.py
+++ b/isvctl/configs/providers/aws/scripts/vm/console_rbac.py
@@ -41,13 +41,12 @@ import boto3
 import botocore.session
 from botocore.exceptions import ClientError
 from common.errors import handle_aws_errors
-from common.serial_console import check_serial_access
+from common.serial_console import SERIAL_ACCESS_DISABLED_SKIP_REASON, check_serial_access
 
 CONSOLE_ACTION = "ec2-instance-connect:SendSerialConsoleSSHPublicKey"
 TEST_USER_PREFIX = "isv-console-rbac-test-"
 ALLOW_POLICY_NAME = "IsvConsoleRbacScopedAccess"
 OWNER_TAG = {"Key": "CreatedBy", "Value": "isvtest"}
-SERIAL_ACCESS_DISABLED_SKIP_REASON = "EC2 serial console access is disabled for this account or region"
 REQUIRED_TESTS = (
     "serial_console_access_enabled",
     "denied_principal_cannot_access_console",

--- a/isvctl/configs/providers/my-isv/config/vm.yaml
+++ b/isvctl/configs/providers/my-isv/config/vm.yaml
@@ -46,10 +46,11 @@
 #     7. serial_console   - Confirm serial console access
 #     8. console_rbac     - Verify console access is RBAC-scoped
 #     9. component_key_access - AUTH03 specified-key SOL / network device access
-#    10. deploy_nim       - SKIPPED (needs real SSH)
+#    10. virtual_device_hardening - Confirm unused virtio devices are absent
+#    11. deploy_nim       - SKIPPED (needs real SSH)
 #   TEARDOWN
-#    11. teardown_nim     - SKIPPED (needs real SSH)
-#    12. teardown         - Terminate the VM
+#    12. teardown_nim     - SKIPPED (needs real SSH)
+#    13. teardown         - Terminate the VM
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/vm.yaml

--- a/isvctl/configs/providers/my-isv/config/vm.yaml
+++ b/isvctl/configs/providers/my-isv/config/vm.yaml
@@ -25,7 +25,7 @@
 #   (InstanceStateCheck, InstanceCreatedCheck, InstanceListCheck,
 #    InstanceTagCheck, InstanceStopCheck, InstanceStartCheck,
 #    StableIdentifierCheck, InstanceRebootCheck, SerialConsoleCheck,
-#    ConsoleRbacCheck, StepSuccessCheck). SSH-based host checks (ConnectivityCheck,
+#    ConsoleRbacCheck, ComponentKeyAccessCheck, StepSuccessCheck). SSH-based host checks (ConnectivityCheck,
 #    GpuCheck, DriverCheck, CpuInfoCheck, NIM checks, etc.) are excluded
 #    via `exclude.labels: [ssh]` because a dummy-success stub cannot
 #    spin up a real host to SSH into. The deploy_nim / teardown_nim
@@ -45,10 +45,11 @@
 #     6. reboot_instance  - Reboot it
 #     7. serial_console   - Confirm serial console access
 #     8. console_rbac     - Verify console access is RBAC-scoped
-#     9. deploy_nim       - SKIPPED (needs real SSH)
+#     9. component_key_access - AUTH03 specified-key SOL / network device access
+#    10. deploy_nim       - SKIPPED (needs real SSH)
 #   TEARDOWN
-#    10. teardown_nim     - SKIPPED (needs real SSH)
-#    11. teardown         - Terminate the VM
+#    11. teardown_nim     - SKIPPED (needs real SSH)
+#    12. teardown         - Terminate the VM
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/vm.yaml
@@ -150,6 +151,20 @@ commands:
         args:
           - "--instance-id"
           - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
+      - name: component_key_access
+        phase: test
+        command: "python ../scripts/vm/component_key_access.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--key-name"
+          - "{{steps.launch_instance.key_name}}"
           - "--region"
           - "{{region}}"
         timeout: 60

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -29,7 +29,7 @@ template, then fill in the TODOs.
 |--------|---------|----------|---------------|---------------|
 | `iam/` | 3 | [`suites/iam.yaml`](../../../suites/iam.yaml) | [`config/iam.yaml`](../config/iam.yaml) | [`providers/aws/scripts/iam/`](../../aws/scripts/iam/) |
 | `control-plane/` | 10 | [`suites/control-plane.yaml`](../../../suites/control-plane.yaml) | [`config/control-plane.yaml`](../config/control-plane.yaml) | [`providers/aws/scripts/control-plane/`](../../aws/scripts/control-plane/) |
-| `vm/` | 9 | [`suites/vm.yaml`](../../../suites/vm.yaml) | [`config/vm.yaml`](../config/vm.yaml) | [`providers/aws/scripts/vm/`](../../aws/scripts/vm/) |
+| `vm/` | 10 | [`suites/vm.yaml`](../../../suites/vm.yaml) | [`config/vm.yaml`](../config/vm.yaml) | [`providers/aws/scripts/vm/`](../../aws/scripts/vm/) |
 | `bare_metal/` | 12 | [`suites/bare_metal.yaml`](../../../suites/bare_metal.yaml) | [`config/bare_metal.yaml`](../config/bare_metal.yaml) | [`providers/aws/scripts/bare_metal/`](../../aws/scripts/bare_metal/) |
 | `storage/` | 17 | [`suites/storage.yaml`](../../../suites/storage.yaml) | [`config/storage.yaml`](../config/storage.yaml) | [`providers/aws/scripts/storage/`](../../aws/scripts/storage/) |
 | `network/` | 18 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |

--- a/isvctl/configs/providers/my-isv/scripts/vm/component_key_access.py
+++ b/isvctl/configs/providers/my-isv/scripts/vm/component_key_access.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Component key access (SOL / network devices) - TEMPLATE.
+
+AUTH03-01: prove the specified key from launch can access serial-over-LAN
+and network devices where the platform exposes them.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "vm",
+    "test_name": "component_key_access",
+    "instance_id": "<id>",
+    "key_name": "<key>",
+    "tests": {
+      "sol_access": {"passed": true},
+      "network_device_access": {"passed": true}
+    }
+  }
+
+When a component class is not customer-visible, mark that subtest
+``provider_hidden: true`` with ``passed: true`` instead of failing.
+
+Usage:
+    python component_key_access.py --instance-id <id> --key-file <path> \\
+        --key-name <name> --region <region>
+
+Reference implementation: ../../../aws/scripts/vm/component_key_access.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def _demo_result(instance_id: str, key_name: str) -> dict[str, Any]:
+    """Return a passing demo payload for the AUTH03 contract."""
+    return {
+        "success": True,
+        "platform": "vm",
+        "test_name": "component_key_access",
+        "instance_id": instance_id,
+        "key_name": key_name,
+        "tests": {
+            "sol_access": {
+                "passed": True,
+                "message": "Demo SOL access via specified key",
+                "probes": ["serial_console_ssh"],
+            },
+            "network_device_access": {
+                "passed": True,
+                "message": "Demo network-device access via specified key",
+                "probes": ["network_device_ssh"],
+            },
+        },
+    }
+
+
+def main() -> int:
+    """Probe key-based SOL / network-device access (template) and emit JSON."""
+    parser = argparse.ArgumentParser(description="Component key access (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance identifier")
+    parser.add_argument("--key-file", required=True, help="Path to the instance private key")
+    parser.add_argument("--key-name", required=True, help="Key name requested at launch")
+    parser.add_argument("--region", default="my-isv-region-1", help="Region")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "test_name": "component_key_access",
+        "instance_id": args.instance_id,
+        "key_name": args.key_name,
+        "tests": {},
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's key-access proof  ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    sol = platform.authorize_sol_key(                             ║
+    # ║        instance_id=args.instance_id,                             ║
+    # ║        key_file=args.key_file,                                   ║
+    # ║    )                                                             ║
+    # ║    result["tests"]["sol_access"] = {"passed": sol.ok}            ║
+    # ║    net = platform.probe_network_device_key(args.key_file)        ║
+    # ║    result["tests"]["network_device_access"] = {                   ║
+    # ║        "passed": True,                                           ║
+    # ║        "provider_hidden": not net.available,                     ║
+    # ║    }                                                             ║
+    # ║    result["success"] = True                                      ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result = _demo_result(args.instance_id, args.key_name)
+    else:
+        result["error"] = "Not implemented - replace with your platform's component key access logic"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -85,7 +85,7 @@ For the domain / script-count / AWS-reference overview see the
 | `list_instances` | test | `providers/my-isv/scripts/vm/list_instances.py` | `instances`, `total_count` |
 | `verify_tags` | test | `providers/my-isv/scripts/vm/describe_tags.py` | `instance_id`, `tags`, `tag_count` |
 | `serial_console` | test | `providers/my-isv/scripts/vm/serial_console.py` | `console_available`, `serial_access_enabled` |
-| `component_key_access` | test | `providers/my-isv/scripts/vm/component_key_access.py` | `key_name`, `tests.sol_access.passed`, `tests.network_device_access.passed` (`ComponentKeyAccessCheck` / AUTH03-01) |
+| `component_key_access` | test | `providers/my-isv/scripts/vm/component_key_access.py` | `key_name`; for non-skipped results also `tests.sol_access.passed`, `tests.network_device_access.passed` (`ComponentKeyAccessCheck` / AUTH03-01; AWS may emit top-level `skipped` when serial console access is disabled) |
 | `stop_instance` | test | `providers/my-isv/scripts/vm/stop_instance.py` | `instance_id`, `state`, `stop_initiated` |
 | `start_instance` | test | `providers/my-isv/scripts/vm/start_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
 | `reboot_instance` | test | `providers/my-isv/scripts/vm/reboot_instance.py` | `reboot_initiated`, `ssh_ready`, `uptime_seconds` |

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -31,7 +31,7 @@ For the domain / script-count / AWS-reference overview see the
 | Step | Phase | Script | Key JSON Fields |
 |------|-------|--------|-----------------|
 | `create_user` | setup | `providers/my-isv/scripts/iam/create_user.py` | `username`, `user_id`, `access_key_id`, `secret_access_key` |
-| `test_credentials` | test | `providers/my-isv/scripts/iam/test_credentials.py` | `account_id`, `tests.identity.passed`, `tests.access.passed` |
+| `test_credentials` | test | `providers/my-isv/scripts/iam/test_credentials.py` | `account_id`, `tests.identity.passed`, `tests.access.passed` (`IamCredentialAccessCheck` / IAM03-01) |
 | `teardown` | teardown | `providers/my-isv/scripts/iam/delete_user.py` | `resources_deleted`, `message` |
 
 ### Network (`network.yaml`)
@@ -81,10 +81,11 @@ For the domain / script-count / AWS-reference overview see the
 
 | Step | Phase | Script | Key JSON Fields |
 |------|-------|--------|-----------------|
-| `launch_instance` | setup | `providers/my-isv/scripts/vm/launch_instance.py` | `instance_id`, `public_ip`, `key_file`, `vpc_id` |
+| `launch_instance` | setup | `providers/my-isv/scripts/vm/launch_instance.py` | `instance_id`, `public_ip`, `key_file`, `vpc_id`, `requested_key_name`, `key_name` |
 | `list_instances` | test | `providers/my-isv/scripts/vm/list_instances.py` | `instances`, `total_count` |
 | `verify_tags` | test | `providers/my-isv/scripts/vm/describe_tags.py` | `instance_id`, `tags`, `tag_count` |
 | `serial_console` | test | `providers/my-isv/scripts/vm/serial_console.py` | `console_available`, `serial_access_enabled` |
+| `component_key_access` | test | `providers/my-isv/scripts/vm/component_key_access.py` | `key_name`, `tests.sol_access.passed`, `tests.network_device_access.passed` (`ComponentKeyAccessCheck` / AUTH03-01) |
 | `stop_instance` | test | `providers/my-isv/scripts/vm/stop_instance.py` | `instance_id`, `state`, `stop_initiated` |
 | `start_instance` | test | `providers/my-isv/scripts/vm/start_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
 | `reboot_instance` | test | `providers/my-isv/scripts/vm/reboot_instance.py` | `reboot_initiated`, `ssh_ready`, `uptime_seconds` |

--- a/isvctl/configs/suites/iam.yaml
+++ b/isvctl/configs/suites/iam.yaml
@@ -62,10 +62,10 @@ tests:
     credentials:
       step: test_credentials
       checks:
-        FieldExistsCheck:
+        IamCredentialAccessCheck:
           test_id: "IAM03-01"
           labels: ["iam"]
-          field: "account_id"
+          required_tests: ["identity", "access"]
         StepSuccessCheck:
           test_id: "N/A"
           labels: ["iam"]

--- a/isvctl/configs/suites/iam.yaml
+++ b/isvctl/configs/suites/iam.yaml
@@ -65,7 +65,6 @@ tests:
         IamCredentialAccessCheck:
           test_id: "IAM03-01"
           labels: ["iam"]
-          required_tests: ["identity", "access"]
         StepSuccessCheck:
           test_id: "N/A"
           labels: ["iam"]

--- a/isvctl/configs/suites/vm.yaml
+++ b/isvctl/configs/suites/vm.yaml
@@ -49,7 +49,8 @@ tests:
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.
   #
   # Layout mirrors bare_metal.yaml:
-  #   launch checks -> list -> tags -> serial_console -> console_rbac -> cloud_init
+  #   launch checks -> list -> tags -> serial_console -> console_rbac
+  #   -> component_key_access (AUTH03) -> cloud_init
   #   -> describe_instance (SSH / GPU / host anchor, post-reboot)
   #   -> lifecycle (stop / start / reboot)
   #   -> NIM -> teardown
@@ -68,6 +69,14 @@ tests:
         InstanceSpecifiedKeyCheck:
           test_id: "AUTH02-01"
           labels: ["vm"]
+
+    component_key_access:
+      step: component_key_access
+      checks:
+        ComponentKeyAccessCheck:
+          test_id: "AUTH03-01"
+          labels: ["vm"]
+          required_tests: ["sol_access", "network_device_access"]
 
     instance_created:
       step: launch_instance

--- a/isvctl/configs/suites/vm.yaml
+++ b/isvctl/configs/suites/vm.yaml
@@ -76,7 +76,6 @@ tests:
         ComponentKeyAccessCheck:
           test_id: "AUTH03-01"
           labels: ["vm"]
-          required_tests: ["sol_access", "network_device_access"]
 
     instance_created:
       step: launch_instance

--- a/isvctl/tests/test_component_key_access_contract.py
+++ b/isvctl/tests/test_component_key_access_contract.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for AUTH03 component key access scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+from paramiko import RSAKey
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "vm"
+MY_ISV_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "vm"
+
+
+def _load_aws_script(script_name: str) -> ModuleType:
+    """Load an AWS VM script as a module for direct helper testing."""
+    script_path = AWS_VM_SCRIPTS / script_name
+    spec = importlib.util.spec_from_file_location(f"test_{script_path.stem}", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_temp_rsa_key() -> Path:
+    """Create a temporary RSA private key PEM for SOL authorization tests."""
+    key = RSAKey.generate(2048)
+    path = Path(tempfile.mkstemp(prefix="isv-auth03-", suffix=".pem")[1])
+    key.write_private_key_file(str(path))
+    return path
+
+
+def test_load_openssh_public_key_from_rsa_pem() -> None:
+    """Private key PEM derives an OpenSSH public key line."""
+    module = _load_aws_script("component_key_access.py")
+    key_path = _write_temp_rsa_key()
+    try:
+        public_key = module._load_openssh_public_key(str(key_path))
+    finally:
+        key_path.unlink(missing_ok=True)
+
+    assert public_key.startswith("ssh-rsa ")
+
+
+def test_probe_sol_access_skips_when_serial_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabled serial console yields a skipped SOL probe."""
+    module = _load_aws_script("component_key_access.py")
+    monkeypatch.setattr(module, "check_serial_access", lambda _ec2: {"enabled": False})
+
+    result = module._probe_sol_access(MagicMock(), MagicMock(), "i-abc", "ssh-rsa AAAAB3")
+
+    assert result["passed"] is False
+    assert result["skipped"] is True
+
+
+def test_probe_sol_access_authorizes_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enabled serial console + Instance Connect Success proves SOL key access."""
+    module = _load_aws_script("component_key_access.py")
+    monkeypatch.setattr(module, "check_serial_access", lambda _ec2: {"enabled": True})
+    eic = MagicMock()
+    eic.send_serial_console_ssh_public_key.return_value = {"Success": True, "RequestId": "req-1"}
+
+    result = module._probe_sol_access(MagicMock(), eic, "i-abc", "ssh-rsa AAAAB3")
+
+    assert result["passed"] is True
+    eic.send_serial_console_ssh_public_key.assert_called_once()
+
+
+def test_probe_sol_access_fails_on_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Instance Connect API errors fail the SOL probe."""
+    module = _load_aws_script("component_key_access.py")
+    monkeypatch.setattr(module, "check_serial_access", lambda _ec2: {"enabled": True})
+    eic = MagicMock()
+    eic.send_serial_console_ssh_public_key.side_effect = ClientError(
+        {"Error": {"Code": "InvalidInstanceID.NotFound", "Message": "missing"}},
+        "SendSerialConsoleSSHPublicKey",
+    )
+
+    result = module._probe_sol_access(MagicMock(), eic, "i-missing", "ssh-rsa AAAAB3")
+
+    assert result["passed"] is False
+    assert "missing" in result["error"]
+
+
+def test_network_device_access_is_provider_hidden() -> None:
+    """AWS marks network-device SSH as provider-hidden rather than failing."""
+    module = _load_aws_script("component_key_access.py")
+
+    result = module._probe_network_device_access()
+
+    assert result["passed"] is True
+    assert result["provider_hidden"] is True
+
+
+def test_my_isv_demo_component_key_access_emits_contract() -> None:
+    """Demo mode emits the AUTH03 JSON contract for make demo-test."""
+    import os
+
+    script = MY_ISV_VM_SCRIPTS / "component_key_access.py"
+    env = os.environ.copy()
+    env["ISVCTL_DEMO_MODE"] = "1"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--instance-id",
+            "dummy-vm-0001",
+            "--key-file",
+            "/tmp/dummy-key.pem",
+            "--key-name",
+            "isv-test-gpu",
+            "--region",
+            "my-isv-region-1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload: dict[str, Any] = json.loads(completed.stdout)
+    assert payload["success"] is True
+    assert payload["key_name"] == "isv-test-gpu"
+    assert payload["tests"]["sol_access"]["passed"] is True
+    assert payload["tests"]["network_device_access"]["passed"] is True

--- a/isvctl/tests/test_component_key_access_contract.py
+++ b/isvctl/tests/test_component_key_access_contract.py
@@ -17,13 +17,11 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
+import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -31,44 +29,26 @@ import pytest
 from botocore.exceptions import ClientError
 from paramiko import RSAKey
 
+from .conftest import load_vm_script
+
 ISVCTL_ROOT = Path(__file__).resolve().parents[1]
-AWS_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "vm"
 MY_ISV_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "vm"
 
 
-def _load_aws_script(script_name: str) -> ModuleType:
-    """Load an AWS VM script as a module for direct helper testing."""
-    script_path = AWS_VM_SCRIPTS / script_name
-    spec = importlib.util.spec_from_file_location(f"test_{script_path.stem}", script_path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def _write_temp_rsa_key() -> Path:
-    """Create a temporary RSA private key PEM for SOL authorization tests."""
-    key = RSAKey.generate(2048)
-    path = Path(tempfile.mkstemp(prefix="isv-auth03-", suffix=".pem")[1])
-    key.write_private_key_file(str(path))
-    return path
-
-
-def test_load_openssh_public_key_from_rsa_pem() -> None:
+def test_load_openssh_public_key_from_rsa_pem(tmp_path: Path) -> None:
     """Private key PEM derives an OpenSSH public key line."""
-    module = _load_aws_script("component_key_access.py")
-    key_path = _write_temp_rsa_key()
-    try:
-        public_key = module._load_openssh_public_key(str(key_path))
-    finally:
-        key_path.unlink(missing_ok=True)
+    module = load_vm_script("component_key_access.py")
+    key_path = tmp_path / "isv-auth03-key.pem"
+    RSAKey.generate(2048).write_private_key_file(str(key_path))
+
+    public_key = module._load_openssh_public_key(str(key_path))
 
     assert public_key.startswith("ssh-rsa ")
 
 
 def test_probe_sol_access_skips_when_serial_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disabled serial console yields a skipped SOL probe."""
-    module = _load_aws_script("component_key_access.py")
+    module = load_vm_script("component_key_access.py")
     monkeypatch.setattr(module, "check_serial_access", lambda _ec2: {"enabled": False})
 
     result = module._probe_sol_access(MagicMock(), MagicMock(), "i-abc", "ssh-rsa AAAAB3")
@@ -79,7 +59,7 @@ def test_probe_sol_access_skips_when_serial_disabled(monkeypatch: pytest.MonkeyP
 
 def test_probe_sol_access_authorizes_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Enabled serial console + Instance Connect Success proves SOL key access."""
-    module = _load_aws_script("component_key_access.py")
+    module = load_vm_script("component_key_access.py")
     monkeypatch.setattr(module, "check_serial_access", lambda _ec2: {"enabled": True})
     eic = MagicMock()
     eic.send_serial_console_ssh_public_key.return_value = {"Success": True, "RequestId": "req-1"}
@@ -92,7 +72,7 @@ def test_probe_sol_access_authorizes_key(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_probe_sol_access_fails_on_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Instance Connect API errors fail the SOL probe."""
-    module = _load_aws_script("component_key_access.py")
+    module = load_vm_script("component_key_access.py")
     monkeypatch.setattr(module, "check_serial_access", lambda _ec2: {"enabled": True})
     eic = MagicMock()
     eic.send_serial_console_ssh_public_key.side_effect = ClientError(
@@ -108,7 +88,7 @@ def test_probe_sol_access_fails_on_client_error(monkeypatch: pytest.MonkeyPatch)
 
 def test_network_device_access_is_provider_hidden() -> None:
     """AWS marks network-device SSH as provider-hidden rather than failing."""
-    module = _load_aws_script("component_key_access.py")
+    module = load_vm_script("component_key_access.py")
 
     result = module._probe_network_device_access()
 
@@ -118,11 +98,9 @@ def test_network_device_access_is_provider_hidden() -> None:
 
 def test_my_isv_demo_component_key_access_emits_contract() -> None:
     """Demo mode emits the AUTH03 JSON contract for make demo-test."""
-    import os
-
     script = MY_ISV_VM_SCRIPTS / "component_key_access.py"
-    env = os.environ.copy()
-    env["ISVCTL_DEMO_MODE"] = "1"
+    env = os.environ | {"ISVCTL_DEMO_MODE": "1"}
+
     completed = subprocess.run(
         [
             sys.executable,

--- a/isvctl/tests/test_component_key_access_contract.py
+++ b/isvctl/tests/test_component_key_access_contract.py
@@ -67,7 +67,11 @@ def test_probe_sol_access_authorizes_key(monkeypatch: pytest.MonkeyPatch) -> Non
     result = module._probe_sol_access(MagicMock(), eic, "i-abc", "ssh-rsa AAAAB3")
 
     assert result["passed"] is True
-    eic.send_serial_console_ssh_public_key.assert_called_once()
+    eic.send_serial_console_ssh_public_key.assert_called_once_with(
+        InstanceId="i-abc",
+        SSHPublicKey="ssh-rsa AAAAB3",
+        SerialPort=0,
+    )
 
 
 def test_probe_sol_access_fails_on_client_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/isvtest/src/isvtest/validations/iam.py
+++ b/isvtest/src/isvtest/validations/iam.py
@@ -21,11 +21,41 @@ and tenant/resource groups.
 
 from typing import ClassVar
 
-from isvtest.core.validation import BaseValidation
+from isvtest.core.validation import BaseValidation, check_required_tests
 
 # =============================================================================
 # Access Key Validations
 # =============================================================================
+
+
+class IamCredentialAccessCheck(BaseValidation):
+    """Validate created IAM credentials authenticate and reach authorized resources.
+
+    Proves IAM03-01: a user created earlier can access the API (identity) and at
+    least one authorized resource (access). Scripts emit provider-neutral
+    ``tests.identity`` / ``tests.access`` subtests.
+
+    Config:
+        step_output: The test_credentials step output to check
+        required_tests: Optional override of required subtest names
+            (default: identity, access)
+
+    Step output:
+        tests.identity.passed: True when credentials authenticate to the API
+        tests.access.passed: True when at least one authorized resource is reachable
+    """
+
+    description: ClassVar[str] = "Check IAM credentials authenticate with authorized resource access"
+
+    def run(self) -> None:
+        """Validate identity and authorized-resource access probes from step output."""
+        required = self.config.get("required_tests", ["identity", "access"])
+        if not check_required_tests(self, required, "IAM credential access tests failed"):
+            return
+
+        step_output = self.config.get("step_output", {})
+        account_id = step_output.get("account_id") or "unknown"
+        self.set_passed(f"IAM credentials authenticated with authorized resource access (account={account_id})")
 
 
 class AccessKeyCreatedCheck(BaseValidation):

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -20,7 +20,9 @@ Validations for EC2 instances, virtual machines, and compute resources.
 
 from typing import ClassVar
 
-from isvtest.core.validation import BaseValidation
+import pytest
+
+from isvtest.core.validation import BaseValidation, check_required_tests
 from isvtest.validations.generic import check_operations_passed
 
 SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED = 30
@@ -98,6 +100,54 @@ class InstanceSpecifiedKeyCheck(BaseValidation):
             return
 
         self.set_passed(f"Instance {instance_id} launched with specified key '{requested_key_name}'")
+
+
+class ComponentKeyAccessCheck(BaseValidation):
+    """Validate a specified key can access other components (SOL, network devices).
+
+    Proves AUTH03-01 after AUTH02 launches an instance with a requested key.
+    Scripts emit provider-neutral ``tests.sol_access`` and
+    ``tests.network_device_access`` probes. Network-device access may be marked
+    ``provider_hidden`` when the platform does not expose tenant-visible device
+    SSH (for example AWS).
+
+    Config:
+        step_output: The component_key_access step output to check
+        required_tests: Optional override of required subtest names
+            (default: sol_access, network_device_access)
+
+    Step output:
+        key_name: Key used for component access (links to AUTH02)
+        tests.sol_access.passed: True when SOL/serial console accepts the key
+        tests.network_device_access.passed: True when network-device key access
+            succeeds, or is affirmatively provider-hidden
+    """
+
+    description: ClassVar[str] = "Check specified key accesses SOL and network devices"
+
+    def run(self) -> None:
+        """Validate key-based SOL and network-device access probes from step output."""
+        step_output = self.config.get("step_output", {})
+        if step_output.get("skipped") is True:
+            pytest.skip(step_output.get("skip_reason") or "Component key access validation skipped")
+
+        key_name = step_output.get("key_name") or step_output.get("requested_key_name")
+        if not key_name:
+            self.set_failed("No 'key_name' in step output")
+            return
+
+        required = self.config.get("required_tests", ["sol_access", "network_device_access"])
+        if not check_required_tests(self, required, "Component key access tests failed"):
+            return
+
+        tests = step_output.get("tests", {})
+        hidden = [
+            name
+            for name in required
+            if isinstance(tests.get(name), dict) and tests[name].get("provider_hidden") is True
+        ]
+        hidden_note = f", provider_hidden={','.join(hidden)}" if hidden else ""
+        self.set_passed(f"Specified key '{key_name}' accessed required components{hidden_note}")
 
 
 class InstanceRebootCheck(BaseValidation):

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -20,8 +20,6 @@ Validations for EC2 instances, virtual machines, and compute resources.
 
 from typing import ClassVar
 
-import pytest
-
 from isvtest.core.validation import BaseValidation, check_required_tests
 from isvtest.validations.generic import check_operations_passed
 
@@ -128,10 +126,7 @@ class ComponentKeyAccessCheck(BaseValidation):
     def run(self) -> None:
         """Validate key-based SOL and network-device access probes from step output."""
         step_output = self.config.get("step_output", {})
-        if step_output.get("skipped") is True:
-            pytest.skip(step_output.get("skip_reason") or "Component key access validation skipped")
-
-        key_name = step_output.get("key_name") or step_output.get("requested_key_name")
+        key_name = step_output.get("key_name")
         if not key_name:
             self.set_failed("No 'key_name' in step output")
             return
@@ -141,11 +136,7 @@ class ComponentKeyAccessCheck(BaseValidation):
             return
 
         tests = step_output.get("tests", {})
-        hidden = [
-            name
-            for name in required
-            if isinstance(tests.get(name), dict) and tests[name].get("provider_hidden") is True
-        ]
+        hidden = [name for name in required if tests[name].get("provider_hidden") is True]
         hidden_note = f", provider_hidden={','.join(hidden)}" if hidden else ""
         self.set_passed(f"Specified key '{key_name}' accessed required components{hidden_note}")
 

--- a/isvtest/tests/test_iam.py
+++ b/isvtest/tests/test_iam.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from isvtest.validations.iam import ServiceAccountCredentialCheck
+from isvtest.validations.iam import IamCredentialAccessCheck, ServiceAccountCredentialCheck
 
 
 def _sa_credential_output(**overrides: Any) -> dict[str, Any]:
@@ -36,6 +36,69 @@ def _sa_credential_output(**overrides: Any) -> dict[str, Any]:
     }
     output.update(overrides)
     return output
+
+
+def _credential_access_output(**overrides: Any) -> dict[str, Any]:
+    """Return a valid IAM03 credential-access step output."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "iam",
+        "account_id": "123456789012",
+        "tests": {
+            "identity": {"passed": True},
+            "access": {"passed": True},
+        },
+    }
+    output.update(overrides)
+    return output
+
+
+class TestIamCredentialAccessCheck:
+    """Tests for IamCredentialAccessCheck (IAM03-01)."""
+
+    def test_passes_with_identity_and_access(self) -> None:
+        """Happy path: both identity and access probes pass."""
+        result = IamCredentialAccessCheck(config={"step_output": _credential_access_output()}).execute()
+
+        assert result["passed"] is True
+        assert "authenticated with authorized resource access" in result["output"]
+        assert "123456789012" in result["output"]
+
+    def test_fails_when_identity_missing(self) -> None:
+        """Fails when the identity probe is absent."""
+        out = _credential_access_output()
+        del out["tests"]["identity"]
+
+        result = IamCredentialAccessCheck(config={"step_output": out}).execute()
+
+        assert result["passed"] is False
+        assert "identity" in result["error"]
+
+    def test_fails_when_access_fails(self) -> None:
+        """Fails when authorized-resource access does not pass."""
+        result = IamCredentialAccessCheck(
+            config={
+                "step_output": _credential_access_output(
+                    tests={
+                        "identity": {"passed": True},
+                        "access": {"passed": False, "error": "permission denied"},
+                    }
+                )
+            }
+        ).execute()
+
+        assert result["passed"] is False
+        assert "access" in result["error"]
+
+    def test_fails_when_tests_absent(self) -> None:
+        """Fails when the tests object is missing entirely."""
+        out = _credential_access_output()
+        del out["tests"]
+
+        result = IamCredentialAccessCheck(config={"step_output": out}).execute()
+
+        assert result["passed"] is False
+        assert "tests" in result["error"]
 
 
 def test_sa_credential_check_passes_with_long_lived_key() -> None:

--- a/isvtest/tests/test_instance.py
+++ b/isvtest/tests/test_instance.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from isvtest.validations.instance import (
     SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
     ComponentKeyAccessCheck,
@@ -277,8 +279,6 @@ class TestComponentKeyAccessCheck:
 
     def test_skips_when_step_marked_skipped(self) -> None:
         """Whole-step skip (e.g. serial console disabled) is a pytest skip."""
-        import pytest
-
         with pytest.raises(pytest.skip.Exception, match="serial console"):
             ComponentKeyAccessCheck(
                 config={

--- a/isvtest/tests/test_instance.py
+++ b/isvtest/tests/test_instance.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from isvtest.validations.instance import (
     SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+    ComponentKeyAccessCheck,
     InstanceRebootCheck,
     InstanceSpecifiedKeyCheck,
     SerialConsoleRetentionCheck,
@@ -201,6 +202,92 @@ class TestInstanceSpecifiedKeyCheck:
 
         assert result["passed"] is False
         assert "expected key 'isv-test-key', got 'other-key'" in result["error"]
+
+
+class TestComponentKeyAccessCheck:
+    """Tests for AUTH03-01 specified-key SOL / network-device access."""
+
+    def _output(self, **overrides: Any) -> dict[str, Any]:
+        """Build a minimal passing component_key_access step_output."""
+        base: dict[str, Any] = {
+            "success": True,
+            "platform": "vm",
+            "instance_id": "i-abc123",
+            "key_name": "isv-test-key",
+            "tests": {
+                "sol_access": {"passed": True},
+                "network_device_access": {"passed": True},
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def test_passes_with_sol_and_network_access(self) -> None:
+        """Happy path: both required component probes pass."""
+        result = ComponentKeyAccessCheck(config={"step_output": self._output()}).execute()
+
+        assert result["passed"] is True
+        assert "isv-test-key" in result["output"]
+
+    def test_passes_with_provider_hidden_network_devices(self) -> None:
+        """Network-device access may be provider-hidden when not tenant-visible."""
+        result = ComponentKeyAccessCheck(
+            config={
+                "step_output": self._output(
+                    tests={
+                        "sol_access": {"passed": True},
+                        "network_device_access": {
+                            "passed": True,
+                            "provider_hidden": True,
+                            "message": "no tenant network-device SSH",
+                        },
+                    }
+                )
+            }
+        ).execute()
+
+        assert result["passed"] is True
+        assert "provider_hidden=network_device_access" in result["output"]
+
+    def test_fails_when_key_name_missing(self) -> None:
+        """The provider must report which key was used."""
+        out = self._output()
+        del out["key_name"]
+
+        result = ComponentKeyAccessCheck(config={"step_output": out}).execute()
+
+        assert result["passed"] is False
+        assert "key_name" in result["error"]
+
+    def test_fails_when_sol_access_fails(self) -> None:
+        """SOL access failure fails AUTH03."""
+        result = ComponentKeyAccessCheck(
+            config={
+                "step_output": self._output(
+                    tests={
+                        "sol_access": {"passed": False, "error": "serial disabled"},
+                        "network_device_access": {"passed": True},
+                    }
+                )
+            }
+        ).execute()
+
+        assert result["passed"] is False
+        assert "sol_access" in result["error"]
+
+    def test_skips_when_step_marked_skipped(self) -> None:
+        """Whole-step skip (e.g. serial console disabled) is a pytest skip."""
+        import pytest
+
+        with pytest.raises(pytest.skip.Exception, match="serial console"):
+            ComponentKeyAccessCheck(
+                config={
+                    "step_output": self._output(
+                        skipped=True,
+                        skip_reason="EC2 serial console access is disabled for this account or region",
+                    )
+                }
+            ).execute()
 
 
 class TestSerialConsoleRetentionCheck:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements M7 Batch A foundational identity/access issues:

| Issue | Test ID | Check |
|-------|---------|-------|
| #341 IAM-XX-03 | IAM03-01 | `IamCredentialAccessCheck` |
| #248 AUTH-XX-03 | AUTH03-01 | `ComponentKeyAccessCheck` |

## Changes

### IAM03-01 (#341)
- Replace weak `FieldExistsCheck(account_id)` with `IamCredentialAccessCheck` requiring `tests.identity` + `tests.access`
- Normalize AWS `test_credentials.py` JSON to the provider-neutral `identity`/`access` contract (already used by my-isv)

### AUTH03-01 (#248)
- Add `ComponentKeyAccessCheck` on a new `component_key_access` VM step
- AWS: authorize the launch key for EC2 serial-console SSH (SOL); mark network-device SSH `provider_hidden`
- my-isv: DEMO_MODE stub for `make demo-test`

## Test plan
- [x] $ ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run -f isvctl/configs/providers/aws/config/iam.yaml -- -v -s
- [x] $ ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run -f isvctl/configs/providers/aws/config/vm.yaml -- -v -s
- [x] `make lint` / `make test`

Closes #341
Closes #248


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74c98d75-dac5-40fe-ae03-cc50b0d312d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74c98d75-dac5-40fe-ae03-cc50b0d312d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `component_key_access` VM validation for launch-key access to serial console and network devices (with SOL-disabled skipping).
  * Introduced `AUTH03-01` component key access checks and a my-isv demo-mode implementation.
  * Added IAM03 credential-access validation for identity and authorization results.
* **Documentation**
  * Updated VM/IAM suite and validation docs plus the test plan to include the new `component_key_access` step and JSON field expectations.
* **Tests**
  * Added contract and validation tests covering pass/fail/skip and provider-hidden network-device behavior, and expanded IAM03 validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->