### PR TITLE
feat(storage): implement DIR01/DIR02 home-directory storage validations

### DIFF
--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -2349,7 +2349,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
 | [[BFX03-01]]BFX03-01
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
@@ -2481,7 +2481,7 @@ a|
 | [[DIR02-01]]DIR02-01
 | DIR02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/326[#326]
-| min_req
+| min_req, storage
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/326[#326]
@@ -2495,7 +2495,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/326[#326]
 | [[DIR01-01]]DIR01-01
 | DIR01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/324[#324]
-| min_req
+| min_req, storage
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/324[#324]
@@ -2509,7 +2509,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/324[#324]
 | [[DIR01-02]]DIR01-02
 | DIR01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/325[#325]
-| min_req
+| min_req, storage
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/325[#325]
@@ -2583,7 +2583,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/266[#266]
 | [[STG02-01]]STG02-01
 | STG02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/358[#358]
-| min_req
+| bare_metal, min_req, sanitization, sds_controller
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/358[#358]
@@ -2597,7 +2597,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/358[#358]
 | [[STG03-01]]STG03-01
 | STG03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/359[#359]
-| min_req
+| bare_metal, min_req, network, sds_controller
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/359[#359]
@@ -2611,7 +2611,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/359[#359]
 | [[STG04-01]]STG04-01
 | STG04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/360[#360]
-| min_req
+| bare_metal, health, min_req, sds_controller
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/360[#360]
@@ -2625,7 +2625,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/360[#360]
 | [[STG05-01]]STG05-01
 | STG05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/361[#361]
-| min_req
+| bare_metal, min_req, sds_controller
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/361[#361]
@@ -4188,7 +4188,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
 | [[TELEM05-01]]TELEM05-01
 | TELEM05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
-| min_req
+| min_req, observability
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
@@ -4196,13 +4196,13 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
 | M5
 |
 | Verify storage resource capacity metrics are available (used/free/total)
-| pending
+| approved
 |
 
 | [[TELEM06-01]]TELEM06-01
 | TELEM06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
-| min_req
+| min_req, observability
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
@@ -4210,7 +4210,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
 | M5
 |
 | Verify storage performance metrics are available (bandwidth, IOPS, latency)
-| pending
+| approved
 |
 
 .2+| NVLink Switch Telemetry
@@ -4218,7 +4218,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
 | [[TELEM07-01]]TELEM07-01
 | TELEM07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
-| min_req
+| min_req, observability
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
@@ -4226,13 +4226,13 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
 | M5
 |
 | Verify NVLink metrics are available from the GPU perspective (per-link counters, bandwidth utilization)
-| pending
+| approved
 |
 
 | [[TELEM08-01]]TELEM08-01
 | TELEM08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
-| min_req
+| min_req, observability
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
@@ -4240,7 +4240,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
 | M5
 |
 | Verify NVLink metrics are available from the switch perspective (port-level counters, error rates)
-| pending
+| approved
 |
 
 .23+| Security & Identity
@@ -4308,7 +4308,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/308[#308]
 | [[SEC13-01]]SEC13-01
 | SEC13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/309[#309]
-| min_req
+| min_req, network, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/309[#309]

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2174,6 +2174,7 @@ domains:
               - summary: Verify NFS protocol shared storage is available
                 labels:
                   - min_req
+                  - storage
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -2185,6 +2186,7 @@ domains:
               - summary: Verify configurable filesystem-wide quota limits
                 labels:
                   - min_req
+                  - storage
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -2196,6 +2198,7 @@ domains:
               - summary: Verify usage accounting for uid/gids
                 labels:
                   - min_req
+                  - storage
                 priority: P1
                 milestone: M5
                 notes: ""

--- a/isvctl/configs/providers/aws/config/storage.yaml
+++ b/isvctl/configs/providers/aws/config/storage.yaml
@@ -17,6 +17,7 @@
 #
 # Imports suites/storage.yaml and wires AWS implementations for:
 #   - Block volume (EBS): launch/create/snapshot/resize/persistence/teardown
+#   - Home directory (FSx for OpenZFS): NFSv4, volume quota, uid/gid accounting
 #   - High-speed storage (FSx for Lustre): provisioning, multiple filesystems,
 #     live expansion, root-squash (other HSS checks excluded — need a mounted
 #     client or are not exposed by managed FSx)
@@ -126,6 +127,26 @@ commands:
           - "--expected-content"
           - "{{steps.create_volume.sentinel_content}}"
         timeout: 900
+
+      # ─── Home directory storage (FSx for OpenZFS) ──────────────────
+      # Reuses the block fixture's EC2 client. The script creates one minimum
+      # Single-AZ filesystem, runs all DIR01/DIR02 probes, then deletes it.
+      - name: home_directory_storage
+        phase: test
+        command: "python3 ../scripts/storage/home_directory_storage_test.py"
+        requires_available_validations:
+          - DirectoryFilesystemQuotaCheck
+          - DirectoryUsageAccountingCheck
+          - DirectoryNfsAvailabilityCheck
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        # 1800 (create) + 900 (volume) + 600 (mount) + 900 (delete) + slack.
+        timeout: 4500
 
       # ─── High-speed storage (FSx for Lustre) ────────────────────────
       # Timeouts = worst-case waits in scripts/common/fsx.py + slack so the

--- a/isvctl/configs/providers/aws/scripts/common/ec2.py
+++ b/isvctl/configs/providers/aws/scripts/common/ec2.py
@@ -41,6 +41,7 @@ from botocore.exceptions import (
     ReadTimeoutError,
 )
 
+from common.ebs import describe_instance
 from common.errors import TRANSIENT_AWS_CODES
 
 # Conservative key-name pattern - letters, digits, dash, underscore, dot.
@@ -133,6 +134,27 @@ def wait_for_public_ip(
         if time.monotonic() >= deadline:
             return None
         time.sleep(interval)
+
+
+def instance_network(ec2: Any, instance_id: str) -> dict[str, str]:
+    """Return network and SSH fields for an existing EC2 instance."""
+    instance = describe_instance(ec2, instance_id)
+    security_groups = instance.get("SecurityGroups") or []
+    if not security_groups:
+        raise RuntimeError(f"Instance {instance_id} has no security group")
+    public_ip = instance.get("PublicIpAddress")
+    private_ip = instance.get("PrivateIpAddress")
+    subnet_id = instance.get("SubnetId")
+    vpc_id = instance.get("VpcId")
+    if not all((public_ip, private_ip, subnet_id, vpc_id)):
+        raise RuntimeError(f"Instance {instance_id} is missing required network fields")
+    return {
+        "public_ip": str(public_ip),
+        "private_ip": str(private_ip),
+        "subnet_id": str(subnet_id),
+        "vpc_id": str(vpc_id),
+        "security_group_id": str(security_groups[0]["GroupId"]),
+    }
 
 
 def get_supported_azs(ec2: Any, instance_type: str) -> set[str]:

--- a/isvctl/configs/providers/aws/scripts/common/fsx.py
+++ b/isvctl/configs/providers/aws/scripts/common/fsx.py
@@ -242,9 +242,23 @@ def wait_filesystem_deleted(fsx: Any, fs_id: str, *, timeout: float = 900.0, del
     return False
 
 
-def delete_filesystem(fsx: Any, fs_id: str, *, wait: bool = True, timeout: float = 900.0, delay: float = 15.0) -> bool:
-    """Best-effort delete of an FSx filesystem, optionally waiting for removal."""
-    ok = delete_with_retry(fsx.delete_file_system, FileSystemId=fs_id, resource_desc=f"FSx filesystem {fs_id}")
+def delete_filesystem(
+    fsx: Any,
+    fs_id: str,
+    *,
+    wait: bool = True,
+    timeout: float = 900.0,
+    delay: float = 15.0,
+    **delete_kwargs: Any,
+) -> bool:
+    """Best-effort delete of an FSx filesystem, optionally waiting for removal.
+
+    Extra keyword args (e.g. ``OpenZFSConfiguration``) are forwarded to
+    ``delete_file_system``.
+    """
+    ok = delete_with_retry(
+        fsx.delete_file_system, FileSystemId=fs_id, resource_desc=f"FSx filesystem {fs_id}", **delete_kwargs
+    )
     if not ok or not wait:
         return ok
     return wait_filesystem_deleted(fsx, fs_id, timeout=timeout, delay=delay)

--- a/isvctl/configs/providers/aws/scripts/common/openzfs.py
+++ b/isvctl/configs/providers/aws/scripts/common/openzfs.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Amazon FSx for OpenZFS helpers for home-directory storage tests.
+
+Filesystem-level lifecycle plumbing (describe/wait/delete) is shared with the
+Lustre scripts via :mod:`common.fsx`; this module adds only the OpenZFS-specific
+pieces: NFS security group, filesystem/volume creation, and volume quotas.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from common.errors import TRANSIENT_AWS_CODES, delete_with_retry
+from common.fsx import (
+    LIFECYCLE_AVAILABLE,
+    LIFECYCLE_TERMINAL_BAD,
+    delete_filesystem,
+    wait_filesystem_deleted,
+)
+
+MIN_OPENZFS_CAPACITY_GIB = 64
+MIN_OPENZFS_THROUGHPUT_MBPS = 64
+
+
+def create_nfs_security_group(
+    ec2: Any,
+    vpc_id: str,
+    client_sg_id: str,
+    suffix: str,
+    created: dict[str, str],
+) -> str:
+    """Create an NFS security group allowing TCP/2049 from the client group.
+
+    The new group's ID is recorded in ``created`` as soon as it exists so the
+    caller's cleanup path can reclaim it if tagging/ingress fails.
+    """
+    response = ec2.create_security_group(
+        GroupName=f"isv-dir-{suffix}",
+        Description="NFS access for isvtest home-directory validation",
+        VpcId=vpc_id,
+    )
+    sg_id = response["GroupId"]
+    created["sg_id"] = sg_id
+    ec2.create_tags(
+        Resources=[sg_id],
+        Tags=[{"Key": "Name", "Value": f"isv-dir-{suffix}"}, {"Key": "CreatedBy", "Value": "isvtest"}],
+    )
+    ec2.authorize_security_group_ingress(
+        GroupId=sg_id,
+        IpPermissions=[
+            {
+                "IpProtocol": "tcp",
+                "FromPort": 2049,
+                "ToPort": 2049,
+                "UserIdGroupPairs": [{"GroupId": client_sg_id}],
+            }
+        ],
+    )
+    return sg_id
+
+
+def create_filesystem(fsx: Any, subnet_id: str, sg_id: str, suffix: str) -> str:
+    """Create the minimum-cost Single-AZ FSx for OpenZFS filesystem."""
+    response = fsx.create_file_system(
+        FileSystemType="OPENZFS",
+        StorageType="SSD",
+        StorageCapacity=MIN_OPENZFS_CAPACITY_GIB,
+        SubnetIds=[subnet_id],
+        SecurityGroupIds=[sg_id],
+        OpenZFSConfiguration={
+            "DeploymentType": "SINGLE_AZ_1",
+            "ThroughputCapacity": MIN_OPENZFS_THROUGHPUT_MBPS,
+            "AutomaticBackupRetentionDays": 0,
+            "CopyTagsToBackups": False,
+            "RootVolumeConfiguration": {"DataCompressionType": "NONE"},
+        },
+        Tags=[
+            {"Key": "Name", "Value": f"isv-dir-{suffix}"},
+            {"Key": "CreatedBy", "Value": "isvtest"},
+        ],
+    )
+    return str(response["FileSystem"]["FileSystemId"])
+
+
+def create_test_volume(
+    fsx: Any,
+    root_volume_id: str,
+    client_ip: str,
+    suffix: str,
+    *,
+    quota_gib: int = 2,
+) -> str:
+    """Create an exported child volume with filesystem, UID, and GID quotas."""
+    response = fsx.create_volume(
+        VolumeType="OPENZFS",
+        Name=f"isvdir{suffix.replace('-', '')}",
+        OpenZFSConfiguration={
+            "ParentVolumeId": root_volume_id,
+            "StorageCapacityQuotaGiB": quota_gib,
+            "StorageCapacityReservationGiB": -1,
+            "DataCompressionType": "NONE",
+            "NfsExports": [
+                {
+                    "ClientConfigurations": [
+                        {
+                            "Clients": f"{client_ip}/32",
+                            "Options": ["rw", "no_root_squash"],
+                        }
+                    ]
+                }
+            ],
+            "UserAndGroupQuotas": [
+                {"Type": "USER", "Id": 20001, "StorageCapacityQuotaGiB": 1},
+                {"Type": "GROUP", "Id": 30001, "StorageCapacityQuotaGiB": 1},
+            ],
+        },
+        Tags=[
+            {"Key": "Name", "Value": f"isv-dir-{suffix}"},
+            {"Key": "CreatedBy", "Value": "isvtest"},
+        ],
+    )
+    return str(response["Volume"]["VolumeId"])
+
+
+def describe_volume(fsx: Any, volume_id: str) -> dict[str, Any]:
+    """Return a single FSx volume description."""
+    response = fsx.describe_volumes(VolumeIds=[volume_id])
+    volumes = response.get("Volumes", [])
+    if not volumes:
+        raise RuntimeError(f"Volume {volume_id} not found")
+    return volumes[0]
+
+
+def wait_volume(
+    fsx: Any,
+    volume_id: str,
+    *,
+    expected_quota_gib: int | None = None,
+    timeout: float = 900.0,
+    delay: float = 10.0,
+) -> dict[str, Any]:
+    """Wait until an OpenZFS volume is AVAILABLE, optionally with a given quota."""
+    deadline = time.monotonic() + timeout
+    last_quota: Any = None
+    last_lifecycle: Any = None
+    while time.monotonic() < deadline:
+        volume = describe_volume(fsx, volume_id)
+        last_lifecycle = volume.get("Lifecycle")
+        last_quota = volume.get("OpenZFSConfiguration", {}).get("StorageCapacityQuotaGiB")
+        if last_lifecycle == LIFECYCLE_AVAILABLE and (expected_quota_gib is None or last_quota == expected_quota_gib):
+            return volume
+        if last_lifecycle in LIFECYCLE_TERMINAL_BAD:
+            detail = volume.get("FailureDetails", {}).get("Message", "")
+            raise RuntimeError(f"Volume {volume_id} entered {last_lifecycle}: {detail}")
+        time.sleep(delay)
+    raise TimeoutError(
+        f"Timed out waiting for volume {volume_id} "
+        f"(expected quota={expected_quota_gib!r}, last quota={last_quota!r}, lifecycle={last_lifecycle!r})"
+    )
+
+
+def set_volume_quota(fsx: Any, volume_id: str, quota_gib: int) -> None:
+    """Set the filesystem-wide capacity quota for an OpenZFS volume."""
+    fsx.update_volume(
+        VolumeId=volume_id,
+        OpenZFSConfiguration={"StorageCapacityQuotaGiB": quota_gib},
+    )
+
+
+def cleanup_resources(ec2: Any, fsx: Any, fs_id: str | None, sg_id: str | None) -> list[str]:
+    """Best-effort delete the filesystem and NFS security group."""
+    errors: list[str] = []
+    if fs_id:
+        issued = delete_filesystem(
+            fsx,
+            fs_id,
+            wait=False,
+            OpenZFSConfiguration={
+                "SkipFinalBackup": True,
+                "Options": ["DELETE_CHILD_VOLUMES_AND_SNAPSHOTS"],
+            },
+        )
+        if not issued:
+            errors.append(f"filesystem {fs_id} cleanup failed")
+        elif not wait_filesystem_deleted(fsx, fs_id):
+            errors.append(f"filesystem {fs_id} cleanup timed out")
+    if sg_id:
+        # FSx can disappear from DescribeFileSystems shortly before its ENI
+        # releases the security group, so DependencyViolation is transient here.
+        deleted = delete_with_retry(
+            ec2.delete_security_group,
+            GroupId=sg_id,
+            resource_desc=f"security group {sg_id}",
+            attempts=10,
+            backoff_seconds=3,
+            transient_codes=TRANSIENT_AWS_CODES | {"DependencyViolation"},
+        )
+        if not deleted:
+            errors.append(f"security group {sg_id} cleanup failed")
+    return errors

--- a/isvctl/configs/providers/aws/scripts/storage/home_directory_storage_test.py
+++ b/isvctl/configs/providers/aws/scripts/storage/home_directory_storage_test.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate home-directory quotas, accounting, and NFSv4 via FSx for OpenZFS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+import uuid
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from common.ec2 import instance_network
+from common.errors import handle_aws_errors, stamp_test_errors
+from common.fsx import new_suffix, wait_filesystem_available
+from common.openzfs import (
+    cleanup_resources,
+    create_filesystem,
+    create_nfs_security_group,
+    create_test_volume,
+    set_volume_quota,
+    wait_volume,
+)
+from common.ssh_utils import ssh_run, wait_for_ssh
+
+_MOUNT_A = "/mnt/isv-dir-a"
+_MOUNT_B = "/mnt/isv-dir-b"
+_UID_A = 20001
+_UID_B = 20002
+_GID_A = 30001
+_GID_B = 30002
+_SIZE_A = 8 * 1024 * 1024
+_SIZE_B = 4 * 1024 * 1024
+
+_TEST_NAMES = (
+    "filesystem_quota_configured",
+    "filesystem_quota_updated",
+    "filesystem_quota_enforced",
+    "uid_usage_accounted",
+    "gid_usage_accounted",
+    "identity_usage_isolated",
+    "nfsv4_mounted",
+    "nfs_read_write",
+    "nfs_shared_visibility",
+)
+
+
+def _run_remote(host: str, key_file: str, command: str, *, timeout: int = 300) -> tuple[int, str, str]:
+    """Run a command on the Ubuntu client instance."""
+    return ssh_run(host, "ubuntu", key_file, command, timeout=timeout)
+
+
+def _mount_volume(host: str, key_file: str, dns_name: str, volume_path: str) -> None:
+    """Install NFS tools and mount the export twice using NFSv4.1."""
+    source = shlex.quote(f"{dns_name}:{volume_path}")
+    command = (
+        "set -eu; "
+        "sudo env DEBIAN_FRONTEND=noninteractive apt-get update -qq; "
+        "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nfs-common >/dev/null; "
+        f"sudo mkdir -p {_MOUNT_A} {_MOUNT_B}; "
+        f"sudo mount -t nfs4 -o vers=4.1 {source} {_MOUNT_A}; "
+        f"sudo mount -t nfs4 -o vers=4.1 {source} {_MOUNT_B}; "
+        f"sudo chmod 0777 {_MOUNT_A}"
+    )
+    rc, _, stderr = _run_remote(host, key_file, command, timeout=600)
+    if rc != 0:
+        raise RuntimeError(f"NFS mount setup failed: {stderr.strip()[:300]}")
+
+
+def _probe_nfs(host: str, key_file: str) -> dict[str, dict[str, Any]]:
+    """Verify NFSv4.1, read/write access, and visibility between mounts."""
+    rc, mountinfo, stderr = _run_remote(host, key_file, f"findmnt -n -o FSTYPE,OPTIONS {_MOUNT_A}")
+    mounted = rc == 0 and mountinfo.split(maxsplit=1)[0] == "nfs4" and "vers=4.1" in mountinfo
+    mount_message = mountinfo.strip() if rc == 0 else stderr.strip()[:200]
+
+    canary = f"isv-dir-{uuid.uuid4().hex}"
+    rc, output, stderr = _run_remote(
+        host,
+        key_file,
+        f"printf %s {shlex.quote(canary)} > {_MOUNT_A}/canary && cat {_MOUNT_B}/canary",
+    )
+    read_write = rc == 0
+    shared = read_write and output == canary
+    error = stderr.strip()[:200]
+    return {
+        "nfsv4_mounted": {"passed": mounted, "message": mount_message},
+        "nfs_read_write": {"passed": read_write, "message": "Canary write/read succeeded" if read_write else error},
+        "nfs_shared_visibility": {
+            "passed": shared,
+            "message": "Canary was visible through both mounts" if shared else f"Expected {canary!r}, got {output!r}",
+        },
+    }
+
+
+def _probe_accounting(host: str, key_file: str) -> dict[str, dict[str, Any]]:
+    """Write files with distinct ownership and verify UID/GID byte totals."""
+    byte_sums = "; ".join(
+        f"{var}=$(find {_MOUNT_B} -xdev -type f -{flag} {ident} -printf '%s\\n' | awk '{{s+=$1}} END {{print s+0}}')"
+        for var, flag, ident in (
+            ("uid_a", "uid", _UID_A),
+            ("uid_b", "uid", _UID_B),
+            ("gid_a", "gid", _GID_A),
+            ("gid_b", "gid", _GID_B),
+        )
+    )
+    command = (
+        "set -eu; "
+        f"sudo dd if=/dev/zero of={_MOUNT_A}/uid-a bs=1M count=8 status=none; "
+        f"sudo chown {_UID_A}:{_GID_A} {_MOUNT_A}/uid-a; "
+        f"sudo dd if=/dev/zero of={_MOUNT_A}/uid-b bs=1M count=4 status=none; "
+        f"sudo chown {_UID_B}:{_GID_B} {_MOUNT_A}/uid-b; "
+        f"{byte_sums}; "
+        'printf "%s %s %s %s" "$uid_a" "$uid_b" "$gid_a" "$gid_b"'
+    )
+    rc, output, stderr = _run_remote(host, key_file, command)
+    try:
+        uid_a, uid_b, gid_a, gid_b = (int(value) for value in output.split())
+    except (ValueError, TypeError):
+        return {
+            name: {"passed": False, "error": stderr.strip()[:200] or f"Invalid accounting output: {output!r}"}
+            for name in ("uid_usage_accounted", "gid_usage_accounted", "identity_usage_isolated")
+        }
+
+    uid_ok = rc == 0 and (uid_a, uid_b) == (_SIZE_A, _SIZE_B)
+    gid_ok = rc == 0 and (gid_a, gid_b) == (_SIZE_A, _SIZE_B)
+    isolated = uid_ok and gid_ok and uid_a != uid_b and gid_a != gid_b
+    return {
+        "uid_usage_accounted": {"passed": uid_ok, "message": f"uid totals: {_UID_A}={uid_a}, {_UID_B}={uid_b}"},
+        "gid_usage_accounted": {"passed": gid_ok, "message": f"gid totals: {_GID_A}={gid_a}, {_GID_B}={gid_b}"},
+        "identity_usage_isolated": {"passed": isolated, "message": "UID/GID totals remained identity-scoped"},
+    }
+
+
+def _probe_quota_enforcement(host: str, key_file: str) -> dict[str, Any]:
+    """Pass when a write beyond the 1 GiB volume quota is rejected."""
+    command = f"sudo dd if=/dev/zero of={_MOUNT_A}/over-quota bs=1M count=1100 conv=fsync status=none"
+    rc, _, stderr = _run_remote(host, key_file, command, timeout=300)
+    message = stderr.strip()[:300]
+    return {
+        "passed": rc != 0 and any(token in message.lower() for token in ("quota", "no space", "exceeded")),
+        "message": message or f"Over-quota write exited with status {rc}",
+    }
+
+
+def _quota_config_matches(volume: dict[str, Any], expected_gib: int) -> bool:
+    """Return whether volume and identity quotas match the expected contract."""
+    config = volume.get("OpenZFSConfiguration", {})
+    quotas = config.get("UserAndGroupQuotas", [])
+    expected = {
+        ("USER", _UID_A, 1),
+        ("GROUP", _GID_A, 1),
+    }
+    actual = {(item.get("Type"), item.get("Id"), item.get("StorageCapacityQuotaGiB")) for item in quotas}
+    return config.get("StorageCapacityQuotaGiB") == expected_gib and expected <= actual
+
+
+@handle_aws_errors
+def main() -> int:
+    """Provision FSx for OpenZFS, run all DIR01/DIR02 probes, and clean up."""
+    parser = argparse.ArgumentParser(description="Validate home-directory storage via FSx for OpenZFS")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--instance-id", required=True)
+    parser.add_argument("--key-file", required=True)
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "storage",
+        "test_name": "home_directory_storage",
+        "tests": {name: {"passed": False} for name in _TEST_NAMES},
+    }
+    ec2 = boto3.client("ec2", region_name=args.region)
+    fsx = boto3.client("fsx", region_name=args.region)
+    suffix = new_suffix()
+    fs_id: str | None = None
+    host: str | None = None
+    created: dict[str, str] = {}
+
+    try:
+        network = instance_network(ec2, args.instance_id)
+        host = network["public_ip"]
+        if not wait_for_ssh(host, "ubuntu", args.key_file):
+            raise RuntimeError("SSH client instance did not become ready")
+
+        sg_id = create_nfs_security_group(
+            ec2,
+            network["vpc_id"],
+            network["security_group_id"],
+            suffix,
+            created,
+        )
+        fs_id = create_filesystem(fsx, network["subnet_id"], sg_id, suffix)
+        filesystem = wait_filesystem_available(fsx, fs_id)
+        root_volume_id = filesystem["OpenZFSConfiguration"]["RootVolumeId"]
+        volume_id = create_test_volume(fsx, root_volume_id, network["private_ip"], suffix)
+        volume = wait_volume(fsx, volume_id)
+
+        configured = _quota_config_matches(volume, 2)
+        result["tests"]["filesystem_quota_configured"] = {
+            "passed": configured,
+            "message": "2 GiB volume quota and per-UID/GID quotas configured",
+        }
+
+        dns_name = str(filesystem["DNSName"])
+        volume_path = str(volume["OpenZFSConfiguration"]["VolumePath"])
+        _mount_volume(host, args.key_file, dns_name, volume_path)
+        result["tests"].update(_probe_nfs(host, args.key_file))
+        result["tests"].update(_probe_accounting(host, args.key_file))
+
+        set_volume_quota(fsx, volume_id, 1)
+        updated_volume = wait_volume(fsx, volume_id, expected_quota_gib=1)
+        updated = _quota_config_matches(updated_volume, 1)
+        result["tests"]["filesystem_quota_updated"] = {
+            "passed": updated,
+            "message": "Volume quota updated from 2 GiB to 1 GiB",
+        }
+        if updated:
+            result["tests"]["filesystem_quota_enforced"] = _probe_quota_enforcement(host, args.key_file)
+
+        result["success"] = all(test.get("passed", False) for test in result["tests"].values())
+    except Exception as error:
+        result["error"] = str(error)
+        stamp_test_errors(result, str(error))
+    finally:
+        if host:
+            _run_remote(
+                host,
+                args.key_file,
+                f"sudo umount -l {_MOUNT_B} 2>/dev/null || true; sudo umount -l {_MOUNT_A} 2>/dev/null || true",
+            )
+        cleanup_errors = cleanup_resources(ec2, fsx, fs_id, created.get("sg_id"))
+        result["cleanup"] = not cleanup_errors
+        if cleanup_errors:
+            result["cleanup_errors"] = cleanup_errors
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/storage/home_directory_storage_test.py
+++ b/isvctl/configs/providers/aws/scripts/storage/home_directory_storage_test.py
@@ -241,16 +241,31 @@ def main() -> int:
         result["error"] = str(error)
         stamp_test_errors(result, str(error))
     finally:
+        cleanup_errors: list[str] = []
         if host:
-            _run_remote(
-                host,
-                args.key_file,
-                f"sudo umount -l {_MOUNT_B} 2>/dev/null || true; sudo umount -l {_MOUNT_A} 2>/dev/null || true",
-            )
-        cleanup_errors = cleanup_resources(ec2, fsx, fs_id, created.get("sg_id"))
+            try:
+                rc, _, stderr = _run_remote(
+                    host,
+                    args.key_file,
+                    (
+                        "rc=0; "
+                        f"for mount in {_MOUNT_B} {_MOUNT_A}; do "
+                        'if mountpoint -q "$mount"; then sudo umount -l "$mount" || rc=1; fi; '
+                        "done; exit $rc"
+                    ),
+                )
+                if rc != 0:
+                    cleanup_errors.append(f"unmount cleanup failed: {stderr.strip()[:200] or f'exit code {rc}'}")
+            except Exception as error:
+                cleanup_errors.append(f"unmount cleanup failed: {error}")
+        try:
+            cleanup_errors.extend(cleanup_resources(ec2, fsx, fs_id, created.get("sg_id")))
+        except Exception as error:
+            cleanup_errors.append(f"AWS cleanup failed: {error}")
         result["cleanup"] = not cleanup_errors
         if cleanup_errors:
             result["cleanup_errors"] = cleanup_errors
+            result["success"] = False
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/my-isv/config/storage.yaml
+++ b/isvctl/configs/providers/my-isv/config/storage.yaml
@@ -24,6 +24,10 @@
 #   launch_instance, create_volume, snapshot_lifecycle, volume_resize,
 #   volume_persistence, teardown_volume, teardown
 #
+# Home directory (self-contained test-phase step):
+#   DirectoryFilesystemQuotaCheck, DirectoryUsageAccountingCheck,
+#   DirectoryNfsAvailabilityCheck
+#
 # High-speed storage (self-contained test-phase steps; HSS checks ship
 # unreleased — run with ISVTEST_INCLUDE_UNRELEASED=1 to exercise them):
 #   HssStorageProvisioningCheck (HSS01-01), HssQosThroughputCheck (HSS02-01),
@@ -119,6 +123,16 @@ commands:
           - "{{steps.create_volume.mount_point}}"
           - "--expected-content"
           - "{{steps.create_volume.sentinel_content}}"
+        timeout: 60
+
+      - name: home_directory_storage
+        phase: test
+        command: "python ../scripts/storage/home_directory_storage_test.py"
+        requires_available_validations:
+          - DirectoryFilesystemQuotaCheck
+          - DirectoryUsageAccountingCheck
+          - DirectoryNfsAvailabilityCheck
+        args: ["--region", "{{region}}"]
         timeout: 60
 
       # High-speed storage (self-contained; demo stubs)

--- a/isvctl/configs/providers/my-isv/scripts/storage/home_directory_storage_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/storage/home_directory_storage_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Home-directory storage validation template for DIR01 and DIR02."""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+_TEST_NAMES = (
+    "filesystem_quota_configured",
+    "filesystem_quota_updated",
+    "filesystem_quota_enforced",
+    "uid_usage_accounted",
+    "gid_usage_accounted",
+    "identity_usage_isolated",
+    "nfsv4_mounted",
+    "nfs_read_write",
+    "nfs_shared_visibility",
+)
+
+
+def main() -> int:
+    """Run provider-specific home-directory probes and emit provider-neutral JSON."""
+    parser = argparse.ArgumentParser(description="Home-directory storage validation template")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": DEMO_MODE,
+        "platform": "storage",
+        "test_name": "home_directory_storage",
+        "tests": {name: {"passed": DEMO_MODE} for name in _TEST_NAMES},
+    }
+    if not DEMO_MODE:
+        result["error"] = "Not implemented - replace with your platform's home-directory storage test logic"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/storage.yaml
+++ b/isvctl/configs/suites/storage.yaml
@@ -22,9 +22,9 @@
 # only inspects JSON output fields. As long as your scripts output the
 # right fields, the validations pass regardless of which cloud you use.
 #
-# Scope: persistent block storage (EBS-style volumes) and high-speed
-# storage (SDS controller + parallel file system). Object storage and
-# other storage checks can land here later without a new suite file.
+# Scope: persistent block storage (EBS-style volumes), home-directory
+# NFS storage, and high-speed storage (SDS controller + parallel file
+# system). Object storage and other checks can land here later.
 # High-speed check classes / test_ids keep the HSS* / HSS## naming from
 # the offtake High-Speed Storage requirement family
 # (docs/requirements/offtake-requirements.md).
@@ -138,6 +138,20 @@ tests:
           test_id: "DATASVC04-01"
           labels: ["min_req", "storage"]
           operations: ["stop", "start", "verify_attached", "verify_data"]
+
+    # ─── Home directory storage ──────────────────────────────────────
+    home_directory:
+      step: home_directory_storage
+      checks:
+        DirectoryFilesystemQuotaCheck:
+          test_id: "DIR01-01"
+          labels: ["min_req", "storage"]
+        DirectoryUsageAccountingCheck:
+          test_id: "DIR01-02"
+          labels: ["min_req", "storage"]
+        DirectoryNfsAvailabilityCheck:
+          test_id: "DIR02-01"
+          labels: ["min_req", "storage"]
 
     # ─── High-speed storage: SDS controller ──────────────────────────
     sds_controller:

--- a/isvctl/tests/conftest.py
+++ b/isvctl/tests/conftest.py
@@ -24,7 +24,7 @@ from types import ModuleType
 import pytest
 
 ISVCTL_ROOT = Path(__file__).resolve().parents[1]
-AWS_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "vm"
+AWS_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts"
 
 _LOADED_MODULES: dict[str, ModuleType] = {}
 
@@ -43,17 +43,23 @@ def _isolate_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pyte
     monkeypatch.delenv("ISVCTL_SECRETS", raising=False)
 
 
-def load_vm_script(script_name: str) -> ModuleType:
-    """Load an AWS VM script as a module for direct helper testing.
+def load_aws_script(domain: str, script_name: str) -> ModuleType:
+    """Load an AWS provider script as a module for direct helper testing.
 
-    Cached per script name so tests don't re-import boto3 on every call.
+    Cached per script so tests don't re-import boto3 on every call.
     """
-    if script_name in _LOADED_MODULES:
-        return _LOADED_MODULES[script_name]
-    script_path = AWS_VM_SCRIPTS / script_name
-    spec = importlib.util.spec_from_file_location(f"test_{script_path.stem}", script_path)
+    key = f"{domain}/{script_name}"
+    if key in _LOADED_MODULES:
+        return _LOADED_MODULES[key]
+    script_path = AWS_SCRIPTS / domain / script_name
+    spec = importlib.util.spec_from_file_location(f"test_{domain}_{script_path.stem}", script_path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    _LOADED_MODULES[script_name] = module
+    _LOADED_MODULES[key] = module
     return module
+
+
+def load_vm_script(script_name: str) -> ModuleType:
+    """Load an AWS VM script as a module for direct helper testing."""
+    return load_aws_script("vm", script_name)

--- a/isvctl/tests/test_aws_home_directory.py
+++ b/isvctl/tests/test_aws_home_directory.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the AWS FSx for OpenZFS home-directory probe."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from .conftest import load_aws_script
+
+
+def _load_script() -> ModuleType:
+    """Load the provider script for direct unit testing."""
+    return load_aws_script("storage", "home_directory_storage_test.py")
+
+
+def _volume(quota_gib: int) -> dict[str, Any]:
+    """Build an AVAILABLE OpenZFS volume with the expected identity quotas."""
+    return {
+        "Lifecycle": "AVAILABLE",
+        "OpenZFSConfiguration": {
+            "VolumePath": "/fsx/isvdir",
+            "StorageCapacityQuotaGiB": quota_gib,
+            "UserAndGroupQuotas": [
+                {"Type": "USER", "Id": 20001, "StorageCapacityQuotaGiB": 1},
+                {"Type": "GROUP", "Id": 30001, "StorageCapacityQuotaGiB": 1},
+            ],
+        },
+    }
+
+
+def _passed(names: tuple[str, ...]) -> dict[str, dict[str, Any]]:
+    """Return passing subtest objects for the requested names."""
+    return {name: {"passed": True} for name in names}
+
+
+def _patch_provisioning(
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+) -> list[tuple[str | None, str | None]]:
+    """Install the fakes shared by the main() tests; return the cleanup recorder."""
+    cleanup_calls: list[tuple[str | None, str | None]] = []
+    monkeypatch.setattr(module.boto3, "client", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        module,
+        "instance_network",
+        lambda *args: {
+            "public_ip": "203.0.113.10",
+            "private_ip": "10.0.0.10",
+            "subnet_id": "subnet-1",
+            "vpc_id": "vpc-1",
+            "security_group_id": "sg-client",
+        },
+    )
+    monkeypatch.setattr(module, "wait_for_ssh", lambda *args: True)
+    monkeypatch.setattr(
+        module,
+        "create_nfs_security_group",
+        lambda ec2, vpc_id, client_sg_id, suffix, created: created.update(sg_id="sg-nfs") or "sg-nfs",
+    )
+    monkeypatch.setattr(module, "_run_remote", lambda *args, **kwargs: (0, "", ""))
+    monkeypatch.setattr(
+        module,
+        "cleanup_resources",
+        lambda ec2, fsx, fs_id, sg_id: cleanup_calls.append((fs_id, sg_id)) or [],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["home_directory_storage_test.py", "--instance-id", "i-1", "--key-file", "/tmp/key.pem"],
+    )
+    return cleanup_calls
+
+
+def test_quota_config_requires_volume_and_identity_quotas() -> None:
+    """Quota configuration matching checks both volume and UID/GID limits."""
+    module = _load_script()
+    assert module._quota_config_matches(_volume(2), 2) is True
+    assert module._quota_config_matches(_volume(2), 1) is False
+    missing_group = _volume(2)
+    missing_group["OpenZFSConfiguration"]["UserAndGroupQuotas"].pop()
+    assert module._quota_config_matches(missing_group, 2) is False
+
+
+def test_accounting_probe_parses_identity_totals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The accounting probe passes only for exact, identity-scoped byte totals."""
+    module = _load_script()
+    monkeypatch.setattr(
+        module,
+        "_run_remote",
+        lambda *args, **kwargs: (0, f"{8 * 1024 * 1024} {4 * 1024 * 1024} {8 * 1024 * 1024} {4 * 1024 * 1024}", ""),
+    )
+    result = module._probe_accounting("host", "key")
+    assert all(test["passed"] for test in result.values())
+
+
+def test_accounting_probe_rejects_unparseable_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed remote accounting output fails all dependent probes."""
+    module = _load_script()
+    monkeypatch.setattr(module, "_run_remote", lambda *args, **kwargs: (1, "bad", "find failed"))
+    result = module._probe_accounting("host", "key")
+    assert not any(test["passed"] for test in result.values())
+    assert all("find failed" in test["error"] for test in result.values())
+
+
+def test_wait_volume_ignores_stale_available_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An AVAILABLE response is not enough until it contains the requested quota."""
+    _load_script()
+    helper = sys.modules["common.openzfs"]
+    responses = iter((_volume(2), _volume(1)))
+    monkeypatch.setattr(helper, "describe_volume", lambda *args: next(responses))
+    monkeypatch.setattr(helper.time, "sleep", lambda delay: None)
+
+    result = helper.wait_volume(object(), "vol-child", expected_quota_gib=1, timeout=5, delay=0)
+
+    assert result["OpenZFSConfiguration"]["StorageCapacityQuotaGiB"] == 1
+
+
+def test_main_happy_path(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """One shared filesystem run can satisfy all three DIR validations."""
+    module = _load_script()
+    quota = {"value": 2}
+    cleanup_calls = _patch_provisioning(monkeypatch, module)
+
+    monkeypatch.setattr(module, "create_filesystem", lambda *args: "fs-1")
+    monkeypatch.setattr(
+        module,
+        "wait_filesystem_available",
+        lambda *args: {"DNSName": "fs.example", "OpenZFSConfiguration": {"RootVolumeId": "vol-root"}},
+    )
+    monkeypatch.setattr(module, "create_test_volume", lambda *args: "vol-child")
+    monkeypatch.setattr(module, "wait_volume", lambda *args, **kwargs: _volume(quota["value"]))
+    monkeypatch.setattr(module, "set_volume_quota", lambda *args: quota.update(value=args[2]))
+    monkeypatch.setattr(module, "_mount_volume", lambda *args: None)
+    monkeypatch.setattr(
+        module,
+        "_probe_nfs",
+        lambda *args: _passed(("nfsv4_mounted", "nfs_read_write", "nfs_shared_visibility")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_probe_accounting",
+        lambda *args: _passed(("uid_usage_accounted", "gid_usage_accounted", "identity_usage_isolated")),
+    )
+    monkeypatch.setattr(module, "_probe_quota_enforcement", lambda *args: {"passed": True})
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert all(test["passed"] for test in payload["tests"].values())
+    assert cleanup_calls == [("fs-1", "sg-nfs")]
+
+
+def test_main_cleans_partial_resources_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A provisioning failure is emitted as JSON and still triggers cleanup."""
+    module = _load_script()
+    cleanup_calls = _patch_provisioning(monkeypatch, module)
+    monkeypatch.setattr(module, "create_filesystem", lambda *args: (_ for _ in ()).throw(RuntimeError("create failed")))
+
+    assert module.main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert "create failed" in payload["error"]
+    assert cleanup_calls == [(None, "sg-nfs")]

--- a/isvctl/tests/test_aws_home_directory.py
+++ b/isvctl/tests/test_aws_home_directory.py
@@ -90,6 +90,37 @@ def _patch_provisioning(
     return cleanup_calls
 
 
+def _patch_successful_run(
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+) -> list[tuple[str | None, str | None]]:
+    """Install a complete successful-run fixture and return cleanup calls."""
+    cleanup_calls = _patch_provisioning(monkeypatch, module)
+    quota = {"value": 2}
+    monkeypatch.setattr(module, "create_filesystem", lambda *args: "fs-1")
+    monkeypatch.setattr(
+        module,
+        "wait_filesystem_available",
+        lambda *args: {"DNSName": "fs.example", "OpenZFSConfiguration": {"RootVolumeId": "vol-root"}},
+    )
+    monkeypatch.setattr(module, "create_test_volume", lambda *args: "vol-child")
+    monkeypatch.setattr(module, "wait_volume", lambda *args, **kwargs: _volume(quota["value"]))
+    monkeypatch.setattr(module, "set_volume_quota", lambda *args: quota.update(value=args[2]))
+    monkeypatch.setattr(module, "_mount_volume", lambda *args: None)
+    monkeypatch.setattr(
+        module,
+        "_probe_nfs",
+        lambda *args: _passed(("nfsv4_mounted", "nfs_read_write", "nfs_shared_visibility")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_probe_accounting",
+        lambda *args: _passed(("uid_usage_accounted", "gid_usage_accounted", "identity_usage_isolated")),
+    )
+    monkeypatch.setattr(module, "_probe_quota_enforcement", lambda *args: {"passed": True})
+    return cleanup_calls
+
+
 def test_quota_config_requires_volume_and_identity_quotas() -> None:
     """Quota configuration matching checks both volume and UID/GID limits."""
     module = _load_script()
@@ -137,36 +168,38 @@ def test_wait_volume_ignores_stale_available_response(monkeypatch: pytest.Monkey
 def test_main_happy_path(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     """One shared filesystem run can satisfy all three DIR validations."""
     module = _load_script()
-    quota = {"value": 2}
-    cleanup_calls = _patch_provisioning(monkeypatch, module)
-
-    monkeypatch.setattr(module, "create_filesystem", lambda *args: "fs-1")
-    monkeypatch.setattr(
-        module,
-        "wait_filesystem_available",
-        lambda *args: {"DNSName": "fs.example", "OpenZFSConfiguration": {"RootVolumeId": "vol-root"}},
-    )
-    monkeypatch.setattr(module, "create_test_volume", lambda *args: "vol-child")
-    monkeypatch.setattr(module, "wait_volume", lambda *args, **kwargs: _volume(quota["value"]))
-    monkeypatch.setattr(module, "set_volume_quota", lambda *args: quota.update(value=args[2]))
-    monkeypatch.setattr(module, "_mount_volume", lambda *args: None)
-    monkeypatch.setattr(
-        module,
-        "_probe_nfs",
-        lambda *args: _passed(("nfsv4_mounted", "nfs_read_write", "nfs_shared_visibility")),
-    )
-    monkeypatch.setattr(
-        module,
-        "_probe_accounting",
-        lambda *args: _passed(("uid_usage_accounted", "gid_usage_accounted", "identity_usage_isolated")),
-    )
-    monkeypatch.setattr(module, "_probe_quota_enforcement", lambda *args: {"passed": True})
+    cleanup_calls = _patch_successful_run(monkeypatch, module)
 
     assert module.main() == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["success"] is True
     assert all(test["passed"] for test in payload["tests"].values())
     assert cleanup_calls == [("fs-1", "sg-nfs")]
+
+
+def test_main_combines_unmount_and_aws_cleanup_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Teardown errors fail the run without preventing AWS cleanup."""
+    module = _load_script()
+    cleanup_calls = _patch_successful_run(monkeypatch, module)
+    monkeypatch.setattr(module, "_run_remote", lambda *args, **kwargs: (1, "", "device busy"))
+    monkeypatch.setattr(
+        module,
+        "cleanup_resources",
+        lambda ec2, fsx, fs_id, sg_id: cleanup_calls.append((fs_id, sg_id)) or ["filesystem cleanup failed"],
+    )
+
+    assert module.main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["cleanup"] is False
+    assert payload["cleanup_errors"] == [
+        "unmount cleanup failed: device busy",
+        "filesystem cleanup failed",
+    ]
+    assert cleanup_calls[-1] == ("fs-1", "sg-nfs")
 
 
 def test_main_cleans_partial_resources_on_failure(

--- a/isvtest/src/isvtest/validations/home_directory.py
+++ b/isvtest/src/isvtest/validations/home_directory.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-neutral home-directory storage validations."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from isvtest.core.validation import BaseValidation, check_required_tests
+
+
+class DirectoryFilesystemQuotaCheck(BaseValidation):
+    """Validate configurable filesystem-wide quota limits (DIR01-01).
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with filesystem_quota_configured, filesystem_quota_updated,
+            filesystem_quota_enforced
+    """
+
+    description: ClassVar[str] = "Verify configurable filesystem-wide quota limits"
+
+    def run(self) -> None:
+        """Require quota configuration, update, and enforcement probes."""
+        required = ["filesystem_quota_configured", "filesystem_quota_updated", "filesystem_quota_enforced"]
+        if not check_required_tests(self, required, "Filesystem quota tests failed"):
+            return
+        self.set_passed("Filesystem-wide quota was configured, updated, and enforced")
+
+
+class DirectoryUsageAccountingCheck(BaseValidation):
+    """Validate storage usage accounting by numeric UID and GID (DIR01-02).
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with uid_usage_accounted, gid_usage_accounted,
+            identity_usage_isolated
+    """
+
+    description: ClassVar[str] = "Verify usage accounting for uid/gids"
+
+    def run(self) -> None:
+        """Require UID, GID, and identity-isolation accounting probes."""
+        required = ["uid_usage_accounted", "gid_usage_accounted", "identity_usage_isolated"]
+        if not check_required_tests(self, required, "UID/GID usage accounting tests failed"):
+            return
+        self.set_passed("Storage usage was accounted independently by UID and GID")
+
+
+class DirectoryNfsAvailabilityCheck(BaseValidation):
+    """Validate NFSv4 shared storage availability (DIR02-01).
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with nfsv4_mounted, nfs_read_write, nfs_shared_visibility
+    """
+
+    description: ClassVar[str] = "Verify NFS protocol shared storage is available"
+
+    def run(self) -> None:
+        """Require NFSv4 mount, read/write, and shared-visibility probes."""
+        required = ["nfsv4_mounted", "nfs_read_write", "nfs_shared_visibility"]
+        if not check_required_tests(self, required, "NFS shared-storage tests failed"):
+            return
+        self.set_passed("NFSv4 shared storage mounted read/write with cross-mount visibility")

--- a/isvtest/tests/test_home_directory.py
+++ b/isvtest/tests/test_home_directory.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for home-directory storage validations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from isvtest.validations.home_directory import (
+    DirectoryFilesystemQuotaCheck,
+    DirectoryNfsAvailabilityCheck,
+    DirectoryUsageAccountingCheck,
+)
+
+pytestmark = pytest.mark.unit
+
+_CASES = [
+    (
+        DirectoryFilesystemQuotaCheck,
+        ["filesystem_quota_configured", "filesystem_quota_updated", "filesystem_quota_enforced"],
+        "configured, updated, and enforced",
+    ),
+    (
+        DirectoryUsageAccountingCheck,
+        ["uid_usage_accounted", "gid_usage_accounted", "identity_usage_isolated"],
+        "accounted independently",
+    ),
+    (
+        DirectoryNfsAvailabilityCheck,
+        ["nfsv4_mounted", "nfs_read_write", "nfs_shared_visibility"],
+        "NFSv4 shared storage",
+    ),
+]
+
+
+def _config(tests: dict[str, Any]) -> dict[str, Any]:
+    """Build validation config containing a provider step output."""
+    return {"step_output": {"success": True, "platform": "storage", "tests": tests}}
+
+
+@pytest.mark.parametrize(("validation_class", "required", "message"), _CASES)
+def test_home_directory_check_passes(
+    validation_class: type,
+    required: list[str],
+    message: str,
+) -> None:
+    """Each check passes when all of its required provider probes pass."""
+    validation = validation_class(config=_config({name: {"passed": True} for name in required}))
+    result = validation.execute()
+    assert result["passed"] is True
+    assert message in result["output"]
+
+
+@pytest.mark.parametrize(("validation_class", "required", "message"), _CASES)
+def test_home_directory_check_surfaces_probe_failure(
+    validation_class: type,
+    required: list[str],
+    message: str,
+) -> None:
+    """Each check reports the failed provider probe and its error."""
+    tests = {name: {"passed": True} for name in required}
+    tests[required[0]] = {"passed": False, "error": "probe failed"}
+    validation = validation_class(config=_config(tests))
+    result = validation.execute()
+    assert result["passed"] is False
+    assert required[0] in result["error"]
+    assert "probe failed" in result["error"]
+
+
+@pytest.mark.parametrize("validation_class", [case[0] for case in _CASES])
+def test_home_directory_check_rejects_missing_tests(validation_class: type) -> None:
+    """Each check fails when the provider omitted its tests block."""
+    result = validation_class(config={"step_output": {}}).execute()
+    assert result["passed"] is False
+    assert "tests" in result["error"]


### PR DESCRIPTION
## Summary

Implements the home-directory storage requirement family:

- **DIR01-01** `DirectoryFilesystemQuotaCheck` — configurable filesystem-wide quota limits (#324)
- **DIR01-02** `DirectoryUsageAccountingCheck` — usage accounting by numeric UID/GID (#325)
- **DIR02-01** `DirectoryNfsAvailabilityCheck` — NFSv4 shared storage availability (#326)

The three checks are provider-neutral assertions over the step-output JSON contract, wired through `suites/storage.yaml` with a single `home_directory_storage` test-phase step.

## AWS reference implementation

`home_directory_storage_test.py` provisions one minimum-cost Single-AZ FSx for OpenZFS filesystem, mounts an exported child volume twice over NFSv4.1 from the block fixture's EC2 client, and runs all DIR01/DIR02 probes in a single filesystem lifetime: volume + per-UID/GID quota configuration, quota update (2 GiB → 1 GiB) and enforcement via an over-quota write, identity-scoped byte accounting, and cross-mount canary visibility. Teardown is best-effort with `DELETE_CHILD_VOLUMES_AND_SNAPSHOTS` and retries `DependencyViolation` while the FSx ENI releases the NFS security group.

Filesystem lifecycle plumbing (describe/wait/delete) is shared with the Lustre scripts via `common/fsx.py` — `delete_filesystem` now forwards type-specific delete kwargs instead of the OpenZFS module re-implementing the loop — and the generic `instance_network` helper lands in `common/ec2.py`. A my-isv scaffold stub with the standard `DEMO_MODE` gate is included.

Also regenerates `docs/test-plan.adoc` from `test-plan.yaml` (catch-up for earlier label/status changes) and generalizes the cached script loader in `isvctl/tests/conftest.py` to any AWS script domain.

## Verification

- `uv run pytest isvctl/tests/ isvtest/tests/` — 2533 passed
- `make lint`, `uvx pre-commit run -a` — clean
- `make demo-test` — all my-isv domains pass, including the new storage step

Closes #324 
Closes #325 
Closes #326 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added home-directory storage validation covering NFS shared access, filesystem quota enforcement, and UID/GID usage accounting.
  - Introduced AWS FSx for OpenZFS support to provision and verify home-directory storage end-to-end.
  - Added a provider-neutral placeholder implementation for unsupported environments.
- **Documentation**
  - Updated test-plan metadata/status and expanded labels for multiple storage and security-related test cases.
- **Tests**
  - Added unit tests for the new validations and AWS-focused tests for the home-directory probe flow.
- **Chores**
  - Improved AWS storage validation helper behavior to support additional runtime scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->