### PR TITLE
fix(security): harden SEC04 least-privilege IAM propagation gate

### DIFF
--- a/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
@@ -594,7 +594,11 @@ def main() -> int:
             user_based_passed = allowed_passed and username in caller_arn
             result["tests"]["policy_dimensions_user_based"] = {
                 "passed": user_based_passed,
-                "message": "temporary principal identity verified",
+                "message": (
+                    "temporary principal identity verified"
+                    if user_based_passed
+                    else "temporary principal identity check failed"
+                ),
             }
             if not user_based_passed:
                 result["tests"]["policy_dimensions_user_based"]["error"] = (

--- a/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
@@ -68,6 +68,13 @@ PROBE_CIDR = "10.96.0.0/24"
 
 SKIPPABLE_SETUP_ERRORS = frozenset({"AccessDenied", "UnauthorizedOperation"})
 DENY_CODES = frozenset({"AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "Forbidden"})
+# A freshly minted access key is not accepted by every service endpoint at
+# once; until it propagates, EC2 returns AuthFailure and S3 returns
+# InvalidAccessKeyId. These are credential-propagation races, not deny results,
+# so the probes must wait them out instead of misclassifying them as failures.
+CREDENTIAL_PROPAGATION_CODES = frozenset(
+    {"InvalidClientTokenId", "AuthFailure", "InvalidAccessKeyId", "SignatureDoesNotMatch"}
+)
 DRY_RUN_ALLOWED_CODE = "DryRunOperation"
 IAM_PROPAGATION_MAX_ATTEMPTS = 8
 IAM_PROPAGATION_BACKOFF_CAP = 8
@@ -291,18 +298,33 @@ def _policy_dimension_scope_results(
     """Build resource- and network-scope SEC04 result entries from concrete evidence."""
     allowed_passed = bool(allowed_result.get("passed"))
     source_condition_matches = _policy_has_source_cidr_condition(policy_document, allowed_bucket, source_cidr)
-    resource_result = {
-        "passed": allowed_passed and bool(denied_resource_result.get("passed")),
+    resource_passed = allowed_passed and bool(denied_resource_result.get("passed"))
+    resource_result: dict[str, Any] = {
+        "passed": resource_passed,
         "message": "allowed scoped resource and denied unscoped resource",
         "probes": [denied_resource_result],
     }
-    network_result = {
-        "passed": allowed_passed and source_condition_matches,
+    if not resource_passed:
+        if not allowed_passed:
+            resource_result["error"] = "allowed scoped-resource action did not succeed"
+        else:
+            resource_result["error"] = denied_resource_result.get("error") or (
+                f"unscoped-resource probe returned {denied_resource_result.get('code', 'unknown')}"
+            )
+    network_passed = allowed_passed and source_condition_matches
+    network_result: dict[str, Any] = {
+        "passed": network_passed,
         "message": (
             "minimal policy "
             f"{'contains' if source_condition_matches else 'does not contain'} the expected source CIDR condition"
         ),
     }
+    if not network_passed:
+        network_result["error"] = (
+            "allowed scoped-resource action did not succeed"
+            if not allowed_passed
+            else "minimal policy is missing the expected source CIDR condition"
+        )
     return resource_result, network_result
 
 
@@ -357,18 +379,41 @@ def _cleanup_test_user(
     return errors
 
 
-def _wait_for_iam_propagation(sts: Any) -> None:
-    """Block until the temporary access key is visible to STS."""
-    for attempt in range(IAM_PROPAGATION_MAX_ATTEMPTS):
-        try:
-            sts.get_caller_identity()
-            return
-        except ClientError as exc:
-            code = exc.response.get("Error", {}).get("Code", "")
-            if code == "InvalidClientTokenId" and attempt < IAM_PROPAGATION_MAX_ATTEMPTS - 1:
+def _service_accepts_credentials(probe: Callable[[], Any]) -> bool:
+    """Return True once a probe authenticates (any non-propagation response).
+
+    A deny (``AccessDenied``/``UnauthorizedOperation``) or ``DryRunOperation``
+    still proves the endpoint accepted the key; only credential-propagation
+    codes mean the key is not usable yet.
+    """
+    try:
+        probe()
+    except ClientError as exc:
+        return exc.response.get("Error", {}).get("Code", "") not in CREDENTIAL_PROPAGATION_CODES
+    return True
+
+
+def _wait_for_iam_propagation(clients: dict[str, Any], allowed_bucket: str) -> None:
+    """Block until STS, EC2, and S3 all accept the temporary access key.
+
+    STS visibility does not guarantee the EC2/S3 endpoints accept the key yet;
+    until they do they return AuthFailure/InvalidAccessKeyId, which the deny
+    probes would otherwise misclassify as authorization failures.
+    """
+    probes: tuple[tuple[str, Callable[[], Any]], ...] = (
+        ("sts", lambda: clients["sts"].get_caller_identity()),
+        ("ec2", lambda: clients["ec2"].describe_regions(DryRun=True)),
+        ("s3", lambda: clients["s3"].list_objects_v2(Bucket=allowed_bucket, MaxKeys=1)),
+    )
+    for service, probe in probes:
+        for attempt in range(IAM_PROPAGATION_MAX_ATTEMPTS):
+            if _service_accepts_credentials(probe):
+                break
+            if attempt < IAM_PROPAGATION_MAX_ATTEMPTS - 1:
                 time.sleep(min(2 ** (attempt + 1), IAM_PROPAGATION_BACKOFF_CAP))
-                continue
-            raise
+        else:
+            msg = f"temporary credentials did not propagate to {service} before timeout"
+            raise RuntimeError(msg)
 
 
 def _probe_allowed_bucket(s3_user: Any, allowed_bucket: str) -> dict[str, Any]:
@@ -528,7 +573,7 @@ def main() -> int:
                 raise RuntimeError(msg)
 
             clients = _build_user_clients(access_key_id, secret_key, region)
-            _wait_for_iam_propagation(clients["sts"])
+            _wait_for_iam_propagation(clients, allowed_bucket)
             caller = clients["sts"].get_caller_identity()
             caller_arn = caller.get("Arn", "")
 
@@ -546,10 +591,17 @@ def main() -> int:
                 allowed_bucket=allowed_bucket,
                 source_cidr=source_cidr,
             )
+            user_based_passed = allowed_passed and username in caller_arn
             result["tests"]["policy_dimensions_user_based"] = {
-                "passed": allowed_passed and username in caller_arn,
+                "passed": user_based_passed,
                 "message": "temporary principal identity verified",
             }
+            if not user_based_passed:
+                result["tests"]["policy_dimensions_user_based"]["error"] = (
+                    "allowed scoped-resource action did not succeed"
+                    if not allowed_passed
+                    else "temporary principal identity did not match the minted access key"
+                )
             result["tests"]["policy_dimensions_resource_based"] = resource_scope_result
             result["tests"]["policy_dimensions_network_based"] = network_scope_result
 

--- a/isvctl/tests/providers/aws/test_aws_security_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_security_scripts.py
@@ -1053,6 +1053,76 @@ def test_least_privilege_dimension_results_require_denied_bucket_and_source_cidr
 
     assert failed_resource_result["passed"] is False
     assert failed_network_result["passed"] is False
+    assert failed_resource_result["error"]
+    assert failed_network_result["error"]
+
+
+class _FakeSec04PropagationClient:
+    """Fail a fixed number of times with a propagation code, then authenticate."""
+
+    def __init__(self, operation: str, code: str, fail_times: int) -> None:
+        """Record the op/code to raise and how many times before succeeding."""
+        self.operation = operation
+        self.code = code
+        self.fail_times = fail_times
+        self.calls = 0
+
+    def _maybe_raise(self) -> None:
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise _client_error(self.operation, self.code)
+
+    def get_caller_identity(self, **_kwargs: Any) -> dict[str, str]:
+        """STS probe used by the propagation gate."""
+        self._maybe_raise()
+        return {"Arn": "arn:aws:iam::123:user/isv-sec04-test"}
+
+    def describe_regions(self, **_kwargs: Any) -> dict[str, Any]:
+        """EC2 probe used by the propagation gate."""
+        self._maybe_raise()
+        raise _client_error("DescribeRegions", "DryRunOperation")
+
+    def list_objects_v2(self, **_kwargs: Any) -> dict[str, Any]:
+        """S3 probe used by the propagation gate."""
+        self._maybe_raise()
+        raise _client_error("ListObjectsV2", "AccessDenied")
+
+
+def test_least_privilege_propagation_gate_waits_out_transient_auth_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate retries AuthFailure/InvalidAccessKeyId until every service accepts the key."""
+    module = _load_security_script("least_privilege_test.py")
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    clients = {
+        "sts": _FakeSec04PropagationClient("GetCallerIdentity", "InvalidClientTokenId", fail_times=2),
+        "ec2": _FakeSec04PropagationClient("DescribeRegions", "AuthFailure", fail_times=3),
+        "s3": _FakeSec04PropagationClient("ListObjectsV2", "InvalidAccessKeyId", fail_times=1),
+    }
+
+    module._wait_for_iam_propagation(clients, "isv-sec04-test-allowed")
+
+    assert clients["sts"].calls == 3
+    assert clients["ec2"].calls == 4
+    assert clients["s3"].calls == 2
+
+
+def test_least_privilege_propagation_gate_raises_when_service_never_accepts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A service that keeps returning a propagation code surfaces a clear timeout error."""
+    module = _load_security_script("least_privilege_test.py")
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    clients = {
+        "sts": _FakeSec04PropagationClient("GetCallerIdentity", "InvalidClientTokenId", fail_times=0),
+        "ec2": _FakeSec04PropagationClient("DescribeRegions", "AuthFailure", fail_times=999),
+        "s3": _FakeSec04PropagationClient("ListObjectsV2", "InvalidAccessKeyId", fail_times=0),
+    }
+
+    with pytest.raises(RuntimeError, match="did not propagate to ec2"):
+        module._wait_for_iam_propagation(clients, "isv-sec04-test-allowed")
 
 
 class FakeIamTags:


### PR DESCRIPTION
## Summary
- Wait for STS, EC2, and S3 to accept freshly minted SEC04 test access keys before running deny probes, avoiding flaky `AuthFailure` / `InvalidAccessKeyId` misclassification as authorization failures
- Add explicit `error` fields on policy-dimension subtests so validation failures report the real probe outcome instead of the misleading "test not found"
- Add unit tests covering the multi-service propagation gate and timeout behavior

## Test plan
- [x] `uv run pytest isvctl/tests/providers/aws/test_aws_security_scripts.py -k "least_privilege or propagation" -q` (5 passed)
- [x] `uv run pytest isvctl/tests/providers/aws/test_aws_security_scripts.py -q` (142 passed)
- [x] Live AWS security suite on lab 37 (`ISVTEST_INCLUDE_UNRELEASED=1`, test run 356): all phases passed, including `LeastPrivilegePolicyCheck` and `MinimalRoleEnforcementCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEC04 temporary AWS credential validation by separating propagation races from true authorization denials.
  * Enhanced readiness checks to wait across multiple AWS services (including STS, EC2, and S3) with retries, reporting the specific service that never becomes ready.
  * Refined validation outcomes and error messaging for user, resource, and network checks when expectations aren’t met.
* **Tests**
  * Added deterministic service clients and new test cases covering retry/call counts and timeout behavior, including verification that error details are present when checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->