### PR TITLE
fix(storage): raise FSx live-expansion capacity-wait timeout to 60m

### DIFF
--- a/isvctl/configs/providers/aws/config/storage.yaml
+++ b/isvctl/configs/providers/aws/config/storage.yaml
@@ -175,8 +175,8 @@ commands:
         requires_available_validations:
           - HssLiveExpansionCheck
         args: ["--region", "{{region}}"]
-        # 1800 (create) + 1800 (capacity scale) + 900 (delete) + slack.
-        timeout: 4800
+        # 1800 (create) + 3600 (capacity scale) + 900 (delete) + slack.
+        timeout: 6600
 
       - name: root_squash
         phase: test

--- a/isvctl/configs/providers/aws/scripts/common/fsx.py
+++ b/isvctl/configs/providers/aws/scripts/common/fsx.py
@@ -202,7 +202,7 @@ def wait_root_squash(fsx: Any, fs_id: str, expected: str, *, timeout: float = 60
     return False
 
 
-def wait_storage_capacity(fsx: Any, fs_id: str, at_least: int, *, timeout: float = 1800.0, delay: float = 15.0) -> int:
+def wait_storage_capacity(fsx: Any, fs_id: str, at_least: int, *, timeout: float = 3600.0, delay: float = 15.0) -> int:
     """Poll until StorageCapacity >= ``at_least`` and Lifecycle is AVAILABLE.
 
     FSx for Lustre may briefly enter ``UPDATING`` while adding capacity; the new


### PR DESCRIPTION
## Summary
- Increase `wait_storage_capacity` default from 30m to 60m so FSx for Lustre live expansion (1200→2400 GiB) is not killed while still in `UPDATING`.
- Widen the `live_expansion` orchestrator step timeout from 4800s to 6600s to match the new worst-case budget.

Observed failure in lab run 357: filesystem `fs-041e2642114a34627` stayed at `StorageCapacity=1200, Lifecycle=UPDATING` for the full 30-minute poll window before the script timed out.

## Test plan
- [x] Pre-commit hooks pass on commit
- [x] Re-run AWS storage suite with `ISVTEST_INCLUDE_UNRELEASED=1` and confirm `HssLiveExpansionCheck` passes
- [x] Verified no leaked FSx/VPC resources from the failed run (`fs-041e2642114a34627` not found; no `isv-fsx-*` VPCs; block fixture instance terminated and volume deleted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the wait time for AWS FSx Lustre storage expansion checks.
  - Improved reliability for capacity expansion operations that require longer than expected to complete.
  - Updated timeout guidance to reflect the extended worst-case expansion duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->