### PR TITLE
feat(catalog): register STORAGE as a capability platform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,8 @@ repos:
         files: ^(docs/test-plan\.yaml|isvctl/configs/suites/.*\.yaml|scripts/test_plan_coverage\.py)$
 
       - id: validate-suites
-        name: check tests suites (test_id + labels)
+        name: check tests suites (test_id + labels + platform)
         entry: uv run python scripts/validate_suite_wiring.py --check
         language: system
         pass_filenames: false
-        files: ^isvctl/configs/suites/.*\.yaml$
+        files: ^(isvctl/configs/suites/.*\.yaml|isvtest/src/isvtest/catalog\.py|scripts/validate_suite_wiring\.py)$

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -360,7 +360,10 @@ class ValidationConfig(BaseModel):
     description: str | None = Field(default=None, description="Test run description")
     platform: str | None = Field(
         default=None,
-        description="Platform type: KUBERNETES, SLURM, BARE_METAL, CONTROL_PLANE, IAM, NETWORK, SECURITY, VM, IMAGE_REGISTRY, OBSERVABILITY, STORAGE",
+        description=(
+            "Platform type: KUBERNETES, SLURM, BARE_METAL, CONTROL_PLANE, IAM, NETWORK, "
+            "SECURITY, VM, IMAGE_REGISTRY, OBSERVABILITY, STORAGE"
+        ),
     )
     settings: dict[str, Any] = Field(default_factory=dict, description="Test settings")
     validations: dict[str, list[dict[str, Any]] | dict[str, Any]] = Field(

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -360,7 +360,7 @@ class ValidationConfig(BaseModel):
     description: str | None = Field(default=None, description="Test run description")
     platform: str | None = Field(
         default=None,
-        description="Platform type: KUBERNETES, SLURM, BARE_METAL, CONTROL_PLANE, IAM, NETWORK, SECURITY, VM, IMAGE_REGISTRY, OBSERVABILITY",
+        description="Platform type: KUBERNETES, SLURM, BARE_METAL, CONTROL_PLANE, IAM, NETWORK, SECURITY, VM, IMAGE_REGISTRY, OBSERVABILITY, STORAGE",
     )
     settings: dict[str, Any] = Field(default_factory=dict, description="Test settings")
     validations: dict[str, list[dict[str, Any]] | dict[str, Any]] = Field(

--- a/isvreporter/src/isvreporter/platform.py
+++ b/isvreporter/src/isvreporter/platform.py
@@ -33,6 +33,7 @@ SECURITY = "SECURITY"
 VM = "VM"
 IMAGE_REGISTRY = "IMAGE_REGISTRY"
 OBSERVABILITY = "OBSERVABILITY"
+STORAGE = "STORAGE"
 
 ALL_PLATFORMS = {
     KUBERNETES,
@@ -45,6 +46,7 @@ ALL_PLATFORMS = {
     VM,
     IMAGE_REGISTRY,
     OBSERVABILITY,
+    STORAGE,
 }
 
 # Platform aliases (normalized to canonical uppercase names)
@@ -61,6 +63,7 @@ PLATFORM_ALIASES: dict[str, str] = {
     "vm": VM,
     "image_registry": IMAGE_REGISTRY,
     "observability": OBSERVABILITY,
+    "storage": STORAGE,
 }
 
 DEFAULT_PLATFORM = KUBERNETES

--- a/isvreporter/tests/test_platform.py
+++ b/isvreporter/tests/test_platform.py
@@ -23,6 +23,7 @@ from isvreporter.platform import (
     KUBERNETES,
     OBSERVABILITY,
     SLURM,
+    STORAGE,
     get_platform_from_config,
     is_valid_platform,
     normalize_platform,
@@ -74,6 +75,12 @@ class TestNormalizePlatform:
         assert normalize_platform("OBSERVABILITY") == OBSERVABILITY
         assert normalize_platform("Observability") == OBSERVABILITY
 
+    def test_normalize_storage(self) -> None:
+        """Test that storage normalizes correctly."""
+        assert normalize_platform("storage") == STORAGE
+        assert normalize_platform("STORAGE") == STORAGE
+        assert normalize_platform("Storage") == STORAGE
+
     def test_normalize_empty_and_none(self) -> None:
         """Test that empty/None returns default platform."""
         assert normalize_platform(None) == DEFAULT_PLATFORM
@@ -103,6 +110,7 @@ class TestIsValidPlatform:
         assert is_valid_platform("bare-metal") is True
         assert is_valid_platform("bm") is True
         assert is_valid_platform("observability") is True
+        assert is_valid_platform("storage") is True
 
     def test_valid_platforms_case_insensitive(self) -> None:
         """Test that platform validation is case insensitive."""
@@ -139,6 +147,11 @@ class TestGetPlatformFromConfig:
         """Test reading observability from config."""
         config = _write_config(tmp_path, "tests:\n  platform: observability\n")
         assert get_platform_from_config(str(config)) == OBSERVABILITY
+
+    def test_config_with_storage(self, tmp_path: Path) -> None:
+        """Test reading storage from config."""
+        config = _write_config(tmp_path, "tests:\n  platform: storage\n")
+        assert get_platform_from_config(str(config)) == STORAGE
 
     def test_config_without_tests_section(self, tmp_path: Path) -> None:
         """Test that missing tests section returns default."""

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -36,44 +36,11 @@ from typing import Any
 import yaml
 from isvreporter.version import get_version
 
+from isvtest.catalog_platforms import LABEL_TO_PLATFORM, PLATFORM_CONFIGS
 from isvtest.core.discovery import discover_all_tests
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
 
 logger = logging.getLogger(__name__)
-
-# Configs that define the canonical test list per platform.
-# Relative to the isvctl/configs/ directory.
-PLATFORM_CONFIGS: dict[str, list[str]] = {
-    "BARE_METAL": ["suites/bare_metal.yaml"],
-    "CONTROL_PLANE": ["suites/control-plane.yaml"],
-    "IAM": ["suites/iam.yaml"],
-    "IMAGE_REGISTRY": ["suites/image-registry.yaml"],
-    "KUBERNETES": ["suites/k8s.yaml"],
-    "NETWORK": ["suites/network.yaml"],
-    "OBSERVABILITY": ["suites/observability.yaml"],
-    "SECURITY": ["suites/security.yaml"],
-    "SLURM": ["suites/slurm.yaml"],
-    "STORAGE": ["suites/storage.yaml"],
-    "VM": ["suites/vm.yaml"],
-}
-
-# Maps wiring labels to platform strings so a check's platform can be inferred
-# from its labels when it isn't otherwise tied to a platform.
-# Only platform-identifying labels are included; trait labels like "gpu",
-# "ssh", "workload", and "slow" are intentionally omitted.
-LABEL_TO_PLATFORM: dict[str, str] = {
-    "bare_metal": "BARE_METAL",
-    "control_plane": "CONTROL_PLANE",
-    "iam": "IAM",
-    "image_registry": "IMAGE_REGISTRY",
-    "kubernetes": "KUBERNETES",
-    "network": "NETWORK",
-    "observability": "OBSERVABILITY",
-    "security": "SECURITY",
-    "slurm": "SLURM",
-    "storage": "STORAGE",
-    "vm": "VM",
-}
 
 # Version of the catalog document envelope (schemaVersion field), bumped only
 # when the top-level shape changes - independent of the isvtest package version

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -53,6 +53,7 @@ PLATFORM_CONFIGS: dict[str, list[str]] = {
     "OBSERVABILITY": ["suites/observability.yaml"],
     "SECURITY": ["suites/security.yaml"],
     "SLURM": ["suites/slurm.yaml"],
+    "STORAGE": ["suites/storage.yaml"],
     "VM": ["suites/vm.yaml"],
 }
 
@@ -70,6 +71,7 @@ LABEL_TO_PLATFORM: dict[str, str] = {
     "observability": "OBSERVABILITY",
     "security": "SECURITY",
     "slurm": "SLURM",
+    "storage": "STORAGE",
     "vm": "VM",
 }
 

--- a/isvtest/src/isvtest/catalog_platforms.py
+++ b/isvtest/src/isvtest/catalog_platforms.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical platform registry for the test catalog.
+
+Leaf module with no dependencies so lightweight consumers (for example the
+validate-suites pre-commit hook) can read the registry without triggering
+test discovery and its heavy transitive imports via :mod:`isvtest.catalog`.
+"""
+
+# Configs that define the canonical test list per platform.
+# Relative to the isvctl/configs/ directory.
+PLATFORM_CONFIGS: dict[str, list[str]] = {
+    "BARE_METAL": ["suites/bare_metal.yaml"],
+    "CONTROL_PLANE": ["suites/control-plane.yaml"],
+    "IAM": ["suites/iam.yaml"],
+    "IMAGE_REGISTRY": ["suites/image-registry.yaml"],
+    "KUBERNETES": ["suites/k8s.yaml"],
+    "NETWORK": ["suites/network.yaml"],
+    "OBSERVABILITY": ["suites/observability.yaml"],
+    "SECURITY": ["suites/security.yaml"],
+    "SLURM": ["suites/slurm.yaml"],
+    "STORAGE": ["suites/storage.yaml"],
+    "VM": ["suites/vm.yaml"],
+}
+
+# Maps wiring labels to platform strings so a check's platform can be inferred
+# from its labels when it isn't otherwise tied to a platform. Derived from
+# PLATFORM_CONFIGS: every platform's label is its lowercase name. Trait labels
+# like "gpu", "ssh", "workload", and "slow" are intentionally not platforms.
+LABEL_TO_PLATFORM: dict[str, str] = {platform.lower(): platform for platform in PLATFORM_CONFIGS}

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -52,6 +52,7 @@ class TestCatalogDocument:
             "OBSERVABILITY",
             "SECURITY",
             "SLURM",
+            "STORAGE",
             "VM",
         ]
 

--- a/scripts/tests/test_validate_suite_wiring.py
+++ b/scripts/tests/test_validate_suite_wiring.py
@@ -120,4 +120,12 @@ def test_platform_registration_errors_flags_unregistered_suite(tmp_path: Path) -
     """
     (tmp_path / "newcap.yaml").write_text("tests:\n  validations: {}\n")
     errors = validate_suite_wiring.platform_registration_errors(tmp_path)
-    assert errors == ["suites/newcap.yaml: not registered in isvtest.catalog.PLATFORM_CONFIGS (catalog platform axis)"]
+    assert errors == [
+        "suites/newcap.yaml: not registered in isvtest.catalog_platforms.PLATFORM_CONFIGS (catalog platform axis)"
+    ]
+
+
+def test_registered_platforms_round_trip_through_isvreporter() -> None:
+    """Guardrail: every catalog platform is recognized by isvreporter."""
+    errors = validate_suite_wiring.registry_consistency_errors()
+    assert not errors, "registry consistency failed:\n  " + "\n  ".join(errors)

--- a/scripts/tests/test_validate_suite_wiring.py
+++ b/scripts/tests/test_validate_suite_wiring.py
@@ -109,3 +109,15 @@ def test_repo_suites_declare_test_id_and_labels() -> None:
     """Guardrail: every check in isvctl/configs/suites declares wiring metadata."""
     errors = validate_suite_wiring.wiring_errors()
     assert not errors, "suite wiring validation failed:\n  " + "\n  ".join(errors)
+
+
+def test_platform_registration_errors_flags_unregistered_suite(tmp_path: Path) -> None:
+    """A suite file not present in PLATFORM_CONFIGS is reported.
+
+    Enforced against the real repo only by the validate-suites pre-commit
+    hook, not by a repo-level pytest guard, so untracked scratch suites
+    don't break `make test`.
+    """
+    (tmp_path / "newcap.yaml").write_text("tests:\n  validations: {}\n")
+    errors = validate_suite_wiring.platform_registration_errors(tmp_path)
+    assert errors == ["suites/newcap.yaml: not registered in isvtest.catalog.PLATFORM_CONFIGS (catalog platform axis)"]

--- a/scripts/validate_suite_wiring.py
+++ b/scripts/validate_suite_wiring.py
@@ -48,7 +48,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-
 from isvreporter.platform import normalize_platform
 from isvtest.catalog_platforms import PLATFORM_CONFIGS
 

--- a/scripts/validate_suite_wiring.py
+++ b/scripts/validate_suite_wiring.py
@@ -25,10 +25,12 @@ validation metadata on this branch. Each wired check must declare:
   Each canonical suite check must include its suite label, for example checks in
   ``bare_metal.yaml`` must include ``bare_metal``.
 
-Every suite file must also be registered in ``isvtest.catalog.PLATFORM_CONFIGS``:
-an unregistered suite is silently dropped from the pushed catalog's platform
-axis and its tests carry no platform, so the capability never shows up in the
-catalog UI.
+Every suite file must also be registered in
+``isvtest.catalog_platforms.PLATFORM_CONFIGS``: an unregistered suite is
+silently dropped from the pushed catalog's platform axis and its tests carry no
+platform, so the capability never shows up in the catalog UI. Registered
+platforms must in turn be recognized by ``isvreporter.platform`` — an unknown
+platform is silently reported as the default on test-run upload.
 
 Usage:
     python3 scripts/validate_suite_wiring.py
@@ -46,23 +48,16 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from isvtest.catalog import PLATFORM_CONFIGS
+from isvreporter.platform import normalize_platform
+from isvtest.catalog_platforms import PLATFORM_CONFIGS
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SUITES_DIR = REPO_ROOT / "isvctl" / "configs" / "suites"
 _NEXT_CATEGORY_LINE = re.compile(r"^    \S")
+# The label every check in a canonical suite must carry, derived from the
+# platform registry: suite file stem -> lowercase platform name.
 SUITE_REQUIRED_LABELS: dict[str, str] = {
-    "bare_metal": "bare_metal",
-    "control-plane": "control_plane",
-    "iam": "iam",
-    "image-registry": "image_registry",
-    "k8s": "kubernetes",
-    "network": "network",
-    "observability": "observability",
-    "security": "security",
-    "slurm": "slurm",
-    "storage": "storage",
-    "vm": "vm",
+    Path(config).stem: platform.lower() for platform, configs in PLATFORM_CONFIGS.items() for config in configs
 }
 
 
@@ -187,17 +182,28 @@ def wiring_errors(suites_dir: Path = SUITES_DIR) -> list[str]:
 
 
 def platform_registration_errors(suites_dir: Path = SUITES_DIR) -> list[str]:
-    """Return errors for suite files not registered in the catalog platform axis.
-
-    A suite missing from ``isvtest.catalog.PLATFORM_CONFIGS`` is silently
-    dropped from the pushed catalog's platform axis and its tests carry no
-    platform, so the capability never shows up in the catalog UI.
-    """
+    """Return errors for suite files not registered in the catalog platform axis."""
     registered = {config for configs in PLATFORM_CONFIGS.values() for config in configs}
     return [
-        f"suites/{path.name}: not registered in isvtest.catalog.PLATFORM_CONFIGS (catalog platform axis)"
-        for path in sorted(suites_dir.glob("*.yaml"))
-        if f"suites/{path.name}" not in registered
+        f"{suite}: not registered in isvtest.catalog_platforms.PLATFORM_CONFIGS (catalog platform axis)"
+        for suite in (f"suites/{path.name}" for path in sorted(suites_dir.glob("*.yaml")))
+        if suite not in registered
+    ]
+
+
+def registry_consistency_errors() -> list[str]:
+    """Return errors for catalog platforms that isvreporter cannot round-trip.
+
+    Suite configs declare ``tests.platform`` as the lowercase platform name;
+    ``normalize_platform`` silently coerces unknown values to the default
+    platform when reporting test runs, so a platform registered in the catalog
+    but missing from isvreporter's constants misattributes every test run.
+    """
+    return [
+        f"platform {platform}: not recognized by isvreporter.platform.normalize_platform "
+        "(add it to ALL_PLATFORMS and PLATFORM_ALIASES)"
+        for platform in sorted(PLATFORM_CONFIGS)
+        if normalize_platform(platform.lower()) != platform
     ]
 
 
@@ -211,7 +217,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    errors = wiring_errors() + platform_registration_errors()
+    errors = wiring_errors() + platform_registration_errors() + registry_consistency_errors()
     if errors:
         header = f"suite wiring validation failed ({len(errors)} issue(s)):"
         message = header + "\n  " + "\n  ".join(errors)

--- a/scripts/validate_suite_wiring.py
+++ b/scripts/validate_suite_wiring.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
 from isvreporter.platform import normalize_platform
 from isvtest.catalog_platforms import PLATFORM_CONFIGS
 
@@ -213,7 +214,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Exit 1 when any suite check is missing test_id or labels.",
+        help=(
+            "Exit 1 on wiring violations (missing test_id/labels, unregistered suites, "
+            "or isvreporter platform mismatches)."
+        ),
     )
     args = parser.parse_args(argv)
 

--- a/scripts/validate_suite_wiring.py
+++ b/scripts/validate_suite_wiring.py
@@ -25,6 +25,11 @@ validation metadata on this branch. Each wired check must declare:
   Each canonical suite check must include its suite label, for example checks in
   ``bare_metal.yaml`` must include ``bare_metal``.
 
+Every suite file must also be registered in ``isvtest.catalog.PLATFORM_CONFIGS``:
+an unregistered suite is silently dropped from the pushed catalog's platform
+axis and its tests carry no platform, so the capability never shows up in the
+catalog UI.
+
 Usage:
     python3 scripts/validate_suite_wiring.py
     python3 scripts/validate_suite_wiring.py --check   # exit 1 on violations
@@ -41,6 +46,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from isvtest.catalog import PLATFORM_CONFIGS
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SUITES_DIR = REPO_ROOT / "isvctl" / "configs" / "suites"
@@ -180,6 +186,21 @@ def wiring_errors(suites_dir: Path = SUITES_DIR) -> list[str]:
     return errors
 
 
+def platform_registration_errors(suites_dir: Path = SUITES_DIR) -> list[str]:
+    """Return errors for suite files not registered in the catalog platform axis.
+
+    A suite missing from ``isvtest.catalog.PLATFORM_CONFIGS`` is silently
+    dropped from the pushed catalog's platform axis and its tests carry no
+    platform, so the capability never shows up in the catalog UI.
+    """
+    registered = {config for configs in PLATFORM_CONFIGS.values() for config in configs}
+    return [
+        f"suites/{path.name}: not registered in isvtest.catalog.PLATFORM_CONFIGS (catalog platform axis)"
+        for path in sorted(suites_dir.glob("*.yaml"))
+        if f"suites/{path.name}" not in registered
+    ]
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns a process exit code."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -190,7 +211,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    errors = wiring_errors()
+    errors = wiring_errors() + platform_registration_errors()
     if errors:
         header = f"suite wiring validation failed ({len(errors)} issue(s)):"
         message = header + "\n  " + "\n  ".join(errors)
@@ -200,7 +221,10 @@ def main(argv: list[str] | None = None) -> int:
         print(message)
         return 0
 
-    ok = f"OK: all wired checks in {SUITES_DIR.relative_to(REPO_ROOT)} declare test_id, labels, and suite labels."
+    ok = (
+        f"OK: all wired checks in {SUITES_DIR.relative_to(REPO_ROOT)} declare test_id, labels, "
+        "and suite labels, and every suite is registered as a catalog platform."
+    )
     print(ok)
     return 0
 


### PR DESCRIPTION
## Problem

The 0.9.0 catalog push surfaced the new storage tests in the catalog UI, but the **storage capability** itself never appeared (https://stg.ai-cloud-labs.nvidia.com/catalog).

Root cause: the storage suite (`suites/storage.yaml`, introduced in #439) was never registered in `PLATFORM_CONFIGS` in `isvtest/catalog.py`, and the `storage` label has no `LABEL_TO_PLATFORM` mapping. Pushed catalogs therefore omit STORAGE from the platform axis and storage tests carry an empty `platforms` list — the UI derives capabilities from exactly those two fields. The backend (V17 catalog axis metadata) and frontend (axis read from the uploaded document, unknown names title-cased) already support new capabilities; this was the missing client-side piece. Unlike security (#370) and observability (#431), which registered their platform in the same PR that created the suite, the storage suite grew across many PRs and the registration step was never hit.

## Changes

- **`isvtest/catalog.py`**: register `"STORAGE": ["suites/storage.yaml"]` in `PLATFORM_CONFIGS` and `"storage": "STORAGE"` in `LABEL_TO_PLATFORM`. 19 tests (Hss*/Directory* + shared checks) now carry the STORAGE platform, and the document axis includes it.
- **`isvreporter/platform.py`**: add the STORAGE constant and `storage` alias. The storage suite declares `tests.platform: storage`, which `normalize_platform()` silently coerced to the KUBERNETES default when reporting test runs.
- **`scripts/validate_suite_wiring.py`** (+ `validate-suites` pre-commit hook): every `suites/*.yaml` must now be registered in `PLATFORM_CONFIGS`, so the next capability suite cannot ship unregistered. The hook also triggers on `isvtest/catalog.py` and the script itself. Enforced hook-only by design: `make test` stays green when untracked scratch suites are present in the working tree.
- Tests updated accordingly (platform axis assertion, isvreporter storage normalization, unit test for the new hook check).

## Verification

- `make test` (all three packages + scripts), `make lint`, `uvx pre-commit run -a` all pass.
- `isvctl catalog list --json`: axis now `[..., SLURM, STORAGE, VM]`, 19 entries with `STORAGE` platform.
- Negative check: an unregistered scratch suite in `suites/` makes the `validate-suites` hook fail with a pointed message while `make test` still passes.

## Rollout note

`isvctl catalog push` skips upload when the `isvTestVersion` already exists, so re-pushing 0.9.0 will not pick this up — this needs to land in a 0.9.1 release followed by a catalog push (or the stored 0.9.0 catalog row must be deleted server-side before a re-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `STORAGE` as a supported platform, included across platform normalization, configuration/schema docs, and the test catalog platform axis.
  * Canonicalizes `storage` (case-insensitive) to `STORAGE`.
* **Bug Fixes**
  * Strengthened suite validation to flag unregistered suite YAMLs and prevent unknown platforms from being silently coerced.
* **Tests**
  * Added coverage for `STORAGE` behavior and for suite registration/registry round-trip consistency checks.
* **Chores**
  * Broadened suite/validation matching in a pre-commit hook and expanded wiring validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->