### PR TITLE
fix(k8s): run CRD webhook helper as non-root

### DIFF
--- a/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
@@ -70,6 +70,13 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            # The agnhost image declares no USER, so it defaults to root. With
+            # runAsNonRoot but no runAsUser the kubelet refuses to start the
+            # container ("container has runAsNonRoot and image will run as
+            # root"), so the Deployment never becomes Available. Pin a non-root
+            # UID (as the sibling network_policy_test_pods.yaml already does)
+            # so the webhook server runs and passes its readiness probe.
+            runAsUser: 1000
             readOnlyRootFilesystem: true
             capabilities:
               drop:


### PR DESCRIPTION
# fix(k8s): run CRD webhook helper as non-root

## Summary

The CRD webhook validation fixture now sets an explicit non-root UID for the
webhook Deployment. This makes the `runAsNonRoot` contract deterministic for
images that do not declare a non-root user in their image metadata.

## Why

The current `agnhost:2.47` image defaults to UID 0, while the fixture requires
`runAsNonRoot: true`. Kubernetes therefore rejects the webhook container before
the CRD admission, mutation, and rejection behavior is exercised. The
Deployment remains unavailable and the check reports a timeout instead of
testing the intended functionality.

## What changes

- Add `runAsUser: 1000` to the webhook pod security context.
- Preserve the existing non-root security requirement and validation behavior.

## Verification

- The Kubernetes CRD webhook validation path passed in the final GCP live run.
- The change is isolated to the shared test manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook Deployment startup reliability by explicitly running the container as a non-root user.
  * Prevented deployment failures caused by security settings when the container image does not define a default user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->