### PR TITLE
fix(k8s): retain CSI diagnostics before cleanup

### DIFF
--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -44,7 +44,7 @@ import subprocess
 import time
 import uuid
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 
 from kubernetes.utils import parse_quantity
 
@@ -60,6 +60,7 @@ from isvtest.core.k8s import (
     parse_kubectl_json,
     render_k8s_manifest,
 )
+from isvtest.core.runners import CommandResult
 from isvtest.core.validation import BaseValidation
 
 _MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
@@ -71,6 +72,8 @@ _MOUNT_POD_MANIFEST = _MANIFEST_DIR / "storage_mount_pod.yaml"
 # BusyBox provides flock/stat/ls/mkdir/awk/seq; override via the ``image``
 # config key for air-gapped clusters that mirror to a private registry.
 _DEFAULT_IMAGE = "busybox:1.36"
+_DIAGNOSTIC_COMMAND_TIMEOUT = 30
+_DIAGNOSTIC_TOTAL_TIMEOUT = 30
 
 _STORAGE_TYPES: tuple[tuple[str, str], ...] = (
     ("block", "ReadWriteOnce"),
@@ -179,7 +182,7 @@ def _bounded_diagnostic_section(label: str, text: str) -> str:
 
 
 def _collect_storage_diagnostics(
-    run_command,
+    run_command: Callable[[str, int | None], CommandResult],
     kubectl_base: str,
     namespace: str,
     *,
@@ -193,6 +196,7 @@ def _collect_storage_diagnostics(
         ("PVC", "pvc", "PersistentVolumeClaim", pvc_name),
     )
     sections: list[str] = []
+    deadline = time.monotonic() + _DIAGNOSTIC_TOTAL_TIMEOUT
     for label, resource, event_kind, name in resources:
         name_quoted = shlex.quote(name)
         commands = (
@@ -206,8 +210,12 @@ def _collect_storage_diagnostics(
             ),
         )
         for section_label, command in commands:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                sections.append("== diagnostics ==\n[collection deadline exceeded]")
+                break
             try:
-                result = run_command(command, timeout=30)
+                result = run_command(command, timeout=min(_DIAGNOSTIC_COMMAND_TIMEOUT, max(1, int(remaining))))
                 output = (
                     result.stdout
                     if result.exit_code == 0
@@ -232,7 +240,7 @@ def _log_storage_diagnostics(
 ) -> None:
     """Emit failure evidence before namespace cleanup; collection is best-effort."""
     diagnostics = _collect_storage_diagnostics(
-        validation.run_command,
+        lambda command, timeout: validation.runner.run(command, timeout=timeout or _DIAGNOSTIC_COMMAND_TIMEOUT),
         validation._kubectl_base,
         validation._namespace,
         pod_name=pod_name,

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -43,8 +43,9 @@ import shlex
 import subprocess
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, ClassVar
+from typing import Any, ClassVar
 
 from kubernetes.utils import parse_quantity
 

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -38,6 +38,7 @@ Implements:
 from __future__ import annotations
 
 import json
+import re
 import shlex
 import subprocess
 import time
@@ -78,6 +79,9 @@ _STORAGE_TYPES: tuple[tuple[str, str], ...] = (
 )
 
 _QUOTA_REJECTION_TOKENS: tuple[str, ...] = ("exceeded quota", "forbidden")
+_DIAGNOSTIC_SECTION_LIMIT = 1024
+_DIAGNOSTIC_TOTAL_LIMIT = 6144
+_SENSITIVE_DIAGNOSTIC_LINE = re.compile(r"(?i)(authorization|credential|password|private[-_ ]?key|secret|token)\s*[:=]")
 
 
 def _apply_manifest(kubectl_parts: list[str], manifest: str, timeout: float) -> tuple[int, str]:
@@ -161,6 +165,85 @@ def _wait_pod_ready(run_command, kubectl_base: str, namespace: str, pod_name: st
     if result.exit_code == 0:
         return True, ""
     return False, (result.stderr.strip() or result.stdout.strip())
+
+
+def _bounded_diagnostic_section(label: str, text: str) -> str:
+    """Redact sensitive lines and cap one diagnostic section."""
+    redacted = "\n".join(
+        "[REDACTED]" if _SENSITIVE_DIAGNOSTIC_LINE.search(line) else line for line in text.splitlines()
+    ).strip()
+    if len(redacted) > _DIAGNOSTIC_SECTION_LIMIT:
+        marker = "\n...[section truncated]"
+        redacted = f"{redacted[: _DIAGNOSTIC_SECTION_LIMIT - len(marker)]}{marker}"
+    return f"== {label} ==\n{redacted or '[no output]'}"
+
+
+def _collect_storage_diagnostics(
+    run_command,
+    kubectl_base: str,
+    namespace: str,
+    *,
+    pod_name: str,
+    pvc_name: str,
+) -> str:
+    """Collect bounded pod/PVC state and events without changing test outcome."""
+    namespace_quoted = shlex.quote(namespace)
+    resources = (
+        ("Pod", "pod", "Pod", pod_name),
+        ("PVC", "pvc", "PersistentVolumeClaim", pvc_name),
+    )
+    sections: list[str] = []
+    for label, resource, event_kind, name in resources:
+        name_quoted = shlex.quote(name)
+        commands = (
+            (f"{label} state", f"{kubectl_base} get {resource} {name_quoted} -n {namespace_quoted} -o wide"),
+            (f"{label} description", f"{kubectl_base} describe {resource} {name_quoted} -n {namespace_quoted}"),
+            (
+                f"{label} events",
+                f"{kubectl_base} get events -n {namespace_quoted} "
+                f"--field-selector involvedObject.kind={event_kind},involvedObject.name={name_quoted} "
+                "--sort-by=.lastTimestamp",
+            ),
+        )
+        for section_label, command in commands:
+            try:
+                result = run_command(command, timeout=30)
+                output = (
+                    result.stdout
+                    if result.exit_code == 0
+                    else (result.stderr or result.stdout or f"command exited {result.exit_code}")
+                )
+            except Exception as exc:
+                output = f"diagnostic command failed: {type(exc).__name__}: {exc}"
+            sections.append(_bounded_diagnostic_section(section_label, output))
+
+    diagnostics = "\n".join(sections)
+    if len(diagnostics) > _DIAGNOSTIC_TOTAL_LIMIT:
+        marker = "\n...[diagnostics truncated]"
+        diagnostics = f"{diagnostics[: _DIAGNOSTIC_TOTAL_LIMIT - len(marker)]}{marker}"
+    return diagnostics
+
+
+def _log_storage_diagnostics(
+    validation: BaseValidation,
+    *,
+    pod_name: str,
+    pvc_name: str,
+) -> None:
+    """Emit failure evidence before namespace cleanup; collection is best-effort."""
+    diagnostics = _collect_storage_diagnostics(
+        validation.run_command,
+        validation._kubectl_base,
+        validation._namespace,
+        pod_name=pod_name,
+        pvc_name=pvc_name,
+    )
+    validation.log.error(
+        "CSI pod/PVC diagnostics before cleanup (pod=%s pvc=%s):\n%s",
+        pod_name,
+        pvc_name,
+        diagnostics,
+    )
 
 
 def _storage_quantities_equal(left: Any, right: Any) -> bool:
@@ -326,6 +409,12 @@ class K8sCsiStorageTypesCheck(BaseValidation):
                     self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
                 )
                 bound = pod_ready and self._wait_pvc_bound(pvc_name, 5)
+                if not bound:
+                    _log_storage_diagnostics(
+                        self,
+                        pod_name=pod_name,
+                        pvc_name=pvc_name,
+                    )
                 self.report_subtest(
                     f"pvc-binds[{type_name}]",
                     passed=bound,
@@ -625,6 +714,11 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
             self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
         )
         if not pod_ready or not self._wait_pvc_bound(pvc_name, 5):
+            _log_storage_diagnostics(
+                self,
+                pod_name=pod_name,
+                pvc_name=pvc_name,
+            )
             self.report_subtest(
                 "per-pvc-usage",
                 passed=False,
@@ -1641,6 +1735,11 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
             self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
         )
         if not pod_ready:
+            _log_storage_diagnostics(
+                self,
+                pod_name=pod_name,
+                pvc_name=pvc_name,
+            )
             self.report_subtest(
                 "dynamic",
                 passed=False,
@@ -1652,6 +1751,11 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
             return None
 
         if not self._wait_pvc_bound(pvc_name, 5):
+            _log_storage_diagnostics(
+                self,
+                pod_name=pod_name,
+                pvc_name=pvc_name,
+            )
             self.report_subtest(
                 "dynamic",
                 passed=False,
@@ -1865,6 +1969,11 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
 
         ready, err = _wait_pod_ready(self.run_command, self._kubectl_base, self._namespace, pod_name, timeout_s)
         if not ready:
+            _log_storage_diagnostics(
+                self,
+                pod_name=pod_name,
+                pvc_name=pvc_name,
+            )
             self.log.error("Mount pod %s did not become Ready: %s", pod_name, err)
             return False
 
@@ -2092,6 +2201,11 @@ class K8sCsiConcurrentPvcCheck(BaseValidation):
                     ),
                 )
                 if not bound:
+                    _log_storage_diagnostics(
+                        self,
+                        pod_name=pod_name,
+                        pvc_name=pvc_name,
+                    )
                     any_failed = True
 
             # Collect PV names from all bound PVCs and assert they are distinct.
@@ -2248,6 +2362,11 @@ class K8sCsiPvcExpandCheck(BaseValidation):
                 self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
             )
             if not pod_ready or not _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, 5):
+                _log_storage_diagnostics(
+                    self,
+                    pod_name=pod_name,
+                    pvc_name=pvc_name,
+                )
                 self.set_failed(
                     f"PVC {pvc_name!r} did not reach Bound before resize within {bind_timeout}s: {wait_err[:200]}"
                 )

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -83,7 +83,8 @@ class TestStorageFailureDiagnostics:
 
         def run(cmd: str, timeout: int | None = None) -> CommandResult:
             commands.append(cmd)
-            assert timeout == 30
+            assert timeout is not None
+            assert 1 <= timeout <= 30
             return _ok(stdout=f"token: do-not-log\n{'x' * 2000}")
 
         diagnostics = _collect_storage_diagnostics(

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -35,6 +35,7 @@ from isvtest.validations.k8s_storage import (
     K8sCsiStorageQuotaApiCheck,
     K8sCsiStorageTypesCheck,
     K8sCsiTenantScopedCredentialsCheck,
+    _collect_storage_diagnostics,
     _find_cluster_secret_grants,
     _find_shared_cluster_marker,
     _rule_grants_unrestricted_secrets,
@@ -74,6 +75,50 @@ def _pvc_json(
     if volume_name is not None:
         spec["volumeName"] = volume_name
     return json.dumps({"kind": "PersistentVolumeClaim", "status": status, "spec": spec})
+
+
+class TestStorageFailureDiagnostics:
+    def test_collects_bounded_redacted_pod_pvc_state_and_events(self) -> None:
+        commands: list[str] = []
+
+        def run(cmd: str, timeout: int | None = None) -> CommandResult:
+            commands.append(cmd)
+            assert timeout == 30
+            return _ok(stdout=f"token: do-not-log\n{'x' * 2000}")
+
+        diagnostics = _collect_storage_diagnostics(
+            run,
+            "kubectl --kubeconfig test",
+            "ns-1",
+            pod_name="pod-1",
+            pvc_name="pvc-1",
+        )
+
+        assert len(commands) == 6
+        assert any("get pod pod-1" in command for command in commands)
+        assert any("describe pod pod-1" in command for command in commands)
+        assert any("involvedObject.kind=Pod" in command for command in commands)
+        assert any("get pvc pvc-1" in command for command in commands)
+        assert any("describe pvc pvc-1" in command for command in commands)
+        assert any("involvedObject.kind=PersistentVolumeClaim" in command for command in commands)
+        assert "do-not-log" not in diagnostics
+        assert "[REDACTED]" in diagnostics
+        assert "[section truncated]" in diagnostics
+        assert len(diagnostics) <= 6144
+
+    def test_command_failure_is_recorded_without_raising(self) -> None:
+        def run(cmd: str, timeout: int | None = None) -> CommandResult:
+            raise RuntimeError(f"kubectl unavailable for {cmd}")
+
+        diagnostics = _collect_storage_diagnostics(
+            run,
+            "kubectl",
+            "ns-1",
+            pod_name="pod-1",
+            pvc_name="pvc-1",
+        )
+
+        assert diagnostics.count("diagnostic command failed: RuntimeError") == 6
 
 
 class _FakeProc:


### PR DESCRIPTION
# fix(k8s): retain CSI diagnostics before cleanup

## Summary

CSI validation failures now capture bounded pod and PVC descriptions plus
scoped Kubernetes events before best-effort cleanup removes those resources.
This preserves the failure cause without changing the validation verdict or
cleanup policy.

## Why

When a CSI consumer pod or PVC timed out, the validator deleted the test
namespace immediately and retained only a generic wait error. That discarded
the pod conditions, PVC state, and scheduling/provisioning/attach/mount events
needed to distinguish a validation defect from a CSI or cluster problem. The
diagnostics make the existing failure actionable while preserving the original
pass/fail behavior.

## What changes

- Capture relevant pod/PVC state and scoped events on CSI failure paths.
- Keep diagnostic output bounded and safe for test logs.
- Add unit coverage for the diagnostic capture behavior.

## Verification

- CSI validation paths passed in the final GCP live run.
- Unit coverage was added for the failure-diagnostic path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSI storage validations now emit best-effort Kubernetes diagnostics when pod readiness or PVC `Bound` checks fail, including pod/PVC state and related events.
  * Diagnostics are redacted for sensitive data and truncated per section with a total output size limit, with strict time bounds.
  * Failures in diagnostics collection no longer block or replace the underlying storage validation results across binding, provisioning/mounting, quota, concurrency, canary, and expansion flows.
* **Tests**
  * Added test coverage to verify bounded, redacted, truncated diagnostic output and resilient handling of diagnostic command errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->