### PR TITLE
feat(k8s): support provider-managed autoscalers

### DIFF
--- a/isvtest/src/isvtest/validations/k8s_autoscaler.py
+++ b/isvtest/src/isvtest/validations/k8s_autoscaler.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import json
 import shlex
 from typing import Any, ClassVar
 
@@ -38,13 +39,20 @@ DEFAULT_LABEL_SELECTORS: tuple[str, ...] = (
     "app=cluster-autoscaler",
     "k8s-app=cluster-autoscaler",
 )
+VALID_MODES: tuple[str, ...] = ("deployment", "provider_managed")
 
 
 class K8sClusterAutoscalerCheck(BaseValidation):
-    """Verify an upstream Cluster Autoscaler deployment is installed and running.
+    """Verify an in-cluster or provider-managed Cluster Autoscaler integration.
 
     Config keys:
 
+    * ``mode`` - ``"deployment"`` (default) discovers an in-cluster upstream
+      Deployment. ``"provider_managed"`` executes
+      ``provider_managed_command`` and validates its provider-neutral JSON.
+    * ``provider_managed_command`` - command that emits an object containing
+      ``enabled``, ``node_pool``, ``min_nodes``, and ``max_nodes``. Required in
+      ``provider_managed`` mode.
     * ``namespaces`` - namespaces to probe by deployment name. Defaults to
       ``["kube-system"]``. ``namespace`` is accepted as a single-value alias.
     * ``deployment_names`` - deployment names to probe. Defaults to
@@ -56,10 +64,18 @@ class K8sClusterAutoscalerCheck(BaseValidation):
       Cluster Autoscaler integration on the cluster.
     """
 
-    description: ClassVar[str] = "Verify upstream Cluster Autoscaler integration is installed and running."
+    description: ClassVar[str] = "Verify an in-cluster or provider-managed Cluster Autoscaler integration."
 
     def run(self) -> None:
-        """Find Cluster Autoscaler deployments and verify their replicas and pods are healthy."""
+        """Dispatch to provider-managed evidence or in-cluster Deployment validation."""
+        mode = self.config.get("mode", "deployment")
+        if not isinstance(mode, str) or mode not in VALID_MODES:
+            self.set_failed(f"Invalid mode: {mode!r} (expected one of {list(VALID_MODES)})")
+            return
+        if mode == "provider_managed":
+            self._run_provider_managed()
+            return
+
         try:
             namespaces = _coerce_str_list(
                 self.config.get("namespaces", self.config.get("namespace", ["kube-system"])),
@@ -135,6 +151,33 @@ class K8sClusterAutoscalerCheck(BaseValidation):
         self.set_passed(
             f"Found {len(deployments)} healthy Cluster Autoscaler deployment(s): {refs}; "
             f"{running_total} matching pod(s) Running"
+        )
+
+    def _run_provider_managed(self) -> None:
+        """Validate provider-managed autoscaling from a configured readback command."""
+        command = self.config.get("provider_managed_command")
+        if not isinstance(command, str) or not command.strip():
+            self.set_failed(
+                "Invalid config: provider_managed_command must be a non-empty string when mode='provider_managed'"
+            )
+            return
+
+        result = self.run_command(command)
+        if result.exit_code != 0:
+            detail = (result.stderr or result.stdout or f"exit {result.exit_code}").strip()
+            self.set_failed(f"Provider-managed autoscaler command failed: {detail}")
+            return
+
+        try:
+            evidence = _parse_provider_managed_evidence(result.stdout)
+        except ValueError as exc:
+            self.set_failed(f"Invalid provider-managed autoscaler evidence: {exc}")
+            return
+
+        self.set_passed(
+            "Provider-managed Cluster Autoscaler verified: "
+            f"node_pool={evidence['node_pool']}, min_nodes={evidence['min_nodes']}, "
+            f"max_nodes={evidence['max_nodes']}"
         )
 
     def _discover_deployments(
@@ -220,6 +263,44 @@ def _coerce_str_list(value: Any, field: str) -> list[str]:
         if stripped:
             values.append(stripped)
     return values
+
+
+def _parse_provider_managed_evidence(stdout: str) -> dict[str, Any]:
+    """Parse and validate the provider-neutral managed-autoscaler JSON contract."""
+    try:
+        evidence = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"command stdout is not valid JSON: {exc.msg}") from exc
+
+    if not isinstance(evidence, dict):
+        raise ValueError(f"command stdout must be a JSON object, got {type(evidence).__name__}")
+    if evidence.get("enabled") is not True:
+        raise ValueError("enabled must be the JSON boolean true")
+
+    node_pool = evidence.get("node_pool")
+    if not isinstance(node_pool, str) or not node_pool.strip():
+        raise ValueError("node_pool must be a non-empty string")
+
+    min_nodes = _managed_node_bound(evidence.get("min_nodes"), "min_nodes")
+    max_nodes = _managed_node_bound(evidence.get("max_nodes"), "max_nodes")
+    if max_nodes < 1:
+        raise ValueError("max_nodes must be at least 1")
+    if min_nodes > max_nodes:
+        raise ValueError(f"min_nodes ({min_nodes}) cannot exceed max_nodes ({max_nodes})")
+
+    return {
+        "enabled": True,
+        "node_pool": node_pool.strip(),
+        "min_nodes": min_nodes,
+        "max_nodes": max_nodes,
+    }
+
+
+def _managed_node_bound(value: Any, field: str) -> int:
+    """Return a non-negative JSON integer node bound."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative JSON integer")
+    return value
 
 
 def _object_ref(obj: dict[str, Any]) -> tuple[str, str]:

--- a/isvtest/tests/test_k8s_autoscaler.py
+++ b/isvtest/tests/test_k8s_autoscaler.py
@@ -231,3 +231,109 @@ def test_cluster_autoscaler_rejects_bad_config() -> None:
     assert not check.passed
     assert "Invalid config" in check.message
     mock_run.assert_not_called()
+
+
+def _managed_evidence(
+    *,
+    enabled: object = True,
+    node_pool: object = "system-pool",
+    min_nodes: object = 1,
+    max_nodes: object = 4,
+) -> str:
+    """Return provider-neutral managed-autoscaler command output."""
+    return json.dumps(
+        {
+            "enabled": enabled,
+            "node_pool": node_pool,
+            "min_nodes": min_nodes,
+            "max_nodes": max_nodes,
+        }
+    )
+
+
+def test_cluster_autoscaler_provider_managed_mode_passes_without_kubectl() -> None:
+    """Verify command readback can prove a managed control-plane autoscaler."""
+    check = K8sClusterAutoscalerCheck(
+        config={"mode": "provider_managed", "provider_managed_command": "probe-managed-autoscaler"}
+    )
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell") as mock_kubectl,
+        patch.object(check, "run_command", return_value=_ok(_managed_evidence())) as mock_run,
+    ):
+        check.run()
+
+    assert check.passed, check.message
+    assert "node_pool=system-pool" in check.message
+    assert "min_nodes=1" in check.message
+    assert "max_nodes=4" in check.message
+    mock_run.assert_called_once_with("probe-managed-autoscaler")
+    mock_kubectl.assert_not_called()
+
+
+def test_cluster_autoscaler_provider_managed_mode_requires_command() -> None:
+    """Verify explicit managed mode cannot silently fall back to Deployment discovery."""
+    check = K8sClusterAutoscalerCheck(config={"mode": "provider_managed"})
+    with patch.object(check, "run_command") as mock_run:
+        check.run()
+
+    assert not check.passed
+    assert "provider_managed_command must be a non-empty string" in check.message
+    mock_run.assert_not_called()
+
+
+def test_cluster_autoscaler_provider_managed_mode_fails_on_command_error() -> None:
+    """Verify provider API or permission failures remain validation failures."""
+    check = K8sClusterAutoscalerCheck(
+        config={"mode": "provider_managed", "provider_managed_command": "probe-managed-autoscaler"}
+    )
+    with patch.object(check, "run_command", return_value=_fail(stderr="permission denied")):
+        check.run()
+
+    assert not check.passed
+    assert "command failed: permission denied" in check.message
+
+
+@pytest.mark.parametrize("stdout", ["not-json", "[]"])
+def test_cluster_autoscaler_provider_managed_mode_rejects_invalid_json(stdout: str) -> None:
+    """Verify only a provider-neutral JSON object can establish managed evidence."""
+    check = K8sClusterAutoscalerCheck(
+        config={"mode": "provider_managed", "provider_managed_command": "probe-managed-autoscaler"}
+    )
+    with patch.object(check, "run_command", return_value=_ok(stdout)):
+        check.run()
+
+    assert not check.passed
+    assert "Invalid provider-managed autoscaler evidence" in check.message
+
+
+@pytest.mark.parametrize(
+    ("stdout", "error"),
+    [
+        (_managed_evidence(enabled=False), "enabled must be the JSON boolean true"),
+        (_managed_evidence(node_pool=""), "node_pool must be a non-empty string"),
+        (_managed_evidence(min_nodes=-1), "min_nodes must be a non-negative JSON integer"),
+        (_managed_evidence(max_nodes=0), "max_nodes must be at least 1"),
+        (_managed_evidence(min_nodes=5, max_nodes=4), "min_nodes (5) cannot exceed max_nodes (4)"),
+    ],
+)
+def test_cluster_autoscaler_provider_managed_mode_rejects_invalid_evidence(stdout: str, error: str) -> None:
+    """Verify managed proof fails closed on disabled or incoherent evidence."""
+    check = K8sClusterAutoscalerCheck(
+        config={"mode": "provider_managed", "provider_managed_command": "probe-managed-autoscaler"}
+    )
+    with patch.object(check, "run_command", return_value=_ok(stdout)):
+        check.run()
+
+    assert not check.passed
+    assert error in check.message
+
+
+def test_cluster_autoscaler_rejects_unknown_mode() -> None:
+    """Verify a typo cannot silently select the Deployment path."""
+    check = K8sClusterAutoscalerCheck(config={"mode": "provider-managed"})
+    with patch.object(check, "run_command") as mock_run:
+        check.run()
+
+    assert not check.passed
+    assert "Invalid mode" in check.message
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Managed Kubernetes services can run Cluster Autoscaler in the provider control plane without exposing an in-cluster Deployment. This change adds an explicit provider-managed validation mode while preserving Deployment discovery as the default.

## Behavior

- execute a configured provider readback command in provider-managed mode
- require provider-neutral JSON evidence with enabled, node_pool, min_nodes, and max_nodes
- fail on command errors, malformed evidence, disabled autoscaling, invalid bounds, or an empty node-pool identity
- keep existing Deployment-mode behavior unchanged

## Verification

- 19 targeted autoscaler tests passed
- 1,277 isvtest tests passed
- repository-wide make pre-commit passed on the final committed tree
- focused live GKE validation passed with managed node-pool autoscaling enabled and bounded

## Follow-up

Provider-specific configuration and readback wiring will be submitted separately after this shared validator contract is reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a provider-managed validation mode for Kubernetes cluster autoscaling.
  * Validates provider-reported JSON evidence, including autoscaler status and node limits.
  * Retains in-cluster deployment validation as the default mode.

* **Bug Fixes**
  * Invalid configuration, command failures, malformed evidence, and contradictory node limits now produce clear validation failures.

* **Tests**
  * Added coverage for successful provider-managed checks and invalid configuration, command output, and evidence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->