### PR TITLE
fix(aws): stamp CreatedBy=isvtest on volumes, CSI, and VPC fixtures

### DIFF
--- a/isvctl/configs/providers/aws/scripts/bare_metal/launch_instance.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/launch_instance.py
@@ -65,6 +65,7 @@ from common.ec2 import (
     create_security_group,
     get_architecture_for_instance_type,
     get_default_vpc_and_subnets,
+    owned_tag_specifications,
 )
 
 
@@ -272,16 +273,10 @@ def main() -> int:
                     SubnetId=subnet_id,
                     SecurityGroupIds=[sg_id],
                     Monitoring={"Enabled": args.detailed_monitoring},
-                    TagSpecifications=[
-                        {
-                            "ResourceType": "instance",
-                            "Tags": [
-                                {"Key": "Name", "Value": args.name},
-                                {"Key": "Platform", "Value": "bare-metal"},
-                                {"Key": "CreatedBy", "Value": "isvtest"},
-                            ],
-                        }
-                    ],
+                    TagSpecifications=owned_tag_specifications(
+                        args.name,
+                        extra_tags=[{"Key": "Platform", "Value": "bare-metal"}],
+                    ),
                     BlockDeviceMappings=[
                         {
                             "DeviceName": "/dev/sda1",

--- a/isvctl/configs/providers/aws/scripts/bare_metal/reinstall_instance.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/reinstall_instance.py
@@ -478,14 +478,20 @@ def main() -> int:
         result["success"] = True
         print("Reinstall completed successfully!", file=sys.stderr)
 
-        # Step 10: Clean up old root volume (post-success only)
+        # Step 10: Clean up old root volume (post-success only). Nothing else
+        # reclaims it: it is detached, so the instance's DeleteOnTermination no
+        # longer covers it and teardown only terminates instances. Report a
+        # failed delete in the JSON so a leak is visible instead of stderr-only.
         if old_volume_id:
             print(f"Cleaning up old volume {old_volume_id}...", file=sys.stderr)
-            try:
-                ec2.delete_volume(VolumeId=old_volume_id)
+            if delete_with_retry(
+                ec2.delete_volume,
+                VolumeId=old_volume_id,
+                resource_desc=f"old root volume {old_volume_id}",
+            ):
                 print("  Old volume deleted", file=sys.stderr)
-            except ClientError as e:
-                print(f"  Warning: could not delete old volume: {e}", file=sys.stderr)
+            else:
+                result.setdefault("cleanup_errors", []).append(f"old root volume {old_volume_id} not deleted")
 
     except Exception as e:
         result["error"] = str(e)

--- a/isvctl/configs/providers/aws/scripts/common/ec2.py
+++ b/isvctl/configs/providers/aws/scripts/common/ec2.py
@@ -254,6 +254,34 @@ def get_default_vpc_and_subnets(
 _ISV_CREATED_BY_TAG = {"Key": "CreatedBy", "Value": "isvtest"}
 
 
+def owned_tag_specifications(
+    name: str,
+    *,
+    extra_tags: list[dict[str, str]] | None = None,
+    resource_types: tuple[str, ...] = ("instance", "volume"),
+) -> list[dict[str, Any]]:
+    """Return ``RunInstances`` tag specifications marking suite ownership.
+
+    ``volume`` is tagged alongside ``instance`` because RunInstances does not
+    copy instance tags onto the root volume. A root volume that outlives its
+    instance - detached by the bare-metal root-volume swap, or left behind
+    when DeleteOnTermination does not apply - is then invisible to every
+    ``CreatedBy=isvtest`` cleanup sweep and bills indefinitely.
+
+    Args:
+        name: Value for the ``Name`` tag.
+        extra_tags: Additional tags to apply to every resource type.
+        resource_types: RunInstances resource types to tag.
+
+    Returns:
+        A TagSpecifications list ready to pass to ``run_instances``.
+    """
+    tags = [{"Key": "Name", "Value": name}, _ISV_CREATED_BY_TAG]
+    if extra_tags:
+        tags.extend(extra_tags)
+    return [{"ResourceType": resource_type, "Tags": list(tags)} for resource_type in resource_types]
+
+
 def _has_isv_tag(tags: list[dict[str, str]] | None) -> bool:
     """Return True if ``tags`` includes the ``CreatedBy=isvtest`` marker.
 

--- a/isvctl/configs/providers/aws/scripts/common/fsx.py
+++ b/isvctl/configs/providers/aws/scripts/common/fsx.py
@@ -92,6 +92,15 @@ def create_fsx_network(ec2: Any, cidr: str, suffix: str, created: dict[str, Any]
         GroupName=f"isv-fsx-{suffix}",
         Description="FSx for Lustre validation (intra-VPC Lustre ports)",
         VpcId=vpc_id,
+        TagSpecifications=[
+            {
+                "ResourceType": "security-group",
+                "Tags": [
+                    {"Key": "Name", "Value": f"isv-fsx-{suffix}"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            }
+        ],
     )
     sg_id = sg["GroupId"]
     created.setdefault("sg_ids", []).append(sg_id)

--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -436,7 +436,7 @@ if [ -n "$BLOCK_SC" ]; then
                 --availability-zone "$NODE_AZ" \
                 --volume-type gp3 \
                 --size 1 \
-                --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${STATIC_VOL_TAG}},{Key=ai-cloud-validation,Value=static-csi},{Key=cluster,Value=${EKS_CLUSTER_NAME}}]" \
+                --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${STATIC_VOL_TAG}},{Key=CreatedBy,Value=isvtest},{Key=ai-cloud-validation,Value=static-csi},{Key=cluster,Value=${EKS_CLUSTER_NAME}}]" \
                 --region "$AWS_REGION" \
                 --query 'VolumeId' --output text 2>/dev/null || echo "")
             if [ -n "$STATIC_VOLUME_HANDLE" ] && [ "$STATIC_VOLUME_HANDLE" != "None" ]; then

--- a/isvctl/configs/providers/aws/scripts/eks/terraform/main.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform/main.tf
@@ -66,6 +66,7 @@ provider "aws" {
       Environment = var.environment
       Project     = "isv-lab-tools"
       ManagedBy   = "terraform"
+      CreatedBy   = "isvtest"
     }
   }
 }
@@ -152,6 +153,7 @@ locals {
   tags = {
     ClusterName = local.cluster_name
     Environment = var.environment
+    CreatedBy   = "isvtest"
   }
 }
 
@@ -705,9 +707,14 @@ resource "kubernetes_storage_class_v1" "gp3" {
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
 
+  # tagSpecification_1 stamps CreatedBy onto every dynamically provisioned
+  # volume. Without it, a PVC whose PV is deleted while the volume is still
+  # detaching survives carrying only kubernetes.io/* tags, invisible to the
+  # CreatedBy=isvtest cleanup sweeps.
   parameters = {
-    type      = "gp3"
-    encrypted = "true"
+    type               = "gp3"
+    encrypted          = "true"
+    tagSpecification_1 = "CreatedBy=isvtest"
   }
 
   depends_on = [module.eks]

--- a/isvctl/configs/providers/aws/scripts/network/create_vpc.py
+++ b/isvctl/configs/providers/aws/scripts/network/create_vpc.py
@@ -57,6 +57,19 @@ from botocore.exceptions import ClientError
 from common.errors import classify_aws_error, handle_aws_errors
 
 
+def owned_tag_specification(resource_type: str, name: str) -> list[dict[str, Any]]:
+    """Return creation-time tags for an isvtest-owned EC2 resource."""
+    return [
+        {
+            "ResourceType": resource_type,
+            "Tags": [
+                {"Key": "Name", "Value": name},
+                {"Key": "CreatedBy", "Value": "isvtest"},
+            ],
+        }
+    ]
+
+
 def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
     """Create VPC with all required components."""
     result = {
@@ -75,7 +88,10 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
 
     try:
         # Create VPC
-        vpc = ec2.create_vpc(CidrBlock=cidr)
+        vpc = ec2.create_vpc(
+            CidrBlock=cidr,
+            TagSpecifications=owned_tag_specification("vpc", f"{name}-{tag_suffix}"),
+        )
         vpc_id = vpc["Vpc"]["VpcId"]
         result["network_id"] = vpc_id  # Generic field for validation
 
@@ -83,31 +99,17 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
         waiter = ec2.get_waiter("vpc_available")
         waiter.wait(VpcIds=[vpc_id])
 
-        # Tag VPC
-        ec2.create_tags(
-            Resources=[vpc_id],
-            Tags=[
-                {"Key": "Name", "Value": f"{name}-{tag_suffix}"},
-                {"Key": "CreatedBy", "Value": "isvtest"},
-            ],
-        )
-
         # Enable DNS hostnames
         ec2.modify_vpc_attribute(VpcId=vpc_id, EnableDnsHostnames={"Value": True})
 
         # Create Internet Gateway
-        igw = ec2.create_internet_gateway()
+        igw = ec2.create_internet_gateway(
+            TagSpecifications=owned_tag_specification("internet-gateway", f"{name}-igw-{tag_suffix}")
+        )
         igw_id = igw["InternetGateway"]["InternetGatewayId"]
         result["internet_gateway_id"] = igw_id
 
         ec2.attach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
-        ec2.create_tags(
-            Resources=[igw_id],
-            Tags=[
-                {"Key": "Name", "Value": f"{name}-igw-{tag_suffix}"},
-                {"Key": "CreatedBy", "Value": "isvtest"},
-            ],
-        )
 
         # Get availability zones
         azs = ec2.describe_availability_zones(Filters=[{"Name": "state", "Values": ["available"]}])
@@ -116,16 +118,13 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
         # Create subnets
         subnet_cidrs = ["10.0.1.0/24", "10.0.2.0/24"]
         for i, (az, subnet_cidr) in enumerate(zip(az_names, subnet_cidrs)):
-            subnet = ec2.create_subnet(VpcId=vpc_id, CidrBlock=subnet_cidr, AvailabilityZone=az)
-            subnet_id = subnet["Subnet"]["SubnetId"]
-
-            ec2.create_tags(
-                Resources=[subnet_id],
-                Tags=[
-                    {"Key": "Name", "Value": f"{name}-subnet-{i}-{tag_suffix}"},
-                    {"Key": "CreatedBy", "Value": "isvtest"},
-                ],
+            subnet = ec2.create_subnet(
+                VpcId=vpc_id,
+                CidrBlock=subnet_cidr,
+                AvailabilityZone=az,
+                TagSpecifications=owned_tag_specification("subnet", f"{name}-subnet-{i}-{tag_suffix}"),
             )
+            subnet_id = subnet["Subnet"]["SubnetId"]
 
             # Enable auto-assign public IP
             ec2.modify_subnet_attribute(SubnetId=subnet_id, MapPublicIpOnLaunch={"Value": True})
@@ -145,17 +144,12 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
             )
 
         # Create route table
-        rtb = ec2.create_route_table(VpcId=vpc_id)
+        rtb = ec2.create_route_table(
+            VpcId=vpc_id,
+            TagSpecifications=owned_tag_specification("route-table", f"{name}-rtb-{tag_suffix}"),
+        )
         rtb_id = rtb["RouteTable"]["RouteTableId"]
         result["route_table_id"] = rtb_id
-
-        ec2.create_tags(
-            Resources=[rtb_id],
-            Tags=[
-                {"Key": "Name", "Value": f"{name}-rtb-{tag_suffix}"},
-                {"Key": "CreatedBy", "Value": "isvtest"},
-            ],
-        )
 
         # Add route to internet gateway
         ec2.create_route(
@@ -173,6 +167,7 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
             GroupName=f"{name}-sg-{tag_suffix}",
             Description="Test security group",
             VpcId=vpc_id,
+            TagSpecifications=owned_tag_specification("security-group", f"{name}-sg-{tag_suffix}"),
         )
         sg_id = sg["GroupId"]
         result["security_group_id"] = sg_id

--- a/isvctl/configs/providers/aws/scripts/vm/launch_instance.py
+++ b/isvctl/configs/providers/aws/scripts/vm/launch_instance.py
@@ -49,6 +49,7 @@ from common.ec2 import (
     create_security_group,
     get_architecture_for_instance_type,
     get_default_vpc_and_subnets,
+    owned_tag_specifications,
 )
 
 
@@ -283,15 +284,7 @@ def main() -> int:
                     KeyName=args.key_name,
                     SubnetId=subnet_id,
                     SecurityGroupIds=[sg_id],
-                    TagSpecifications=[
-                        {
-                            "ResourceType": "instance",
-                            "Tags": [
-                                {"Key": "Name", "Value": args.name},
-                                {"Key": "CreatedBy", "Value": "isvtest"},
-                            ],
-                        }
-                    ],
+                    TagSpecifications=owned_tag_specifications(args.name),
                     BlockDeviceMappings=[
                         {
                             "DeviceName": "/dev/sda1",

--- a/isvctl/tests/providers/aws/test_aws_network_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_network_scripts.py
@@ -53,6 +53,21 @@ def _client_error(operation_name: str, code: str = "AccessDenied", message: str 
     return ClientError({"Error": {"Code": code, "Message": message}}, operation_name)
 
 
+def test_create_vpc_owned_tag_specification() -> None:
+    """Network fixtures must receive ownership tags in their create API call."""
+    module = _load_network_script("create_vpc.py")
+
+    assert module.owned_tag_specification("vpc", "isv-shared-vpc-12345678") == [
+        {
+            "ResourceType": "vpc",
+            "Tags": [
+                {"Key": "Name", "Value": "isv-shared-vpc-12345678"},
+                {"Key": "CreatedBy", "Value": "isvtest"},
+            ],
+        }
+    ]
+
+
 def _assert_stable_egress_contract(result: dict[str, Any]) -> None:
     """Assert stable egress scripts emit the minimal provider JSON contract."""
     assert set(result) == STABLE_EGRESS_TOP_LEVEL_KEYS

--- a/isvctl/tests/providers/aws/test_aws_verified_reuse.py
+++ b/isvctl/tests/providers/aws/test_aws_verified_reuse.py
@@ -38,6 +38,7 @@ if str(_COMMON_DIR) not in sys.path:
 from common.ec2 import (  # noqa: E402
     create_key_pair,
     create_security_group,
+    owned_tag_specifications,
     sanitize_key_name,
     wait_for_public_ip,
 )
@@ -305,6 +306,30 @@ class TestWaitForPublicIp:
             {"Reservations": [{"Instances": [{"PublicIpAddress": "34.5.5.5"}]}]},
         ]
         assert wait_for_public_ip(ec2, "i-1", timeout=10, interval=0) == "34.5.5.5"
+
+
+class TestOwnedTagSpecifications:
+    """Root volumes must carry the ownership tag, not just the instance."""
+
+    def test_tags_instance_and_volume(self) -> None:
+        """RunInstances does not copy instance tags to the root volume."""
+        specs = owned_tag_specifications("isv-test-block")
+        assert [spec["ResourceType"] for spec in specs] == ["instance", "volume"]
+        for spec in specs:
+            assert {"Key": "CreatedBy", "Value": "isvtest"} in spec["Tags"]
+            assert {"Key": "Name", "Value": "isv-test-block"} in spec["Tags"]
+
+    def test_extra_tags_apply_to_every_resource_type(self) -> None:
+        """Callers adding their own tags get them on the volume too."""
+        specs = owned_tag_specifications("bm", extra_tags=[{"Key": "Platform", "Value": "bare-metal"}])
+        for spec in specs:
+            assert {"Key": "Platform", "Value": "bare-metal"} in spec["Tags"]
+
+    def test_tag_lists_are_independent_per_resource_type(self) -> None:
+        """Mutating one entry's tags must not leak into the others."""
+        specs = owned_tag_specifications("iso")
+        specs[0]["Tags"].append({"Key": "Extra", "Value": "1"})
+        assert {"Key": "Extra", "Value": "1"} not in specs[1]["Tags"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Tag root EBS volumes at `RunInstances` time (instance tags are not copied to volumes), and surface failed old-root deletes from bare-metal reinstall in JSON
- Stamp `CreatedBy=isvtest` on FSx Lustre SGs, static CSI volumes, dynamic EBS CSI volumes (`tagSpecification_1`), and EKS Terraform default/local tags
- Apply ownership tags atomically via `TagSpecifications` in `create_vpc.py` so interrupted network setup cannot leave untagged shared VPCs

## Test plan
- [x] `make lint` / `uvx pre-commit run -a`
- [x] `make test` (prior commit) and targeted AWS provider tests for ownership tagging / network scripts
- [x] Confirm a fresh `vm`/`bare_metal` launch shows `CreatedBy=isvtest` on the root volume
- [x] Confirm network suite `create_network` VPC/subnets/SG carry `CreatedBy=isvtest` at create time
- [x] Confirm EKS gp3 StorageClass provisions volumes with `CreatedBy=isvtest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AWS resources are now consistently tagged with ownership and name information during creation.
  * Added platform tagging for bare-metal instances.
  * Improved cleanup reporting after bare-metal reinstalls, including failed volume deletions.
  * EBS volumes created through EKS workflows now include ownership tags.
  * Dynamically provisioned EBS volumes receive consistent ownership metadata.

* **Tests**
  * Added coverage for resource tagging across networking, instance, volume, and reuse workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->