### PR TITLE
fix: restore the storage suite's on-cluster invocation after #561

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ Config (YAML) → Script (any language) → JSON output → Validations (asserti
 - **Teardown is best-effort** - one failing teardown step does not block the others.
 - **Standalone teardown** (`isvctl test run -f config.yaml --phase teardown`) runs
   unconditionally - useful after a previous run with `AWS_SKIP_TEARDOWN`.
+- **A config with no `commands:` runs validations only** against a system that is
+  already up (a suite `-f`'d on its own, no provider). Only the test phase runs.
+  Live probes run directly; validations wired to provider step output still skip
+  as `step_not_configured`.
 - Multiple `-f` configs merge; later files override earlier ones.
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,10 @@ Config (YAML) → Script (any language) → JSON output → Validations (asserti
 - **Standalone teardown** (`isvctl test run -f config.yaml --phase teardown`) runs
   unconditionally - useful after a previous run with `AWS_SKIP_TEARDOWN`.
 - **A config with no `commands:` runs validations only** against a system that is
-  already up (a suite `-f`'d on its own, no provider). Only the test phase runs.
-  Live probes run directly; validations wired to provider step output still skip
-  as `step_not_configured`.
+  already up. Only the test phase runs. Live probes run directly; validations
+  wired to provider step output still skip as `step_not_configured`. Declaring
+  commands is per file - some canonical suites carry a scaffold fixture, others
+  none - so read the file rather than inferring from the kind of suite.
 - Multiple `-f` configs merge; later files override earlier ones.
 
 ## Architecture

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -324,10 +324,15 @@ and `--label` discovery behave identically:
 > capability to add the checks gated on it.
 
 ```bash
+isvctl test run --suite storage --capability kubernetes --phase test    # canonical suite, no provider lifecycle
 isvctl test run --provider acme --suite storage                         # core only
 isvctl test run --provider acme --suite storage --capability vm         # core + vm checks
 isvctl test run --provider acme --suite kubernetes                      # the platform suite
 ```
+
+Without `--provider`, `--suite` selects the canonical file in
+`configs/suites/`. With `--provider`, it selects the provider config and its
+lifecycle commands.
 
 There is no "run everything" context: a plain suite always carries exactly one.
 Passing a capability no check in the suite requires is allowed but warns, since

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -232,6 +232,9 @@ full model.
 ## Running Validations
 
 ```bash
+# Canonical suite against an already-running system - no provider lifecycle
+isvctl test run --suite storage --capability kubernetes --phase test
+
 # One suite for your provider - the form the UI emits
 isvctl test run --provider acme --suite storage                         # core checks
 isvctl test run --provider acme --suite storage --capability kubernetes # + k8s checks
@@ -272,6 +275,10 @@ isvctl test run --provider acme --suite storage --capability kubernetes -- -k K8
 # Debug: full output on failure
 isvctl test run -f config.yaml -v -- -s --tb=long
 ```
+
+`--suite` on its own resolves the canonical file in `configs/suites/`.
+Adding `--provider` resolves that provider's config instead, including any
+lifecycle commands it defines.
 
 Re-running a single failed check is pytest passthrough after `--`; there are no
 dedicated rerun flags. Setup steps re-run, which is the deliberate trade for not

--- a/docs/guides/remote-deployment.md
+++ b/docs/guides/remote-deployment.md
@@ -18,15 +18,22 @@ The `isvctl deploy run` command packages and transfers the tools to a remote tar
 
 ## Environment Variables
 
-Environment variables required by tests must be set on the local machine - they are forwarded to the remote session automatically:
+Set these on the local machine. The upload variables are read here, since
+`deploy` reports the test run itself; the others are forwarded to the remote
+`isvctl test run`:
 
-| Variable | Description |
-| -------- | ----------- |
-| `ISV_SERVICE_ENDPOINT` | Required for result upload to ISV Lab Service |
-| `ISV_SSA_ISSUER` | Required for result upload to ISV Lab Service |
-| `ISV_CLIENT_ID` | Required for result upload to ISV Lab Service |
-| `ISV_CLIENT_SECRET` | Required for result upload to ISV Lab Service |
-| `NGC_API_KEY` | Required for NIM model benchmarks |
+| Variable | Description | Read |
+| -------- | ----------- | ---- |
+| `ISV_SERVICE_ENDPOINT` | Required for result upload to ISV Lab Service | locally |
+| `ISV_SSA_ISSUER` | Required for result upload to ISV Lab Service | locally |
+| `ISV_CLIENT_ID` | Required for result upload to ISV Lab Service | locally |
+| `ISV_CLIENT_SECRET` | Required for result upload to ISV Lab Service | locally |
+| `NGC_API_KEY` | Required for NIM model benchmarks | forwarded |
+| `ISVTEST_INCLUDE_UNRELEASED` | Include checks not yet in `released_tests.json` | forwarded |
+
+Anything else the tests need has to reach the target another way - a config file
+under `isvctl/` travels in the deployment archive, so `-f` overrides are the
+reliable route for values like StorageClass names.
 
 ## Usage
 

--- a/docs/guides/remote-deployment.md
+++ b/docs/guides/remote-deployment.md
@@ -33,8 +33,21 @@ Environment variables required by tests must be set on the local machine - they 
 ### Basic Deployment
 
 ```bash
-# Deploy and run tests on remote machine
+# Deploy and run one suite on the remote machine
+uv run isvctl deploy run <target-ip> --suite kubernetes
+
+# Or name the config file directly
 uv run isvctl deploy run <target-ip> -f isvctl/configs/suites/k8s.yaml
+```
+
+### Selecting a Capability
+
+A plain suite such as `storage` runs its core checks unless a capability is
+named; `--capability` is forwarded to the remote run. A platform suite already
+runs under the capability it declares, so combining the two is rejected.
+
+```bash
+uv run isvctl deploy run <target-ip> --suite storage --capability kubernetes
 ```
 
 ### With Jumphost
@@ -80,6 +93,8 @@ Run `uv run isvctl deploy run --help` for all available options:
 | Option | Description |
 | ------ | ----------- |
 | `<target>` | Target machine IP or hostname |
+| `--suite` | Canonical suite to run, instead of `-f` |
+| `--capability` | Capability context for the remote run (plain suites only) |
 | `-f, --config` | Config file(s) to use (can be specified multiple times) |
 | `-u, --user` | SSH user on target machine |
 | `-j, --jumphost` | Jumphost for air-gapped environments |

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -248,8 +248,11 @@ print(json.dumps({
 See [Remote Deployment Guide](../guides/remote-deployment.md) for full details.
 
 ```bash
-# Deploy and run tests on remote machine
-uv run isvctl deploy run 192.168.1.100 -u ubuntu -f isvctl/configs/suites/k8s.yaml
+# Deploy and run one suite on a remote machine
+uv run isvctl deploy run 192.168.1.100 -u ubuntu --suite kubernetes
+
+# A plain suite under a capability
+uv run isvctl deploy run 192.168.1.100 -u ubuntu --suite storage --capability kubernetes
 
 # With jumphost
 uv run isvctl deploy run 192.168.1.100 -j jumphost.example.com -u ubuntu -f isvctl/configs/suites/k8s.yaml

--- a/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
+++ b/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
@@ -169,7 +169,8 @@ cat << EOF
     "shared_fs_storage_class": "${CSI_SHARED_FS_SC}",
     "nfs_storage_class": "${CSI_NFS_SC}",
     "static_volume_handle": "",
-    "static_driver_name": ""
+    "static_driver_name": "",
+    "static_volume_az": ""
   }
 }
 EOF

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -43,15 +43,14 @@ some contexts need, so a core run neither provisions nor leaks it.
 
 ## Running against a system that is already up
 
-A commandless canonical suite such as `storage` can be run directly with `-f`;
-it drives no lifecycle. That is a supported way to run: ssh to a cluster you
-already have, and only the test phase runs — no provider setup or teardown
-commands execute. For example, run selected Kubernetes storage probes against
-the cluster selected by `KUBECTL`:
+A commandless canonical suite such as `storage` can be run directly with
+`--suite` (or `-f`); it drives no lifecycle. That is a supported way to run:
+ssh to a cluster you already have, and only the test phase runs — no provider
+setup or teardown commands execute. For example, run selected Kubernetes
+storage probes against the cluster selected by `KUBECTL`:
 
 ```bash
-ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run \
-  -f isvctl/configs/suites/storage.yaml \
+ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run --suite storage \
   --capability kubernetes --phase test -- \
   -k "K8sNfsMountOptionsCheck or K8sCsiStorageTypesCheck"
 ```
@@ -59,6 +58,8 @@ ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run \
 Set `K8S_CSI_BLOCK_SC`, `K8S_CSI_SHARED_FS_SC`, and/or `K8S_CSI_NFS_SC` when
 the selected checks need StorageClass names. Checks bound to provider-produced
 step output still skip as `step_not_configured` when their provider is absent.
+The equivalent explicit-file form is
+`-f isvctl/configs/suites/storage.yaml`.
 
 Suites:
 [`iam`](iam.yaml),

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -41,6 +41,25 @@ at once, so a run always carries exactly one context. Steps follow the same
 rule — give a step `requires:` when it builds or tears down a fixture only
 some contexts need, so a core run neither provisions nor leaks it.
 
+## Running against a system that is already up
+
+A commandless canonical suite such as `storage` can be run directly with `-f`;
+it drives no lifecycle. That is a supported way to run: ssh to a cluster you
+already have, and only the test phase runs — no provider setup or teardown
+commands execute. For example, run selected Kubernetes storage probes against
+the cluster selected by `KUBECTL`:
+
+```bash
+ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run \
+  -f isvctl/configs/suites/storage.yaml \
+  --capability kubernetes --phase test -- \
+  -k "K8sNfsMountOptionsCheck or K8sCsiStorageTypesCheck"
+```
+
+Set `K8S_CSI_BLOCK_SC`, `K8S_CSI_SHARED_FS_SC`, and/or `K8S_CSI_NFS_SC` when
+the selected checks need StorageClass names. Checks bound to provider-produced
+step output still skip as `step_not_configured` when their provider is absent.
+
 Suites:
 [`iam`](iam.yaml),
 [`network`](network.yaml),

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -43,20 +43,23 @@ some contexts need, so a core run neither provisions nor leaks it.
 
 ## Running against a system that is already up
 
-A commandless canonical suite such as `storage` can be run directly with
-`--suite` (or `-f`); it drives no lifecycle. That is a supported way to run:
-ssh to a cluster you already have, and only the test phase runs — no provider
-setup or teardown commands execute. For example, run selected Kubernetes
-storage probes against the cluster selected by `KUBECTL`:
+A canonical suite can be run directly with `--suite` (or `-f`), against a
+cluster you already have and with no provider selected. Whether any lifecycle
+runs depends on the file: a suite that declares no `commands:` runs its test
+phase only, and one that declares them supplies a scaffold fixture that reports
+on the current system rather than provisioning anything. For example, run
+selected Kubernetes storage probes against the cluster `KUBECTL` selects:
 
 ```bash
 ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run --suite storage \
-  --capability kubernetes --phase test -- \
+  --capability kubernetes -- \
   -k "K8sNfsMountOptionsCheck or K8sCsiStorageTypesCheck"
 ```
 
-Set `K8S_CSI_BLOCK_SC`, `K8S_CSI_SHARED_FS_SC`, and/or `K8S_CSI_NFS_SC` when
-the selected checks need StorageClass names. Checks bound to provider-produced
+`storage` gets its StorageClass names from its `setup_cluster` fixture, which
+reports the classes already installed on the cluster. Set `K8S_CSI_BLOCK_SC`,
+`K8S_CSI_SHARED_FS_SC`, or `K8S_CSI_NFS_SC` to name them yourself, and add
+`--phase test` to skip the fixture entirely. Checks bound to provider-produced
 step output still skip as `step_not_configured` when their provider is absent.
 The equivalent explicit-file form is
 `-f isvctl/configs/suites/storage.yaml`.

--- a/isvctl/configs/suites/storage.yaml
+++ b/isvctl/configs/suites/storage.yaml
@@ -52,6 +52,30 @@
 
 version: "1.0"
 
+# The kubernetes storage checks read StorageClass names from
+# steps.setup_cluster.csi, so the suite supplies the fixture that produces them
+# rather than leaving the names to K8S_CSI_* env vars on a run with no provider.
+# Same scaffold stub k8s.yaml uses: it reports the classes already installed on
+# the current cluster and provisions nothing, so it is safe to run unattended.
+# A provider's own steps replace this list wholesale when it defines them.
+commands:
+  storage:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      - name: setup_cluster
+        phase: setup
+        command: "../providers/my-isv/scripts/k8s/setup.sh"
+        requires: [kubernetes]
+        # Storage reads only the csi block, so do not hold this fixture to the
+        # `cluster` inventory schema its step name would otherwise select.
+        output_schema: generic
+        timeout: 120
+      - name: teardown_cluster
+        phase: teardown
+        command: "../providers/my-isv/scripts/k8s/teardown.sh"
+        requires: [kubernetes]
+        timeout: 30
+
 tests:
   cluster_name: "storage-validation"
   description: "Storage: block volumes and high-speed / parallel filesystem services"

--- a/isvctl/configs/suites/storage.yaml
+++ b/isvctl/configs/suites/storage.yaml
@@ -227,9 +227,10 @@ tests:
           requires: [vm, bare_metal]
           step: multipath
 
-    # Kubernetes storage checks probe the current cluster. Provider runs may
-    # populate steps.setup_cluster.csi with StorageClass defaults first, while
-    # on-cluster validation-only runs can supply the equivalent K8S_CSI_* env vars.
+    # Kubernetes storage checks probe the current cluster, so they bind to no
+    # step: a `step:` here would skip them whenever no provider supplies that
+    # fixture. StorageClass names come from steps.setup_cluster.csi on a provider
+    # run, and from the K8S_CSI_* env vars on a validation-only run.
     k8s_storage:
       checks:
         K8sCsiStorageTypesCheck:

--- a/isvctl/configs/suites/storage.yaml
+++ b/isvctl/configs/suites/storage.yaml
@@ -227,9 +227,10 @@ tests:
           requires: [vm, bare_metal]
           step: multipath
 
-    # Kubernetes storage checks use a normal provider-owned cluster fixture.
+    # Kubernetes storage checks probe the current cluster. Provider runs may
+    # populate steps.setup_cluster.csi with StorageClass defaults first, while
+    # on-cluster validation-only runs can supply the equivalent K8S_CSI_* env vars.
     k8s_storage:
-      step: setup_cluster
       checks:
         K8sCsiStorageTypesCheck:
           test_id: "K8S23-04"
@@ -365,7 +366,6 @@ tests:
           expected_read_ahead_kb: ""
 
     k8s_filesystem:
-      step: setup_cluster
       checks:
         # Shared-filesystem POSIX-semantics checks (multi-pod, RWX PVC).
         K8sFileLockingCheck:

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -29,6 +29,7 @@ from typing import Annotated
 import typer
 from isvreporter.config import get_endpoint, get_ssa_issuer
 from isvreporter.platform import get_platform_from_config
+from isvtest.core.ngc import get_ngc_api_key
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV
 
 from isvctl.cli import setup_logging
@@ -38,8 +39,8 @@ from isvctl.config.suite_resolution import (
     SuiteResolutionError,
     parse_capability,
     platform_vocabulary,
-    resolve_suite,
     resolve_suite_name,
+    select_suite,
 )
 from isvctl.orchestrator.loop import Phase
 from isvctl.remote import SCPTransfer, SSHClient, TarArchive
@@ -91,7 +92,7 @@ def _remote_env_assignments() -> str:
     deliberately not forwarded, since they name files that exist only here.
     """
     forwarded: dict[str, str] = {}
-    ngc_api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
+    ngc_api_key = get_ngc_api_key()
     if ngc_api_key:
         forwarded["NGC_API_KEY"] = ngc_api_key
     include_unreleased = os.environ.get(INCLUDE_UNRELEASED_ENV, "")
@@ -100,18 +101,21 @@ def _remote_env_assignments() -> str:
     return " ".join(f"{name}={shlex.quote(value)}" for name, value in forwarded.items())
 
 
-def _reporting_suite_and_capability(
-    config_files: list[Path],
-    capability: str | None = None,
-) -> tuple[str | None, str | None]:
-    """Return the suite and capability recorded for a deploy.
+def _reporting_suite_and_capability(config_files: list[Path], capability: str | None) -> tuple[str | None, str | None]:
+    """Return the (suite, capability) identity a deploy runs and reports under.
 
-    A platform suite runs under the capability it declares; a plain suite runs
-    under the one ``--capability`` names, and is core when it names none.
+    A platform suite runs under the capability it declares, and so rejects an
+    explicit one; a plain suite runs under whatever ``--capability`` names, and
+    is core when it names none.
     """
     suite = resolve_suite_name(config_files, CONFIGS_ROOT)
-    declared = suite if suite in platform_vocabulary(CONFIGS_ROOT) else None
-    return suite, declared or capability
+    if suite not in platform_vocabulary(CONFIGS_ROOT):
+        return suite, capability
+    if capability:
+        raise SuiteResolutionError(
+            f"--capability cannot be used with platform suite {suite!r}; it already runs under capability {suite!r}."
+        )
+    return suite, suite
 
 
 def _resolve_config_paths(
@@ -337,17 +341,10 @@ def run(
     try:
         capability_context = parse_capability(capability, CONFIGS_ROOT)
         if suite:
-            if config_files:
-                raise SuiteResolutionError("--suite cannot be combined with --config/-f.")
-            selected_suite = resolve_suite(None, suite, configs_root=CONFIGS_ROOT)
-            print_progress(f"Selected canonical {selected_suite.name!r} suite.")
+            selected_suite, selection_message = select_suite(suite, config_files, None, configs_root=CONFIGS_ROOT)
+            print_progress(selection_message)
             config_files = [selected_suite.config_path]
         reported_suite, reported_capability = _reporting_suite_and_capability(config_files, capability_context)
-        if capability_context and reported_suite in platform_vocabulary(CONFIGS_ROOT):
-            raise SuiteResolutionError(
-                f"--capability cannot be used with platform suite {reported_suite!r}; "
-                f"it already runs under capability {reported_capability!r}."
-            )
     except SuiteResolutionError as exc:
         print_error(str(exc))
         raise typer.Exit(code=1)

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -29,6 +29,7 @@ from typing import Annotated
 import typer
 from isvreporter.config import get_endpoint, get_ssa_issuer
 from isvreporter.platform import get_platform_from_config
+from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV
 
 from isvctl.cli import setup_logging
 from isvctl.cli.common import get_output_dir, print_error, print_progress, print_step, print_warning
@@ -79,6 +80,24 @@ def _pytest_passthrough(args: list[str]) -> str:
 def _capability_option(capability: str | None) -> str:
     """Render the capability context for the remote ``test run`` command."""
     return f"--capability {shlex.quote(capability)}" if capability else ""
+
+
+def _remote_env_assignments() -> str:
+    """Render the environment the remote ``test run`` needs from this process.
+
+    Only values the target cannot obtain on its own: a credential and the
+    release gate, both set per invocation by whoever runs the deploy. Quoted
+    because they end up on a shell command line. Path-valued variables are
+    deliberately not forwarded, since they name files that exist only here.
+    """
+    forwarded: dict[str, str] = {}
+    ngc_api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
+    if ngc_api_key:
+        forwarded["NGC_API_KEY"] = ngc_api_key
+    include_unreleased = os.environ.get(INCLUDE_UNRELEASED_ENV, "")
+    if include_unreleased:
+        forwarded[INCLUDE_UNRELEASED_ENV] = include_unreleased
+    return " ".join(f"{name}={shlex.quote(value)}" for name, value in forwarded.items())
 
 
 def _reporting_suite_and_capability(
@@ -488,9 +507,7 @@ def run(
         config_args = " ".join(f"-f {c}" for c in configs)
         capability_arg = _capability_option(capability_context)
 
-        # Handle NGC API key securely - use shlex.quote to prevent shell injection
-        ngc_api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
-        env_vars = f"NGC_API_KEY={shlex.quote(ngc_api_key)}" if ngc_api_key else ""
+        env_vars = _remote_env_assignments()
 
         # Note: Variables like $PATH and $TEST_RESULT expand on the remote shell
         remote_script = f"""

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -59,6 +59,16 @@ app = typer.Typer(
 )
 
 
+def _pytest_passthrough(args: list[str]) -> str:
+    """Render the args collected after ``--`` for the remote ``test run`` command.
+
+    The separator has to be reproduced remotely: ``test run`` rejects unknown
+    options, so a bare ``-s`` appended to its command line is read as an isvctl
+    option and fails the run before pytest sees it.
+    """
+    return f"-- {shlex.join(args)}" if args else ""
+
+
 def _reporting_suite_and_capability(config_files: list[Path]) -> tuple[str | None, str | None]:
     """Return the suite and platform-suite capability recorded for a deploy."""
     suite = resolve_suite_name(config_files, CONFIGS_ROOT)
@@ -260,7 +270,7 @@ def run(
     setup_logging(verbose)
 
     # Collect extra pytest args from context (after --)
-    pytest_extra_args = shlex.join(ctx.args) if ctx.args else ""
+    pytest_extra_args = _pytest_passthrough(ctx.args)
 
     # Set working directory to workspace root
     working_dir = Path.cwd()
@@ -443,7 +453,7 @@ echo "Running uv sync..."
 uv sync --quiet
 
 echo "Running validation tests with isvctl..."
-echo "Command: isvctl test run {config_args} --phase {phase.value}"
+echo "Command: isvctl test run {config_args} --phase {phase.value} {pytest_extra_args}"
 
 set +e
 set -o pipefail

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -32,7 +32,14 @@ from isvreporter.platform import get_platform_from_config
 
 from isvctl.cli import setup_logging
 from isvctl.cli.common import get_output_dir, print_error, print_progress, print_step, print_warning
-from isvctl.config.suite_resolution import CONFIGS_ROOT, platform_vocabulary, resolve_suite_name
+from isvctl.config.suite_resolution import (
+    CONFIGS_ROOT,
+    SuiteResolutionError,
+    parse_capability,
+    platform_vocabulary,
+    resolve_suite,
+    resolve_suite_name,
+)
 from isvctl.orchestrator.loop import Phase
 from isvctl.remote import SCPTransfer, SSHClient, TarArchive
 from isvctl.remote.archive import DEFAULT_EXCLUDES as DEFAULT_ARCHIVE_EXCLUDES
@@ -69,11 +76,23 @@ def _pytest_passthrough(args: list[str]) -> str:
     return f"-- {shlex.join(args)}" if args else ""
 
 
-def _reporting_suite_and_capability(config_files: list[Path]) -> tuple[str | None, str | None]:
-    """Return the suite and platform-suite capability recorded for a deploy."""
+def _capability_option(capability: str | None) -> str:
+    """Render the capability context for the remote ``test run`` command."""
+    return f"--capability {shlex.quote(capability)}" if capability else ""
+
+
+def _reporting_suite_and_capability(
+    config_files: list[Path],
+    capability: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Return the suite and capability recorded for a deploy.
+
+    A platform suite runs under the capability it declares; a plain suite runs
+    under the one ``--capability`` names, and is core when it names none.
+    """
     suite = resolve_suite_name(config_files, CONFIGS_ROOT)
-    capability = suite if suite in platform_vocabulary(CONFIGS_ROOT) else None
-    return suite, capability
+    declared = suite if suite in platform_vocabulary(CONFIGS_ROOT) else None
+    return suite, declared or capability
 
 
 def _resolve_config_paths(
@@ -150,7 +169,12 @@ def _print_configuration(
     print_progress("")
 
 
-@app.command("run", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+@app.command(
+    "run",
+    # Allow pytest args after `--`, but reject unknown options before it so a
+    # flag this command does not have fails here instead of reaching pytest.
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": False},
+)
 def run(
     ctx: typer.Context,
     remote_ip: Annotated[
@@ -193,6 +217,20 @@ def run(
             file_okay=True,
             dir_okay=False,
             readable=True,
+        ),
+    ] = None,
+    suite: Annotated[
+        str | None,
+        typer.Option(
+            "--suite",
+            help="Run one canonical suite instead of naming its file with --config/-f.",
+        ),
+    ] = None,
+    capability: Annotated[
+        str | None,
+        typer.Option(
+            "--capability",
+            help="Capability context for the remote run (one of the platform suites). Plain suites only.",
         ),
     ] = None,
     lab_id: Annotated[
@@ -261,7 +299,9 @@ def run(
     extracts and runs the validation tests, then downloads results.
 
     Examples:
-        isvctl deploy run 192.168.1.100 -f isvctl/configs/suites/k8s.yaml
+        isvctl deploy run 192.168.1.100 --suite kubernetes
+
+        isvctl deploy run 192.168.1.100 --suite storage --capability kubernetes
 
         isvctl deploy run 7.243.33.191 -j 202.56.94.106:2260 -u ubuntu -f isvctl/configs/suites/k8s.yaml
 
@@ -272,6 +312,27 @@ def run(
     # Collect extra pytest args from context (after --)
     pytest_extra_args = _pytest_passthrough(ctx.args)
 
+    # Resolve the suite selection before anything is archived or uploaded, so a
+    # rejected combination costs no SSH round trip.
+    config_files = list(config or [])
+    try:
+        capability_context = parse_capability(capability, CONFIGS_ROOT)
+        if suite:
+            if config_files:
+                raise SuiteResolutionError("--suite cannot be combined with --config/-f.")
+            selected_suite = resolve_suite(None, suite, configs_root=CONFIGS_ROOT)
+            print_progress(f"Selected canonical {selected_suite.name!r} suite.")
+            config_files = [selected_suite.config_path]
+        reported_suite, reported_capability = _reporting_suite_and_capability(config_files, capability_context)
+        if capability_context and reported_suite in platform_vocabulary(CONFIGS_ROOT):
+            raise SuiteResolutionError(
+                f"--capability cannot be used with platform suite {reported_suite!r}; "
+                f"it already runs under capability {reported_capability!r}."
+            )
+    except SuiteResolutionError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1)
+
     # Set working directory to workspace root
     working_dir = Path.cwd()
 
@@ -279,7 +340,6 @@ def run(
     effective_remote_dir = remote_dir or f"/home/{user}/ai-cloud-validation"
 
     # Resolve config paths
-    config_files = config or []
     try:
         configs = _resolve_config_paths(config_files, working_dir)
     except typer.BadParameter as e:
@@ -406,7 +466,6 @@ def run(
             print_step("Creating test run in isvreporter...")
             # Derive platform from first config file
             platform = get_platform_from_config(config_files[0]) if config_files else "kubernetes"
-            suite, capability = _reporting_suite_and_capability(list(config_files))
             test_run_id = create_test_run(
                 lab_id=lab_id,
                 platform=platform,
@@ -415,10 +474,8 @@ def run(
                 executed_by="isvctl deploy",
                 ci_reference="local-deployment",
                 isv_software_version=isv_software_version,
-                # deploy has no --capability of its own; the remote `test run`
-                # it invokes is core-only unless the config is a platform suite.
-                suite=suite,
-                capability=capability,
+                suite=reported_suite,
+                capability=reported_capability,
             )
             if not test_run_id:
                 print_warning("Failed to create test run, continuing without upload")
@@ -429,6 +486,7 @@ def run(
 
         # Build config args for isvctl
         config_args = " ".join(f"-f {c}" for c in configs)
+        capability_arg = _capability_option(capability_context)
 
         # Handle NGC API key securely - use shlex.quote to prevent shell injection
         ngc_api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
@@ -453,11 +511,11 @@ echo "Running uv sync..."
 uv sync --quiet
 
 echo "Running validation tests with isvctl..."
-echo "Command: isvctl test run {config_args} --phase {phase.value} {pytest_extra_args}"
+echo "Command: isvctl test run {config_args} --phase {phase.value} {capability_arg} {pytest_extra_args}"
 
 set +e
 set -o pipefail
-sudo -E env PATH="$PATH" PYTHONUNBUFFERED=1 {env_vars} uv run isvctl test run {config_args} --phase {phase.value} --color=yes --junitxml=junit-validation.xml {pytest_extra_args} 2>&1 | tee pytest-output.log
+sudo -E env PATH="$PATH" PYTHONUNBUFFERED=1 {env_vars} uv run isvctl test run {config_args} --phase {phase.value} {capability_arg} --color=yes --junitxml=junit-validation.xml {pytest_extra_args} 2>&1 | tee pytest-output.log
 TEST_RESULT=${{PIPESTATUS[0]}}
 set +o pipefail
 

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -52,8 +52,8 @@ from isvctl.config.suite_resolution import (
     CONFIGS_ROOT,
     SuiteResolutionError,
     parse_capability,
-    resolve_suite,
     resolve_suite_name,
+    select_suite,
 )
 from isvctl.orchestrator.loop import Orchestrator, Phase, _has_explicit_pytest_selection
 from isvctl.reporting import check_upload_credentials, create_test_run, get_environment_config, update_test_run
@@ -407,18 +407,12 @@ def run(
     suite_label: str | None = None
 
     if suite:
-        if config_files:
-            print_error("--suite cannot be combined with --config/-f.")
-            raise typer.Exit(code=1)
         try:
-            selected_suite = resolve_suite(provider, suite, configs_root=CONFIGS_ROOT)
+            selected_suite, selection_message = select_suite(suite, config_files, provider, configs_root=CONFIGS_ROOT)
         except SuiteResolutionError as exc:
             print_error(str(exc))
             raise typer.Exit(code=1)
-        if provider:
-            print_progress(f"Selected {selected_suite.name!r} suite for provider {provider!r}.")
-        else:
-            print_progress(f"Selected canonical {selected_suite.name!r} suite.")
+        print_progress(selection_message)
         suite_label = selected_suite.name
         config_files = [selected_suite.config_path]
         provider = None

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -245,14 +245,14 @@ def run(
         str | None,
         typer.Option(
             "--provider",
-            help="Provider name for --suite selection or --label discovery when no --config/-f is supplied.",
+            help="Use provider-backed --suite selection or provider-scoped --label discovery.",
         ),
     ] = None,
     suite: Annotated[
         str | None,
         typer.Option(
             "--suite",
-            help="Run one platform or plain suite from the selected provider.",
+            help="Run a canonical suite directly, or its provider-backed config with --provider.",
         ),
     ] = None,
     capability: Annotated[
@@ -378,6 +378,7 @@ def run(
     Use -- to pass additional arguments to pytest/isvtest.
 
     Examples:
+        isvctl test run --suite storage --capability kubernetes --phase test
         isvctl test run --provider aws --suite k8s
         isvctl test run --provider aws --suite storage --label min_req
         isvctl test run --provider aws --label network
@@ -399,9 +400,6 @@ def run(
     suite_label: str | None = None
 
     if suite:
-        if not provider:
-            print_error("--suite requires --provider.")
-            raise typer.Exit(code=1)
         if config_files:
             print_error("--suite cannot be combined with --config/-f.")
             raise typer.Exit(code=1)
@@ -410,7 +408,10 @@ def run(
         except SuiteResolutionError as exc:
             print_error(str(exc))
             raise typer.Exit(code=1)
-        print_progress(f"Selected {selected_suite.name!r} suite for provider {provider!r}.")
+        if provider:
+            print_progress(f"Selected {selected_suite.name!r} suite for provider {provider!r}.")
+        else:
+            print_progress(f"Selected canonical {selected_suite.name!r} suite.")
         suite_label = selected_suite.name
         config_files = [selected_suite.config_path]
         provider = None

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -391,6 +391,13 @@ def run(
     setup_logging(verbose)
     apply_user_config(no_user_config)
 
+    # --color governs this command's own output, not just the pytest args built
+    # from it below. click otherwise auto-detects a terminal, and under `deploy`
+    # stdout is a pipe: the results summary would arrive unstyled in the log
+    # while pytest, told explicitly, keeps its colors.
+    if color in ("yes", "no"):
+        ctx.color = color == "yes"
+
     try:
         capability_context = parse_capability(capability, CONFIGS_ROOT)
     except SuiteResolutionError as exc:

--- a/isvctl/src/isvctl/config/suite_resolution.py
+++ b/isvctl/src/isvctl/config/suite_resolution.py
@@ -148,10 +148,14 @@ def resolve_suite_name(config_paths: list[Path], configs_root: Path) -> str | No
 
 def resolve_suite(provider: str | None, suite: str, *, configs_root: Path) -> ResolvedSuite:
     """Resolve one canonical suite, or one provider config when a provider is selected."""
-    config_dir = configs_root / "providers" / provider / "config" if provider is not None else configs_root / "suites"
-    source = f"Provider {provider!r}" if provider is not None else "Canonical suite catalog"
-    if provider is not None and not config_dir.is_dir():
-        raise SuiteResolutionError(f"Provider {provider!r} has no config directory at {config_dir}.")
+    if provider is None:
+        config_dir = configs_root / "suites"
+        source = "Canonical suite catalog"
+    else:
+        config_dir = configs_root / "providers" / provider / "config"
+        source = f"Provider {provider!r}"
+        if not config_dir.is_dir():
+            raise SuiteResolutionError(f"Provider {provider!r} has no config directory at {config_dir}.")
 
     requested = _normalize_name(suite)
     declarable = platform_vocabulary(configs_root)
@@ -176,3 +180,24 @@ def resolve_suite(provider: str | None, suite: str, *, configs_root: Path) -> Re
         )
     path, name, platform = matches[0]
     return ResolvedSuite(config_path=path, name=name, platform=platform)
+
+
+def select_suite(
+    suite: str,
+    config_files: list[Path],
+    provider: str | None,
+    *,
+    configs_root: Path,
+) -> tuple[ResolvedSuite, str]:
+    """Resolve ``--suite`` for a CLI command, with the line announcing the choice.
+
+    ``test run`` and ``deploy run`` both offer ``--suite``; the rule it excludes
+    and the wording of the announcement belong to the selection, not to either
+    command, so neither can drift from the other.
+    """
+    if config_files:
+        raise SuiteResolutionError("--suite cannot be combined with --config/-f.")
+    selected = resolve_suite(provider, suite, configs_root=configs_root)
+    if provider:
+        return selected, f"Selected {selected.name!r} suite for provider {provider!r}."
+    return selected, f"Selected canonical {selected.name!r} suite."

--- a/isvctl/src/isvctl/config/suite_resolution.py
+++ b/isvctl/src/isvctl/config/suite_resolution.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Resolve one platform or plain suite to a provider configuration."""
+"""Resolve one platform or plain suite to a canonical or provider configuration."""
 
 from dataclasses import dataclass
 from functools import cache
@@ -25,7 +25,7 @@ class SuiteResolutionError(Exception):
 
 @dataclass(frozen=True)
 class ResolvedSuite:
-    """A provider configuration selected for one logical suite."""
+    """A configuration selected for one logical suite."""
 
     config_path: Path
     name: str
@@ -146,10 +146,11 @@ def resolve_suite_name(config_paths: list[Path], configs_root: Path) -> str | No
     return _normalize_name(config_paths[0].stem)
 
 
-def resolve_suite(provider: str, suite: str, *, configs_root: Path) -> ResolvedSuite:
-    """Resolve exactly one provider config for a platform or plain suite."""
-    config_dir = configs_root / "providers" / provider / "config"
-    if not config_dir.is_dir():
+def resolve_suite(provider: str | None, suite: str, *, configs_root: Path) -> ResolvedSuite:
+    """Resolve one canonical suite, or one provider config when a provider is selected."""
+    config_dir = configs_root / "providers" / provider / "config" if provider is not None else configs_root / "suites"
+    source = f"Provider {provider!r}" if provider is not None else "Canonical suite catalog"
+    if provider is not None and not config_dir.is_dir():
         raise SuiteResolutionError(f"Provider {provider!r} has no config directory at {config_dir}.")
 
     requested = _normalize_name(suite)
@@ -166,12 +167,12 @@ def resolve_suite(provider: str, suite: str, *, configs_root: Path) -> ResolvedS
     if not matches:
         available = sorted({name for _, name, _ in classified})
         raise SuiteResolutionError(
-            f"Provider {provider!r} has no {requested!r} suite. Available suites: {', '.join(available) or '(none)'}."
+            f"{source} has no {requested!r} suite. Available suites: {', '.join(available) or '(none)'}."
         )
     if len(matches) > 1:
         paths = ", ".join(str(path) for path, _, _ in matches)
         raise SuiteResolutionError(
-            f"Provider {provider!r} has multiple {requested!r} suite configs ({paths}). Disambiguate with --config/-f."
+            f"{source} has multiple {requested!r} suite configs ({paths}). Disambiguate with --config/-f."
         )
     path, name, platform = matches[0]
     return ResolvedSuite(config_path=path, name=name, platform=platform)

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any
 
 from isvtest.core.resolution import (
+    DECLARABLE_CAPABILITIES,
     ErrorReason,
     ResolvedEntry,
     SkipReason,
@@ -52,7 +53,8 @@ from isvctl.redaction import redact_dict, redact_junit_xml_tree
 
 logger = logging.getLogger(__name__)
 
-# Platform label for a run whose config declares no commands and no capability.
+# Platform label for a run whose config declares no commands, when the requirement
+# context names no execution environment either ("core" is a context, not a platform).
 VALIDATIONS_ONLY_PLATFORM = "validations"
 
 
@@ -918,7 +920,8 @@ class Orchestrator:
         1. tests.capability (isvctl schema)
         2. Root-level platform (legacy isvtest schema)
         3. The sole commands mapping key (plain suites)
-        4. The capability context, when the config declares no commands at all
+        4. The capability context, when the config declares no commands at all,
+           falling back to ``VALIDATIONS_ONLY_PLATFORM`` for a core context
 
         Returns:
             Platform string (e.g., 'kubernetes', 'slurm', 'bare_metal') or None
@@ -934,9 +937,11 @@ class Orchestrator:
         if not platform and len(self.config.commands) == 1:
             platform = next(iter(self.config.commands))
         # A config with no commands names no platform because it drives no lifecycle.
-        # It still has an identity for logs and reports: the context it asserts under.
+        # It still has an identity for logs and reports: the environment it asserts
+        # against, when the context names one.
         if not platform and not self.config.commands:
-            platform = self._capability or VALIDATIONS_ONLY_PLATFORM
+            in_capability = self._capability in DECLARABLE_CAPABILITIES
+            platform = self._capability if in_capability else VALIDATIONS_ONLY_PLATFORM
 
         if platform:
             # Normalize 'k8s' to 'kubernetes'

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -45,7 +45,7 @@ from isvtest.core.resolution import (
 from isvtest.main import run_validations_via_pytest
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
 
-from isvctl.config.schema import RunConfig
+from isvctl.config.schema import RunConfig, StepConfig
 from isvctl.orchestrator.commands import CommandExecutor
 from isvctl.orchestrator.context import Context
 from isvctl.orchestrator.step_executor import StepExecutor, StepResults
@@ -481,40 +481,42 @@ class Orchestrator:
         """
         logger.info(f"Running in steps mode for platform: {platform}")
 
-        has_lifecycle = bool(self.config.commands)
-        if has_lifecycle:
-            config_phases = self.config.get_phases(platform)
-        else:
+        if not self.config.commands:
+            # No lifecycle to drive: the run asserts against the current system.
+            # Every question below is about the commands mapping, so all of them
+            # are answered at once here rather than guarded one at a time.
             logger.info("No commands configured; running validations only against the current system")
             config_phases = [Phase.TEST.value]
+            steps: list[StepConfig] = []
+        else:
+            config_phases = self.config.get_phases(platform)
+            if self.config.commands[platform].skip:
+                skipped_phases = _requested_config_phases(config_phases, requested_phases)
+                return OrchestratorResult(
+                    success=True,
+                    phases=[
+                        PhaseResult(
+                            phase=_phase_enum_for_name(phase_name),
+                            success=True,
+                            message=f"SKIPPED: platform '{platform}' is skipped by configuration",
+                        )
+                        for phase_name in skipped_phases
+                    ],
+                    inventory={},
+                )
 
-        if has_lifecycle and self.config.commands[platform].skip:
-            skipped_phases = _requested_config_phases(config_phases, requested_phases)
-            return OrchestratorResult(
-                success=True,
-                phases=[
-                    PhaseResult(
-                        phase=_phase_enum_for_name(phase_name),
-                        success=True,
-                        message=f"SKIPPED: platform '{platform}' is skipped by configuration",
-                    )
-                    for phase_name in skipped_phases
-                ],
-                inventory={},
-            )
-
-        steps = self.config.get_steps(platform) if has_lifecycle else []
-        if has_lifecycle and not steps:
-            return OrchestratorResult(
-                success=False,
-                phases=[
-                    PhaseResult(
-                        phase=Phase.SETUP,
-                        success=False,
-                        message=f"No steps defined for platform: {platform}",
-                    )
-                ],
-            )
+            steps = self.config.get_steps(platform)
+            if not steps:
+                return OrchestratorResult(
+                    success=False,
+                    phases=[
+                        PhaseResult(
+                            phase=Phase.SETUP,
+                            success=False,
+                            message=f"No steps defined for platform: {platform}",
+                        )
+                    ],
+                )
 
         released_tests = load_released_test_filter()
         if released_tests is None:
@@ -940,8 +942,7 @@ class Orchestrator:
         # It still has an identity for logs and reports: the environment it asserts
         # against, when the context names one.
         if not platform and not self.config.commands:
-            in_capability = self._capability in DECLARABLE_CAPABILITIES
-            platform = self._capability if in_capability else VALIDATIONS_ONLY_PLATFORM
+            platform = self._capability if self._capability in DECLARABLE_CAPABILITIES else VALIDATIONS_ONLY_PLATFORM
 
         if platform:
             # Normalize 'k8s' to 'kubernetes'

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -527,6 +527,20 @@ class Orchestrator:
         if self.config.tests and self.config.tests.validations:
             all_validations = self.config.tests.validations
         validation_entries = parse_validations(all_validations)
+        # A run with no commands has only its validations to offer, so wiring none
+        # asserts nothing. Reporting that as a pass would make a miswired -f look
+        # like a green run; a lifecycle run still has its steps to answer for.
+        if not self.config.commands and not validation_entries:
+            return OrchestratorResult(
+                success=False,
+                phases=[
+                    PhaseResult(
+                        phase=Phase.TEST,
+                        success=False,
+                        message="No validations configured: a run without commands would assert nothing",
+                    )
+                ],
+            )
         steps = _apply_capability_step_gates(steps, validation_entries, self._capability)
 
         logger.info(f"Configured phases: {config_phases}")

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -52,6 +52,9 @@ from isvctl.redaction import redact_dict, redact_junit_xml_tree
 
 logger = logging.getLogger(__name__)
 
+# Platform label for a run whose config declares no commands and no capability.
+VALIDATIONS_ONLY_PLATFORM = "validations"
+
 
 class Phase(StrEnum):
     """Test lifecycle phases."""
@@ -476,8 +479,14 @@ class Orchestrator:
         """
         logger.info(f"Running in steps mode for platform: {platform}")
 
-        config_phases = self.config.get_phases(platform)
-        if self.config.commands[platform].skip:
+        has_lifecycle = bool(self.config.commands)
+        if has_lifecycle:
+            config_phases = self.config.get_phases(platform)
+        else:
+            logger.info("No commands configured; running validations only against the current system")
+            config_phases = [Phase.TEST.value]
+
+        if has_lifecycle and self.config.commands[platform].skip:
             skipped_phases = _requested_config_phases(config_phases, requested_phases)
             return OrchestratorResult(
                 success=True,
@@ -492,8 +501,8 @@ class Orchestrator:
                 inventory={},
             )
 
-        steps = self.config.get_steps(platform)
-        if not steps:
+        steps = self.config.get_steps(platform) if has_lifecycle else []
+        if has_lifecycle and not steps:
             return OrchestratorResult(
                 success=False,
                 phases=[
@@ -909,6 +918,7 @@ class Orchestrator:
         1. tests.capability (isvctl schema)
         2. Root-level platform (legacy isvtest schema)
         3. The sole commands mapping key (plain suites)
+        4. The capability context, when the config declares no commands at all
 
         Returns:
             Platform string (e.g., 'kubernetes', 'slurm', 'bare_metal') or None
@@ -923,6 +933,10 @@ class Orchestrator:
             platform = self.config.model_extra.get("platform")
         if not platform and len(self.config.commands) == 1:
             platform = next(iter(self.config.commands))
+        # A config with no commands names no platform because it drives no lifecycle.
+        # It still has an identity for logs and reports: the context it asserts under.
+        if not platform and not self.config.commands:
+            platform = self._capability or VALIDATIONS_ONLY_PLATFORM
 
         if platform:
             # Normalize 'k8s' to 'kubernetes'

--- a/isvctl/tests/conftest.py
+++ b/isvctl/tests/conftest.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 from types import ModuleType
 
@@ -25,6 +26,11 @@ import pytest
 
 ISVCTL_ROOT = Path(__file__).resolve().parents[1]
 AWS_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts"
+
+# Typer forces rich styling under GITHUB_ACTIONS, which splices escape codes into
+# the middle of the strings CLI tests assert on. Also used to assert on styling
+# itself, so the pattern is shared rather than a strip-only helper.
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
 _LOADED_MODULES: dict[str, ModuleType] = {}
 

--- a/isvctl/tests/test_deploy_passthrough.py
+++ b/isvctl/tests/test_deploy_passthrough.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for forwarding a deploy's pytest args to the remote test run."""
+"""Tests for what a deploy forwards to the remote test run."""
 
-from isvctl.cli.deploy import _pytest_passthrough
+import pytest
+from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV
+
+from isvctl.cli.deploy import _pytest_passthrough, _remote_env_assignments
 
 
 def test_passthrough_carries_the_separator() -> None:
@@ -19,3 +22,29 @@ def test_passthrough_is_empty_without_args() -> None:
 def test_passthrough_quotes_a_multi_word_expression() -> None:
     """The remote shell must receive one -k argument, not three words."""
     assert _pytest_passthrough(["-k", "A or B"]) == "-- -k 'A or B'"
+
+
+def test_release_gate_reaches_the_remote_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without this the remote run silently skips every unreleased check."""
+    monkeypatch.delenv("NGC_NIM_API_KEY", raising=False)
+    monkeypatch.setenv("NGC_API_KEY", "secret key")
+    monkeypatch.setenv(INCLUDE_UNRELEASED_ENV, "1")
+
+    assert _remote_env_assignments() == f"NGC_API_KEY='secret key' {INCLUDE_UNRELEASED_ENV}=1"
+
+
+def test_ngc_key_alias_is_forwarded_under_the_canonical_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The target reads NGC_API_KEY, whichever name it was supplied under here."""
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv(INCLUDE_UNRELEASED_ENV, raising=False)
+    monkeypatch.setenv("NGC_NIM_API_KEY", "nim-key")
+
+    assert _remote_env_assignments() == "NGC_API_KEY=nim-key"
+
+
+def test_nothing_is_forwarded_when_nothing_is_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty assignment list must not leave a stray token on the command line."""
+    for name in ("NGC_API_KEY", "NGC_NIM_API_KEY", INCLUDE_UNRELEASED_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+    assert _remote_env_assignments() == ""

--- a/isvctl/tests/test_deploy_passthrough.py
+++ b/isvctl/tests/test_deploy_passthrough.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for forwarding a deploy's pytest args to the remote test run."""
+
+from isvctl.cli.deploy import _pytest_passthrough
+
+
+def test_passthrough_carries_the_separator() -> None:
+    """Without `--`, `test run` reads a bare pytest flag as an unknown isvctl option."""
+    assert _pytest_passthrough(["-v", "-s", "-k", "K8sNodeReadyCheck"]) == "-- -v -s -k K8sNodeReadyCheck"
+
+
+def test_passthrough_is_empty_without_args() -> None:
+    """A deploy with no pytest args leaves no dangling separator on the command line."""
+    assert _pytest_passthrough([]) == ""
+
+
+def test_passthrough_quotes_a_multi_word_expression() -> None:
+    """The remote shell must receive one -k argument, not three words."""
+    assert _pytest_passthrough(["-k", "A or B"]) == "-- -k 'A or B'"

--- a/isvctl/tests/test_deploy_reporting.py
+++ b/isvctl/tests/test_deploy_reporting.py
@@ -29,7 +29,7 @@ def test_platform_deploy_reports_its_suite_as_capability(
     platform, _ = _write_catalog(tmp_path)
     monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
 
-    assert deploy_cli._reporting_suite_and_capability([platform]) == ("vm", "vm")
+    assert deploy_cli._reporting_suite_and_capability([platform], None) == ("vm", "vm")
 
 
 def test_plain_suite_deploy_reports_no_capability(
@@ -40,7 +40,7 @@ def test_plain_suite_deploy_reports_no_capability(
     _, plain = _write_catalog(tmp_path)
     monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
 
-    assert deploy_cli._reporting_suite_and_capability([plain]) == ("storage", None)
+    assert deploy_cli._reporting_suite_and_capability([plain], None) == ("storage", None)
 
 
 def test_plain_suite_deploy_reports_the_selected_capability(

--- a/isvctl/tests/test_deploy_reporting.py
+++ b/isvctl/tests/test_deploy_reporting.py
@@ -36,8 +36,19 @@ def test_plain_suite_deploy_reports_no_capability(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A plain-suite deploy remains a core run when it has no capability option."""
+    """A plain-suite deploy with no --capability is a core run."""
     _, plain = _write_catalog(tmp_path)
     monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
 
     assert deploy_cli._reporting_suite_and_capability([plain]) == ("storage", None)
+
+
+def test_plain_suite_deploy_reports_the_selected_capability(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`--capability` changes which checks run, so the run must record it."""
+    _, plain = _write_catalog(tmp_path)
+    monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
+
+    assert deploy_cli._reporting_suite_and_capability([plain], "vm") == ("storage", "vm")

--- a/isvctl/tests/test_deploy_suite_selection.py
+++ b/isvctl/tests/test_deploy_suite_selection.py
@@ -7,7 +7,6 @@ Every case here is rejected before the archive is built, so none of them reach
 SSH.
 """
 
-import re
 from pathlib import Path
 
 import pytest
@@ -15,9 +14,9 @@ from typer.testing import CliRunner
 
 import isvctl.cli.deploy as deploy_cli
 
-runner = CliRunner()
+from .conftest import ANSI_ESCAPE
 
-_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+runner = CliRunner()
 
 
 def _write_catalog(root: Path) -> Path:
@@ -37,9 +36,7 @@ def test_unknown_option_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 
     result = runner.invoke(deploy_cli.app, ["run", "1.2.3.4", "--suite", "storage", "--bogus", "x"])
 
-    # Typer forces rich styling under GITHUB_ACTIONS, which splices escape
-    # codes into the middle of the reported option name.
-    output = _ANSI_ESCAPE.sub("", result.output)
+    output = ANSI_ESCAPE.sub("", result.output)
 
     assert result.exit_code != 0, output
     assert "No such option" in output

--- a/isvctl/tests/test_deploy_suite_selection.py
+++ b/isvctl/tests/test_deploy_suite_selection.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for deploy suite selection and its option parsing.
+
+Every case here is rejected before the archive is built, so none of them reach
+SSH.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import isvctl.cli.deploy as deploy_cli
+
+runner = CliRunner()
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _write_catalog(root: Path) -> Path:
+    """Write one platform suite and one plain suite; return the plain suite."""
+    suites = root / "suites"
+    suites.mkdir(parents=True)
+    (suites / "k8s.yaml").write_text("tests:\n  capability: kubernetes\n  validations: {}\n", encoding="utf-8")
+    plain = suites / "storage.yaml"
+    plain.write_text("tests:\n  validations: {}\n", encoding="utf-8")
+    return plain
+
+
+def test_unknown_option_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An option deploy does not have fails here instead of reaching pytest."""
+    _write_catalog(tmp_path)
+    monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
+
+    result = runner.invoke(deploy_cli.app, ["run", "1.2.3.4", "--suite", "storage", "--bogus", "x"])
+
+    # Typer forces rich styling under GITHUB_ACTIONS, which splices escape
+    # codes into the middle of the reported option name.
+    output = _ANSI_ESCAPE.sub("", result.output)
+
+    assert result.exit_code != 0, output
+    assert "No such option" in output
+    assert "--bogus" in output
+
+
+def test_suite_cannot_be_combined_with_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Two ways of naming the same thing would silently disagree."""
+    plain = _write_catalog(tmp_path)
+    monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
+
+    result = runner.invoke(deploy_cli.app, ["run", "1.2.3.4", "--suite", "storage", "-f", str(plain)])
+
+    assert result.exit_code == 1, result.output
+    assert "--suite cannot be combined with --config/-f." in result.output
+
+
+def test_unknown_suite_lists_the_available_ones(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A typo names the catalog it was looked up in."""
+    _write_catalog(tmp_path)
+    monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
+
+    result = runner.invoke(deploy_cli.app, ["run", "1.2.3.4", "--suite", "nosuch"])
+
+    assert result.exit_code == 1, result.output
+    assert "has no 'nosuch' suite" in result.output
+    assert "storage" in result.output
+
+
+def test_platform_suite_rejects_explicit_capability(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A platform suite already runs under the capability it declares."""
+    _write_catalog(tmp_path)
+    monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
+
+    result = runner.invoke(
+        deploy_cli.app,
+        ["run", "1.2.3.4", "--suite", "kubernetes", "--capability", "kubernetes"],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "--capability cannot be used with platform suite 'kubernetes'" in result.output
+
+
+def test_capability_uses_the_catalog_vocabulary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A capability no platform suite declares cannot gate anything."""
+    _write_catalog(tmp_path)
+    monkeypatch.setattr(deploy_cli, "CONFIGS_ROOT", tmp_path)
+
+    result = runner.invoke(
+        deploy_cli.app,
+        ["run", "1.2.3.4", "--suite", "storage", "--capability", "compute"],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Unknown or non-declarable capability: compute" in result.output
+
+
+def test_capability_option_reaches_the_remote_command() -> None:
+    """The remote `test run` needs the context as an option, not just in reporting."""
+    assert deploy_cli._capability_option("kubernetes") == "--capability kubernetes"
+    assert deploy_cli._capability_option(None) == ""

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -388,9 +388,16 @@ EOF
         assert teardown_phases[0].success
 
     def test_platform_detection_missing(self) -> None:
-        """Test error when platform cannot be detected."""
+        """Test error when platform cannot be detected.
+
+        Commands are present, so the run does drive a lifecycle - but nothing says
+        which one, and guessing between them would run the wrong scripts.
+        """
         config = RunConfig(
-            commands={},
+            commands={
+                "kubernetes": PlatformCommands(steps=[StepConfig(name="setup", command="echo", phase="setup")]),
+                "slurm": PlatformCommands(steps=[StepConfig(name="setup", command="echo", phase="setup")]),
+            },
             tests=ValidationConfig(),  # No platform specified
         )
         orchestrator = Orchestrator(config)
@@ -399,6 +406,31 @@ EOF
 
         assert not result.success
         assert "Cannot determine platform" in result.phases[0].message
+
+    def test_config_without_commands_runs_live_validations_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A suite config can probe an already-running system without a provider lifecycle."""
+        monkeypatch.setattr("isvctl.orchestrator.loop.load_released_test_filter", lambda: None)
+        config = RunConfig(
+            tests=ValidationConfig(
+                validations={
+                    "k8s_storage": {
+                        "checks": {
+                            "K8sCsiStorageTypesCheck": {
+                                "requires": ["kubernetes"],
+                            }
+                        },
+                    }
+                },
+            ),
+        )
+        orchestrator = Orchestrator(config)
+
+        result = orchestrator.run(phases=[Phase.TEST], capability="kubernetes")
+
+        assert result.success
+        assert [phase.phase for phase in result.phases] == [Phase.TEST]
+        assert [entry.entry.name for entry in result.validations] == ["K8sCsiStorageTypesCheck"]
+        assert result.validations[0].state is State.PASSED
 
     def test_teardown_runs_when_setup_validation_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Teardown must run when setup steps succeed but setup validations fail.

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -448,6 +448,15 @@ EOF
         assert [entry.entry.name for entry in result.validations] == ["K8sCsiStorageTypesCheck"]
         assert result.validations[0].state is State.PASSED
 
+    def test_config_without_commands_or_validations_is_not_a_pass(self) -> None:
+        """Validations are all a commandless run has, so wiring none asserts nothing."""
+        orchestrator = Orchestrator(RunConfig(tests=ValidationConfig(validations={})))
+
+        result = orchestrator.run(phases=[Phase.TEST], capability="kubernetes")
+
+        assert not result.success
+        assert "would assert nothing" in result.phases[0].message
+
     def test_teardown_runs_when_setup_validation_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Teardown must run when setup steps succeed but setup validations fail.
 

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -27,9 +27,11 @@ from isvtest.core.resolution import (
     ValidationEntry,
 )
 
+from isvctl.cli.test import CORE_REQUIREMENT_CONTEXT
 from isvctl.config.schema import PlatformCommands, RunConfig, StepConfig, ValidationConfig
 from isvctl.orchestrator.context import Context
 from isvctl.orchestrator.loop import (
+    VALIDATIONS_ONLY_PLATFORM,
     Orchestrator,
     Phase,
     _apply_capability_step_gates,
@@ -157,6 +159,20 @@ class TestOrchestrator:
 
         platform = orchestrator._detect_platform()
         assert platform == "kubernetes"
+
+    def test_commandless_run_is_identified_by_its_environment_not_its_context(self) -> None:
+        """A commandless config borrows its identity from the capability, if it names one.
+
+        ``core`` is the CLI's word for "no capability", so it names no environment
+        and must not surface as one in logs and JUnit suite names.
+        """
+        orchestrator = Orchestrator(RunConfig(tests=ValidationConfig()))
+
+        orchestrator._capability = "kubernetes"
+        assert orchestrator._detect_platform() == "kubernetes"
+
+        orchestrator._capability = CORE_REQUIREMENT_CONTEXT
+        assert orchestrator._detect_platform() == VALIDATIONS_ONLY_PLATFORM
 
     def test_run_setup_phase_success(self, tmp_path: Path) -> None:
         """Test successful setup phase execution."""

--- a/isvctl/tests/test_suite_resolution.py
+++ b/isvctl/tests/test_suite_resolution.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 
 import pytest
-from isvtest.core.resolution import DECLARABLE_CAPABILITIES
+from isvtest.core.resolution import DECLARABLE_CAPABILITIES, parse_validations
 from pydantic import ValidationError
 
 from isvctl.config.merger import merge_yaml_files
@@ -103,6 +103,16 @@ def test_storage_cleanup_steps_have_explicit_capability_gates(provider: str) -> 
 
     assert steps["teardown_volume"].requires == ["vm", "bare_metal"]
     assert steps["teardown"].requires == ["vm", "bare_metal"]
+
+
+def test_kubernetes_storage_groups_are_live_test_phase_probes() -> None:
+    """Kubernetes storage groups must also run directly on an existing cluster."""
+    config = RunConfig.model_validate(merge_yaml_files([str(CONFIGS_ROOT / "suites" / "storage.yaml")]))
+    entries = parse_validations(config.tests.validations if config.tests else {})
+    selected = [entry for entry in entries if entry.category in {"k8s_storage", "k8s_filesystem"}]
+
+    assert {entry.category for entry in selected} == {"k8s_storage", "k8s_filesystem"}
+    assert all(entry.step is None for entry in selected)
 
 
 @pytest.mark.parametrize("capability", sorted(DECLARABLE_CAPABILITIES))

--- a/isvctl/tests/test_suite_resolution.py
+++ b/isvctl/tests/test_suite_resolution.py
@@ -126,6 +126,24 @@ def test_kubernetes_storage_groups_are_live_test_phase_probes() -> None:
     assert all(entry.step is None for entry in selected)
 
 
+def test_storage_suite_supplies_the_csi_fixture_those_probes_read() -> None:
+    """The suite names its own StorageClasses, so a run needs no provider to do it.
+
+    Without this fixture the templates behind the kubernetes storage checks have
+    no producer, and the classes can only arrive through K8S_CSI_* env vars.
+    """
+    config = RunConfig.model_validate(merge_yaml_files([str(CONFIGS_ROOT / "suites" / "storage.yaml")]))
+    steps = {step.name: step for step in config.get_steps("storage")}
+
+    assert "setup_cluster" in steps, "storage.yaml no longer produces steps.setup_cluster.csi"
+    assert steps["setup_cluster"].requires == ["kubernetes"]
+    assert steps["setup_cluster"].phase == "setup"
+
+    # Both providers pair the fixture with a release; the suite they copy shows it.
+    assert steps["teardown_cluster"].requires == ["kubernetes"]
+    assert steps["teardown_cluster"].phase == "teardown"
+
+
 @pytest.mark.parametrize("capability", sorted(DECLARABLE_CAPABILITIES))
 def test_my_isv_scaffold_covers_every_declarable_capability(capability: str) -> None:
     """Every capability an ISV can declare has a my-isv platform suite to copy.

--- a/isvctl/tests/test_suite_resolution.py
+++ b/isvctl/tests/test_suite_resolution.py
@@ -112,12 +112,17 @@ def test_storage_cleanup_steps_have_explicit_capability_gates(provider: str) -> 
 
 
 def test_kubernetes_storage_groups_are_live_test_phase_probes() -> None:
-    """Kubernetes storage groups must also run directly on an existing cluster."""
+    """Kubernetes storage groups must also run directly on an existing cluster.
+
+    Binding them to a provider's cluster fixture would skip every one of them as
+    ``step_not_configured`` on a validation-only run, which is how these checks
+    are reached when the cluster is already up.
+    """
     config = RunConfig.model_validate(merge_yaml_files([str(CONFIGS_ROOT / "suites" / "storage.yaml")]))
     entries = parse_validations(config.tests.validations if config.tests else {})
     selected = [entry for entry in entries if entry.category in {"k8s_storage", "k8s_filesystem"}]
 
-    assert {entry.category for entry in selected} == {"k8s_storage", "k8s_filesystem"}
+    assert selected, "storage.yaml no longer wires the kubernetes storage groups"
     assert all(entry.step is None for entry in selected)
 
 

--- a/isvctl/tests/test_suite_resolution.py
+++ b/isvctl/tests/test_suite_resolution.py
@@ -33,17 +33,23 @@ def _write_catalog(root: Path) -> None:
     (configs / "storage.yaml").write_text("import: ../../../suites/storage.yaml\ncommands: {}\n")
 
 
-def test_one_suite_flag_resolves_platform_and_plain_suites(tmp_path: Path) -> None:
-    """The same selector resolves both suite kinds by effective YAML identity."""
+def test_one_suite_flag_resolves_canonical_and_provider_suites(tmp_path: Path) -> None:
+    """The selector resolves canonical and provider suites by effective YAML identity."""
     _write_catalog(tmp_path)
 
     platform = resolve_suite("acme", "kubernetes", configs_root=tmp_path)
     plain = resolve_suite("acme", "storage", configs_root=tmp_path)
+    canonical_platform = resolve_suite(None, "kubernetes", configs_root=tmp_path)
+    canonical_plain = resolve_suite(None, "storage", configs_root=tmp_path)
 
     assert platform.config_path.name == "eks.yaml"
     assert platform.platform == "kubernetes"
     assert plain.config_path.name == "storage.yaml"
     assert plain.platform is None
+    assert canonical_platform.config_path == tmp_path / "suites" / "k8s.yaml"
+    assert canonical_platform.platform == "kubernetes"
+    assert canonical_plain.config_path == tmp_path / "suites" / "storage.yaml"
+    assert canonical_plain.platform is None
 
 
 def test_capability_uses_catalog_vocabulary(tmp_path: Path) -> None:

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -320,7 +320,7 @@ def test_suite_without_provider_runs_the_canonical_config(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Providerless --suite selects the commandless canonical suite directly."""
+    """Providerless --suite selects the canonical suite file directly."""
     configs_root = tmp_path / "configs"
     _write_suite(configs_root, "storage.yaml", ["storage"], "K8sCsiStorageTypesCheck")
     (configs_root / "suites" / "k8s.yaml").write_text(

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -676,3 +676,30 @@ def test_pytest_args_after_separator_are_forwarded(monkeypatch: pytest.MonkeyPat
 
     assert result.exit_code == 0, result.output
     assert _FakeOrchestrator.captured["extra_pytest_args"] == ["-k", "K8sNodeCountCheck"]
+
+
+@pytest.mark.parametrize(("color", "styled"), [("yes", True), ("no", False)])
+def test_color_choice_applies_to_the_results_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    color: str,
+    styled: bool,
+) -> None:
+    """--color governs this command's output, not only the pytest args it builds.
+
+    Under `deploy` the remote stdout is a pipe, so click's auto-detection would
+    hand back an unstyled summary alongside colored pytest output.
+    """
+    config = _write_config(tmp_path)
+    _FakeOrchestrator.calls = []
+    monkeypatch.setattr(test_cli, "Orchestrator", _FakeOrchestrator)
+
+    result = runner.invoke(
+        test_cli.app,
+        ["run", "-f", str(config), "--no-upload", f"--color={color}"],
+        color=True,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert bool(_ANSI_ESCAPE.search(result.output)) is styled
+    assert _FakeOrchestrator.captured["extra_pytest_args"] == [f"--color={color}"]

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -317,6 +317,43 @@ def test_provider_without_suite_or_label_mentions_both_options(monkeypatch: pyte
     assert _FakeOrchestrator.calls == []
 
 
+def test_suite_without_provider_runs_the_canonical_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Providerless --suite selects the commandless canonical suite directly."""
+    configs_root = tmp_path / "configs"
+    _write_suite(configs_root, "storage.yaml", ["storage"], "K8sCsiStorageTypesCheck")
+    (configs_root / "suites" / "k8s.yaml").write_text(
+        "tests:\n  capability: kubernetes\n  validations: {}\n",
+        encoding="utf-8",
+    )
+    _FakeOrchestrator.calls = []
+    monkeypatch.setattr(test_cli, "CONFIGS_ROOT", configs_root)
+    monkeypatch.setattr(test_cli, "Orchestrator", _FakeOrchestrator)
+
+    result = runner.invoke(
+        test_cli.app,
+        [
+            "run",
+            "--suite",
+            "storage",
+            "--capability",
+            "kubernetes",
+            "--phase",
+            "test",
+            "--no-upload",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Selected canonical 'storage' suite." in result.output
+    assert len(_FakeOrchestrator.calls) == 1
+    assert _FakeOrchestrator.calls[0]["working_dir"] == configs_root / "suites"
+    assert _FakeOrchestrator.calls[0]["run_kwargs"]["phases"] == [Phase.TEST]
+    assert _FakeOrchestrator.calls[0]["run_kwargs"]["capability"] == "kubernetes"
+
+
 def test_plain_suite_without_capability_defaults_to_core(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -16,7 +16,6 @@
 """Tests for isvctl test CLI label filtering."""
 
 import json
-import re
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -26,9 +25,9 @@ from typer.testing import CliRunner
 import isvctl.cli.test as test_cli
 from isvctl.orchestrator.loop import OrchestratorResult, Phase, PhaseResult
 
-runner = CliRunner()
+from .conftest import ANSI_ESCAPE
 
-_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+runner = CliRunner()
 
 
 def _write_config(tmp_path: Path) -> Path:
@@ -654,7 +653,7 @@ def test_unknown_option_before_separator_is_rejected(monkeypatch: pytest.MonkeyP
 
     # Typer forces rich styling under GITHUB_ACTIONS, which splices escape
     # codes into the middle of the reported option name.
-    output = _ANSI_ESCAPE.sub("", result.output)
+    output = ANSI_ESCAPE.sub("", result.output)
 
     assert result.exit_code != 0, output
     assert "No such option" in output or "no such option" in output.lower()
@@ -701,5 +700,5 @@ def test_color_choice_applies_to_the_results_summary(
     )
 
     assert result.exit_code == 0, result.output
-    assert bool(_ANSI_ESCAPE.search(result.output)) is styled
+    assert bool(ANSI_ESCAPE.search(result.output)) is styled
     assert _FakeOrchestrator.captured["extra_pytest_args"] == [f"--color={color}"]

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -556,6 +556,17 @@ def _render_string(env: Environment, value: str, render_context: Mapping[str, An
     return env.from_string(value).render(**render_context)
 
 
+def _looked_up_in_nothing(value: Undefined) -> bool:
+    """Return whether the reference was resolved against a container with no contents.
+
+    A name missing from something empty cannot be a misspelling of what is in
+    there. A validation-only run has no steps at all, so every
+    ``steps.<name>`` is undefined by construction and the default is the
+    designed path rather than a masked mistake.
+    """
+    return isinstance(value._undefined_obj, Mapping) and not value._undefined_obj
+
+
 def _warning_default(value: Any, default_value: Any = "", boolean: bool = False) -> Any:
     """Drop-in replacement for Jinja's ``default`` filter that warns when it
     catches an Undefined value. Without this, a typo like
@@ -563,7 +574,7 @@ def _warning_default(value: Any, default_value: Any = "", boolean: bool = False)
     the default for the missing field instead of surfacing the mistake.
     """
     if isinstance(value, Undefined):
-        if value._undefined_message:
+        if value._undefined_message and not _looked_up_in_nothing(value):
             logger.warning(f"default(...) masked: {value._undefined_message}")
         return default_value
     if boolean and not value:

--- a/isvtest/tests/test_resolution.py
+++ b/isvtest/tests/test_resolution.py
@@ -444,3 +444,25 @@ def test_resolve_entries_warns_when_default_filter_masks_missing_step_field(
 
     assert "default(" in caplog.text, "default(...) wrapper should log a warning when masking Undefined"
     assert "node_count_invalid" in caplog.text, "warning must surface the missing field name"
+
+
+def test_resolve_entries_is_quiet_when_the_run_has_no_steps(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A validation-only run has no steps, so a step reference cannot be a typo.
+
+    The suites wire provider step output behind ``default(...)`` so the same
+    check also runs against a system that is already up. Warning once per
+    reference there buries the results under a page of identical lines.
+    """
+    monkeypatch.setattr(logging.getLogger("isvtest"), "propagate", True)
+
+    entry = _entry(params={"storage_class": "{{ steps.setup_cluster.csi.block_sc | default('', true) }}"})
+
+    with caplog.at_level("WARNING", logger="isvtest.core.resolution"):
+        resolved = _resolve(entry, render_context={"steps": {}})
+
+    assert resolved.rendered_params is not None
+    assert resolved.rendered_params["storage_class"] == ""
+    assert "default(" not in caplog.text


### PR DESCRIPTION
## What

#561 moved the Kubernetes storage checks from `k8s.yaml` into `storage.yaml`, and in doing so broke the way the storage team invokes them. Two commands that worked on `v0.9.0` stopped working, in ways that were quiet rather than loud. This restores both, then fixes what surfaced while verifying them.

Reported against the storage team's runs in [isv-ncp-validation-suite-mirror!18](https://gitlab-master.nvidia.com/nsvis/storage/storage-control-plane/thirdparty/isv-ncp-validation-suite-mirror/-/merge_requests/18).

## The two regressions

**A commandless suite could not run at all.** `storage.yaml` declares no `commands:`, so `-f isvctl/configs/suites/storage.yaml` died with `Cannot determine platform from configuration` before a single check ran. `_run_steps_mode` assumed a lifecycle: it indexed `commands[platform]` and required steps. A config with no commands drives no lifecycle, so only the test phase applies, and its identity comes from the capability it asserts under rather than from a command group. `core` is the CLI's word for "no capability", so it names no environment and must not surface as one -- that case gets `VALIDATIONS_ONLY_PLATFORM`.

**The moved checks then skipped themselves.** In `storage.yaml` the `k8s_storage` and `k8s_filesystem` groups gained `step: setup_cluster`, so all 14 skipped as `step_not_configured` whenever no provider supplied that fixture -- which is exactly the case when you `-f` the suite against a cluster that is already up. They carried no `step:` in `k8s.yaml` before #561, so this restores the previous wiring; the templates already read `steps.setup_cluster.csi.*` behind `| default('', true)`, and `requires: [kubernetes]` on both the checks and the fixture step keeps the gating intact. A test pins the absence so the tempting re-binding cannot silently return.

## Found while verifying

**`deploy run` dropped its pytest args.** `deploy run ... -- -v -s -k Check` appended them straight onto the remote `isvctl test run` with no `--` of its own. That only worked while `test run` swallowed unknown options; b4d7c74 made it reject them, so every deploy carrying pytest args died on `No such option: -s`.

**`deploy run` never forwarded the release gate.** `sudo -E` preserves the target's environment, not the caller's, so `ISVTEST_INCLUDE_UNRELEASED=1 isvctl deploy run ...` applied the gate remotely anyway and silently ran nothing for an unreleased check. The storage team's checks were unreleased when they wrote those runs.

**`deploy run` accepted unknown options.** It was the last command still doing so, so `--suite kubernetes` -- a flag it did not have -- was folded into the pytest passthrough instead of rejected. It now has `--suite` and `--capability`, resolved before the archive is built, and `--capability` reaches reporting: deriving it from the config alone recorded `storage` as a core run while the Kubernetes checks executed.

**27 identical warnings per validation-only run.** The custom `default(...)` filter warns whenever it swallows an Undefined, to stop a typo like `steps.setup.node_cout` reading as a legitimately empty value. With no steps at all, every `steps.<name>` is undefined by construction. A name missing from an empty container cannot be a misspelling of what is in there, so that case is now quiet; looking into something that has contents and missing still warns.

**`--color` applied only to pytest.** Under `deploy` the remote stdout is a pipe, so a log showed colored pytest output beside an unstyled summary -- the same check reading `PASSED` twice, once green and once not.

## Testing

`make test` (1454 isvctl + 1310 isvtest + 58 isvreporter + 124 script), `make lint`, `make demo-test`, `validate_suite_wiring.py --check` and `uvx pre-commit run -a` all pass.

Verified against a real multi-node lab through a jumphost, not only in unit tests:

- `deploy run --suite storage --capability kubernetes -- -v -s -k "K8sNodeKernelModules or K8sNfsMountOptions"` -> both selected, `K8sNodeKernelModulesCheck` genuinely probed 4 nodes, `Including unreleased validations because ISVTEST_INCLUDE_UNRELEASED is enabled` confirming the forwarding, zero masked-default warnings.
- The originally broken `-k "K8sNfsMountOptionsCheck or K8sCsiStorageTypesCheck"` now selects and runs both.
- `K8sCsiStorageTypesCheck` provisioning and binding a real PVC on a `WaitForFirstConsumer` StorageClass.
- The regression reproduced on the parent commit first, so each fix is tied to a failure it removes.

Warning counts measured across every plain suite in core/vm/kubernetes and every `my-isv` demo config: 27 before, 0 after, with the 4 real ones intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct canonical-suite execution without selecting a provider.
  * Remote deploy now supports `--suite`/`--capability` and forwards pytest args provided after `--`.
  * Added “validations-only” runs when no lifecycle commands are configured.
  * Kubernetes CSI inventory output now includes `static_volume_az`.
* **Bug Fixes**
  * Storage validations now run as live probes without provider-step dependencies.
  * Improved suite/capability resolution and earlier rejection of invalid CLI flag combinations.
  * Reduced noisy resolver warnings for runs with no step outputs.
* **Documentation**
  * Updated guides and examples for canonical-suite usage, remote deployment, and configuration flow.
* **Tests**
  * Expanded coverage for suite selection, passthrough, reporting, orchestrator behavior, and resolver warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->