### PR TITLE
feat: add storage provider shim and manifest discovery

### DIFF
--- a/.cursor/skills/storage-api-stub-authoring/SKILL.md
+++ b/.cursor/skills/storage-api-stub-authoring/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: storage-api-stub-authoring
+description: >-
+  Guides implementation of Storage Provider shims in-place under
+  isvctl/configs/providers/my-isv/ — fill TODO blocks in scripts/storage/api.py
+  and edit storage-provider-manifest.yaml. Does not copy to new provider dirs
+  or scaffold full provider trees. Walks through each method with pointed
+  questions and runs isolated sanity probes. Use when the user mentions storage
+  shim, StorageApi, storage-provider-manifest, StorageProviderApiCheck, or
+  storage provider stubs.
+compatibility: >-
+  Requires this repo. Run commands from repo root after `uv sync`. Live
+  probes need network/credentials the user grants (kubectl, cloud APIs, VMS
+  REST).
+---
+
+# Storage API Stub Authoring
+
+Interactive workflow for implementing a provider's storage shim. Follow
+this skill end-to-end; do not skip intake or sanity gates.
+
+## Scope boundaries (read first)
+
+**Default workspace:** `isvctl/configs/providers/my-isv/`
+
+Implement by **filling in the existing stubs** — replace `TODO` blocks in
+`scripts/storage/api.py` and update the sibling manifest. **Do not** `cp` or
+`cp -r` my-isv to `providers/<customer>/` unless the user explicitly requests
+a separate handoff folder.
+
+| In scope (my-isv) | Path |
+| ----------------- | ---- |
+| Required | `scripts/storage/api.py` — edit `MyStorageApi` TODO blocks in place |
+| Required | `config/storage-provider-manifest.yaml` |
+| Harness (exists) | `config/storage.yaml` — tweak in place if needed for tests |
+| Optional | `scripts/storage/README.md` (document env vars when stub is done) |
+
+AWS/VAST/weka paths under `providers/aws/`, `providers/vast/`, etc. are
+**read-only references** — study them; do not copy their layout into new dirs.
+
+**Out of scope — do not create, copy, or edit unless the user explicitly asks:**
+
+- New provider directories (`providers/<customer>/`)
+- Other `config/*.yaml` or `scripts/**` trees in my-isv (if any exist)
+- Full-provider scaffold (`cp -r my-isv …`)
+
+K8s `manifest_path` overrides in external eks configs are optional test wiring
+only when the user wants k8s-integrated runs beyond `my-isv/config/storage.yaml`.
+
+## Outcomes
+
+By session end the user should have:
+
+1. `config/storage-provider-manifest.yaml` declaring the provider and pointing at the shim
+2. `scripts/storage/.../api.py` implementing `StorageApi` + `build_api()`
+3. Documented env vars in `scripts/storage/README.md` (when stub is complete)
+4. Passing isolated probes (`probe_shim.py`) before any full `isvctl test run`
+5. *(Optional, on request)* `manifest_path` wired into `storage.yaml` or a k8s override
+
+## Reference implementations (read before coding)
+
+| Backend | Shim | Manifest | Config |
+| ------- | ---- | -------- | ------ |
+| AWS FSx Lustre | `isvctl/configs/providers/aws/scripts/storage/fsx-lustre/api.py` | `aws/config/storage-provider-manifest.yaml` | `aws/config/eks.yaml` |
+| VAST NFS | `isvctl/configs/providers/vast/scripts/storage/vast/api.py` | `vast/config/storage-provider-manifest.yaml` | `vast/config/storage.yaml` |
+| WEKA | `isvctl/configs/providers/weka/scripts/storage/weka/api.py` | `weka/config/storage-provider-manifest.yaml` | `weka/config/storage.yaml` |
+| **Authoring target (edit in place)** | `my-isv/scripts/storage/api.py` | `my-isv/config/storage-provider-manifest.yaml` | `my-isv/config/storage.yaml` |
+
+Contract: `isvtest/src/isvtest/core/storage_provider/api.py` (per-method
+docstrings cover inputs/outputs, error conditions, and capability/qualifier semantics)
+Check drivers:
+- `isvtest/src/isvtest/validations/storage_provider.py` (`StorageProviderApiCheck`)
+- `isvtest/src/isvtest/validations/storage_quota_enforcement.py`
+  (`StorageDirectoryQuotaEnforcementCheck` — live CRUD + write enforcement; needs K8s)
+
+Manifest (schema v1alpha2):
+
+- Schema: `isvctl/schemas/storage-provider-manifest.schema.json`
+- Fully-populated example: `my-isv/config/storage-provider-manifest.example.yaml`
+- Manifest → step adapter: `isvctl/configs/providers/shared/storage_manifest_to_steps.py`
+  (parses the manifest, loads no shim; drives the k8s suite via `storage-k8s.yaml`)
+
+## Session workflow
+
+Copy this checklist and update as you go:
+
+```text
+Progress:
+- [ ] Phase 0: Intake + environment permission (discover what's there)
+- [ ] Phase 1: Confirm my-isv files
+- [ ] Phase 2: Generate manifest (discover + Q&A) + config wiring
+- [ ] Phase 3: Implement StorageApi methods (one at a time)
+- [ ] Phase 4: Isolated sanity probes
+- [ ] Phase 5: Targeted StorageProviderApiCheck run
+- [ ] Phase 6: Full suite guidance (optional)
+```
+
+---
+
+## Phase 0: Intake and environment access
+
+**Ask permission before any discovery command.** If granted, run probes
+from repo root. If denied, ask the user to paste command output.
+
+Work through [intake-questions.md](references/intake-questions.md) first.
+Summarize answers in a short "Implementation profile" before writing code.
+
+### Environment discovery (when permitted)
+
+Discovery is the **first half of manifest generation**: probe the cluster/API to
+propose field values, then confirm the rest by Q&A. The full discover-vs-ask
+mapping for every manifest field is in
+[manifest-generation.md](references/manifest-generation.md).
+
+**Kubernetes** (adjust namespace/context as needed):
+
+```bash
+kubectl config current-context
+kubectl get storageclass -o wide
+kubectl get sc <sc-name> -o yaml    # provisioner, parameters, mountOptions
+kubectl get csidriver
+kubectl get nodes --show-labels    # -> node_selector for the CSI/filesystem checks
+kubectl get pods -A | grep -i csi  # driver health hint + which nodes run node plugin
+```
+
+Map findings into the **v1alpha2 manifest** (which drives
+`StorageProviderApiCheck` ONLY):
+
+- `providers[].provider.*` / `identity.*` (infer vendor/protocol/type from the
+  driver; ask for version)
+- `providers[].capabilities.*` (what the shim's `properties()` reports)
+- `providers[].shim.*` (module path / configmap / credentials_secret)
+
+The StorageClass names, NFS expectations, and node selectors are NOT in the
+manifest: the CSI / filesystem checks (`K8sCsiStorageTypesCheck`,
+`K8sCsiDriverHealthCheck`, `K8sFile*`, `K8sNfsMountOptionsCheck`, …) read them
+from the suite/provider config or the `K8S_CSI_*` env vars (see
+[config-wiring.md](references/config-wiring.md)).
+
+**Network locality:** If the management API is only reachable in-cluster (VAST VMS pattern), note that `isvctl deploy run` may be required instead of laptop-side `isvctl test run`.
+
+---
+
+## Phase 1: Work in my-isv
+
+Open the existing files — they already contain `TODO` markers and `DEMO_MODE`:
+
+```text
+isvctl/configs/providers/my-isv/
+├── config/storage-provider-manifest.yaml   # shim.module → ../scripts/storage/api.py
+├── config/storage.yaml                     # manifest_path already set
+└── scripts/storage/api.py                  # MyStorageApi — fill each TODO block
+```
+
+**Do not** create `providers/<customer>/` or copy these files elsewhere unless prompted by the user.
+
+Before coding:
+
+1. Read `scripts/storage/api.py` end-to-end — every method has a `TODO` block to replace
+2. Read AWS/VAST reference shims for patterns matching intake answers
+3. Update `config/storage-provider-manifest.yaml` (v1alpha2): `providers[].name`, `identity`/`provider`, `shim`, `capabilities` — see [manifest-generation.md](references/manifest-generation.md)
+4. Keep `shim.module: ../scripts/storage/api.py` (flat my-isv layout)
+5. Keep `DEMO_MODE` until real backend calls land — enables smoke without credentials
+
+Rename `MyStorageApi` / `properties()` identity fields to match the backend; keep
+`build_api()` at module level.
+
+---
+
+## Phase 2: Manifest generation and config wiring
+
+Generate `config/storage-provider-manifest.yaml` (schema **v1alpha2**) using the
+**discover-then-ask** workflow in
+[manifest-generation.md](references/manifest-generation.md): probe the
+environment to propose field values, ask the customer for what you can't
+observe, and omit (don't guess) anything still unknown so the dependent check
+skips cleanly. Then wire `manifest_path` into a test config **only when the user
+wants to run checks** — see [config-wiring.md](references/config-wiring.md).
+
+Two files ship beside the template — use them as you fill the blank one:
+
+- `config/storage-provider-manifest.yaml` — blank template to edit in place
+- `config/storage-provider-manifest.example.yaml` — fully-populated v1alpha2 reference (every field)
+
+**The manifest is a contract, not docs.** For providers with a `shim:` block,
+`StorageProviderApiCheck` cross-checks declared `identity`/`capabilities` against
+the running shim and **fails on mismatch** (`manifest-consistency[<name>]`). Only
+declare what the shim actually reports; omit a field to leave it unchecked.
+
+**Validate the draft without a backend** (parses the manifest, loads no shim):
+
+```bash
+STORAGE_PROVIDER_MANIFEST=isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml \
+  uv run python isvctl/configs/providers/shared/storage_manifest_to_steps.py | uv run python -m json.tool
+```
+
+**Critical couplings:**
+
+| Artifact | Purpose |
+| -------- | ------- |
+| `shim.module` | Relative to manifest parent; must resolve to `api.py` with `build_api()` |
+| `manifest_path` in provider YAML | Path passed to `StorageProviderApiCheck` (on-disk now; ConfigMap mount path in prod) |
+| Env vars in shim `__init__` | Runtime config — manifest `attributes` are **informational only** |
+| `K8S_CSI_*` env vars / config overrides | StorageClass names for the CSI/filesystem checks — set in config/env, NOT the manifest |
+
+**K8s override pattern** (from `aws/config/eks.yaml`):
+
+```yaml
+tests:
+  validations:
+    k8s_storage:
+      checks:
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml"
+```
+
+**ConfigMap handoff** (document for customer, do not implement operator):
+
+- Manifest → ConfigMap `storage-provider-manifest`, key `manifest.yaml`
+- Shim `api.py` → per-provider ConfigMap referenced by `shim.configmap`
+- Credentials → per-provider Secret; env vars at runtime
+
+---
+
+## Phase 3: Implement methods (one at a time)
+
+Follow [method-walkthrough.md](references/method-walkthrough.md). **Implement and
+probe each method before moving on.** Ask the pointed questions listed there.
+
+### Decision tree: volume lifecycle
+
+```text
+Does a CSI driver dynamically provision PVCs on this cluster?
+├─ YES (managed K8s — AWS FSx, VAST, WEKA pattern)
+│    → create_volume / delete_volume raise NotSupportedError
+│    → list_volumes MUST return existing CSI-provisioned volumes (count ≥ 1 for N-020 pass)
+│    → Populate Volume.csi (driver + volume_handle) when discoverable
+└─ NO (bare-metal / API-managed storage)
+     → Implement create_volume + delete_volume
+     → Tag volumes with isvtest-run-id for orphan sweep
+```
+
+### ProviderProperties
+
+Declare capabilities honestly in `storage-provider-manifest.yaml`, and implement
+only the corresponding methods in `scripts/storage/api.py`. `new_implementation()`
+detects which surfaces are backed and advertises the merged capability set.
+Directory-quota shims should also exercise
+`StorageDirectoryQuotaEnforcementCheck` under a K8s config (optional
+`pvc_name` / `pod_name` reuse for faster iteration — see provider READMEs).
+
+---
+
+## Phase 4: Isolated sanity probes
+
+Run **before** full suite. Order matters.
+
+### 4a. Manifest loads
+
+```bash
+uv run python -c "
+from isvtest.core.storage import load_provider_registry
+ps = load_provider_registry({'manifest_path': 'isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml'})
+print([p.name for p in ps if p.has_shim])
+"
+```
+
+### 4b. Shim probe script
+
+```bash
+uv run python .cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py \
+  --manifest isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml
+```
+
+Expect: `health_check` ok, `get_tenant_quota` with `hard_limit_bytes > 0`, and either
+`create_volume` path or `list_volumes` returning ≥1 volume (CSI fallback).
+
+### 4c. Backend-specific CLI probes
+
+Use patterns from the reference READMEs:
+
+- **AWS:** `aws sts get-caller-identity`, `aws fsx describe-file-systems`, `aws service-quotas get-service-quota`
+- **VAST:** `curl -H "Authorization: Api-Token $VAST_TOKEN" "https://$VAST_ENDPOINT/api/quotas/"`
+- **Generic:** whatever authenticated GET the shim's `health_check` uses
+
+### 4d. Demo mode smoke (no credentials, optional)
+
+Uses the existing `my-isv/config/storage.yaml` harness:
+
+```bash
+ISVCTL_DEMO_MODE=1 ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run -f isvctl/configs/providers/my-isv/config/storage.yaml
+```
+
+### 4e. Contract / validation unit tests
+
+```bash
+# Shim contract package (ABC, loader, mock)
+uv run pytest isvtest/src/isvtest/core/storage_provider/tests/
+
+# StorageProviderApiCheck behavior (framework tests)
+uv run pytest isvtest/tests/test_storage_provider.py
+
+# Provider-specific hermetic shim tests, when added:
+uv run pytest isvtest/tests/test_aws_fsx_lustre_shim.py
+uv run pytest isvtest/tests/test_weka_shim.py
+uv run pytest isvtest/tests/test_storage_quota_enforcement.py
+```
+
+**Gate:** Do not proceed to Phase 5 until 4a–4c pass (4d acceptable during scaffolding).
+
+---
+
+## Phase 5: Targeted acceptance check (optional)
+
+Run only when the user wants end-to-end `StorageProviderApiCheck` validation.
+Requires an existing `storage.yaml` or a k8s config with `manifest_path` set.
+
+```bash
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run -f isvctl/configs/providers/my-isv/config/storage.yaml
+```
+
+For K8s-integrated runs, add a `StorageProviderApiCheck` override to the
+provider's **existing** eks/k8s config — do not create a new full provider tree.
+
+**Expected CSI fallback (not a failure):**
+
+```text
+volume-provisioning[<name>] SKIPPED: create_volume not implemented; observed N CSI-provisioned volume(s)
+```
+
+**Common failures → fixes:**
+
+| Symptom | Fix |
+| ------- | --- |
+| `Skipping unreleased validation 'StorageProviderApiCheck'` | Set `ISVTEST_INCLUDE_UNRELEASED=1` |
+| `AuthenticationError` on health_check | Fix creds / network / IAM |
+| `hard_limit_bytes=0` | Wrong quota source or empty tenant |
+| `observed 0 ... via list_volumes` | Create a PVC against the StorageClass first |
+| Manifest not found | Run from repo root; fix `manifest_path` |
+
+---
+
+## Phase 6: Full suite (optional)
+
+Only after Phase 5 passes. Import the storage suite
+(`isvctl/configs/suites/storage.yaml`, often alongside `suites/k8s.yaml`) and align:
+
+- StorageClass names via the `K8S_CSI_*` env vars (`K8S_CSI_BLOCK_SC`,
+  `K8S_CSI_SHARED_FS_SC`, `K8S_CSI_NFS_SC`) or literal
+  overrides in your config — these are NOT in the manifest
+- `k8s_storage` CSI checks beyond the shim: `K8sCsiStorageTypesCheck`, `K8sCsiStorageQuotaApiCheck`, `K8sCsiProvisioningModesCheck`, `K8sCsiConcurrentPvcCheck`, `K8sCsiPvcExpandCheck`, `K8sCsiDriverHealthCheck`
+- `k8s_filesystem` checks (`K8sFileLockingCheck`, `K8sCrossNodeWriteVisibilityCheck`, …) and `node_selector` (literal dict) when CSI requires labeled nodes
+
+```bash
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run -f isvctl/configs/providers/my-isv/config/<k8s-or-storage-config>.yaml
+```
+
+---
+
+## Agent behavior rules
+
+1. **Edit my-isv in place** — fill `scripts/storage/api.py` TODO blocks; never `cp -r my-isv` to a new provider dir unless the user explicitly asks for handoff.
+2. **One method at a time** — implement `properties` + `__init__`, then `health_check`, then `get_tenant_quota`, then volume methods.
+3. **Ask before assuming** — especially CSI vs API provisioning, tenant model, quota semantics.
+4. **Match reference style** — env-driven config, tight IAM/API surface, `NotSupportedError` for CSI-owned lifecycle.
+5. **Do not edit** `isvtest/src/isvtest/released_tests.json`.
+6. **Do not add setup scripts** — this skill does not author provider orchestration steps.
+7. **Document env vars** in `scripts/storage/README.md` when the stub is done (in-scope).
+8. **Test harness on request** — create `storage.yaml` or k8s `manifest_path` overrides only when the user wants to run checks.
+
+## Additional resources
+
+- [manifest-generation.md](references/manifest-generation.md) — discover-then-ask, field-by-field manifest authoring (v1alpha2)
+- [intake-questions.md](references/intake-questions.md) — upfront questionnaire
+- [method-walkthrough.md](references/method-walkthrough.md) — per-method questions and acceptance criteria
+- [config-wiring.md](references/config-wiring.md) — manifest, overrides, CSI, ConfigMap
+- [AWS stub implementation](../../../isvctl/configs/providers/aws/scripts/storage/fsx-lustre/api.py)
+- [VAST stub implementation](../../../isvctl/configs/providers/vast/scripts/storage/vast/api.py)
+- [WEKA stub implementation](../../../isvctl/configs/providers/weka/scripts/storage/weka/api.py)

--- a/.cursor/skills/storage-api-stub-authoring/references/config-wiring.md
+++ b/.cursor/skills/storage-api-stub-authoring/references/config-wiring.md
@@ -1,0 +1,193 @@
+# Config wiring
+
+How manifest, shim, and (optionally) test harness connect.
+
+## Scope
+
+**Default workspace:** `isvctl/configs/providers/my-isv/`
+
+Edit in place — fill `scripts/storage/api.py` TODO blocks and update
+`config/storage-provider-manifest.yaml`. Do not copy to `providers/<name>/`
+unless the user explicitly requests a handoff folder.
+
+**Test harness:** `my-isv/config/storage.yaml` already exists and points at the
+manifest. Tweak in place; or add a `manifest_path` override in an external k8s
+config only when the user wants k8s-integrated runs.
+
+## Two-artifact model
+
+```text
+config/storage-provider-manifest.yaml     # discovery — lists providers
+        │
+        │ providers[].shim.module (relative path)
+        ▼
+scripts/storage/api.py                    # MyStorageApi + build_api() (my-isv flat layout)
+```
+
+`StorageProviderApiCheck` reads `manifest_path` → loads each Python shim → runs storage api tests.
+
+## manifest_path sources
+
+| Mode | `manifest_path` value |
+| ---- | --------------------- |
+| Standalone (`storage.yaml`) | Repo-relative path to manifest on disk |
+| K8s provider override (`eks.yaml`) | Same on-disk path for dev; mounted ConfigMap path in prod |
+| Suite default (`k8s.yaml`) | `{{ steps.setup.storage.manifest_path \| default('', true) }}` — empty skips check |
+
+**Empty manifest_path = check skipped (pass).** Onboarded providers must override.
+
+## Provider YAML patterns
+
+### Standalone storage validation
+
+Use the existing `my-isv/config/storage.yaml` (update in place if needed):
+
+```yaml
+commands:
+  storage:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      - name: preflight
+        phase: setup
+        command: "echo"
+        args: ['{"success": true, "platform": "storage", "test_name": "preflight"}']
+
+tests:
+  platform: storage
+  validations:
+    storage_provider_api:
+      checks:
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml"
+          volume_size_bytes: 1073741824
+```
+
+### K8s-integrated override
+
+See `aws/config/eks.yaml` — imports `suites/k8s.yaml` + `suites/storage.yaml`, overrides:
+
+```yaml
+tests:
+  validations:
+    k8s_storage:
+      checks:
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml"
+```
+
+## Manifest entry fields (schema v1alpha2)
+
+For the full discover-vs-ask, field-by-field walkthrough see
+[manifest-generation.md](manifest-generation.md). Summary shape:
+
+```yaml
+schema_version: v1alpha2
+providers:
+  - name: <unique-provider-name>       # subtest tag (derived from identity.provider.id if omitted)
+    type: file                          # or block (derived from identity.storage_type if omitted)
+    tenant_id: <optional-default>       # omit if shim resolves at runtime; quote numeric IDs
+
+    identity:                           # static handoff identity (contract for shim providers)
+      provider: { domain: <dns>, id: <label>, version: <semver> }
+      backend: { vendor: <name>, version: <ver> }   # optional
+      storage_type: file                # file | block
+      storage_protocol: nfsv4           # lustre | nfsv4 | nfsv3 | smb | nvme | iscsi | ...
+
+    shim:                               # omit entirely for providers with no mgmt API
+      kind: python
+      module: ../scripts/storage/api.py
+
+    capabilities:                        # CONTRACT for shim providers (source of truth; probed at runtime)
+      tenantManagement: native|default|none      # or { list, get, getQuota }
+      volumeManagement:                          # state, or per-leaf:
+        list: native|default|none
+        get: native|default|none
+        create: native|default|none
+        delete: native|default|none
+      quotaManagement: native|default|none       # or { directory: {...}, user: {...} }
+
+    attributes:                          # informational — shim reads env vars
+      <key>: <value>
+```
+
+`shim.module` resolves relative to the manifest file's parent directory.
+`v1alpha1` manifests still load. Declared `identity`/`capabilities` are
+cross-checked against the live shim and **fail on mismatch** — only declare what
+the shim reports, or omit to skip the check. The manifest drives
+`StorageProviderApiCheck` ONLY; it carries no CSI / topology / protocol data.
+
+## CSI / filesystem alignment (config-driven, not from the manifest)
+
+The `k8s_storage` CSI checks and `k8s_filesystem` checks are config-driven, like
+every other suite check — they do NOT read the storage manifest. Checks in
+`isvctl/configs/suites/storage.yaml` include `K8sCsiStorageTypesCheck`,
+`K8sCsiStorageQuotaApiCheck`, `K8sCsiTenantScopedCredentialsCheck`,
+`K8sCsiProvisioningModesCheck`, `K8sCsiConcurrentPvcCheck`,
+`K8sCsiPvcExpandCheck`, `K8sCsiDriverHealthCheck`, and the `K8sFile*` /
+`K8sNfsMountOptionsCheck` / `K8sNodeKernelModulesCheck` filesystem checks.
+
+Set their StorageClass names via the `K8S_CSI_*` env vars (the suite templates
+read these), or as literal overrides in a provider `storage-k8s.yaml`.
+Resolution order is **explicit YAML → `K8S_CSI_*` env var → skip**.
+
+Env vars (one per role):
+
+- `K8S_CSI_BLOCK_SC`
+- `K8S_CSI_SHARED_FS_SC`
+- `K8S_CSI_NFS_SC`
+
+NFS mount-option expectations (`K8sNfsMountOptionsCheck`), `node_selector`, and
+`kernel_modules` (`K8sNodeKernelModulesCheck`) are likewise literal values in the
+config (a check skips when its inputs are unset). See
+`isvctl/configs/providers/vast/config/storage-k8s.yaml` for an example that sets
+the VAST NFS expectations and documents the `K8S_CSI_*` exports.
+
+**Agent task:** After `kubectl get storageclass`, map SC names into the
+`K8S_CSI_*` env vars (or literal overrides in the provider `storage-k8s.yaml`).
+The storage manifest stays focused on the shim contract.
+
+## Directory-quota enforcement check
+
+`StorageDirectoryQuotaEnforcementCheck` (suite `k8s_storage`) needs a reachable
+cluster and a shared-fs StorageClass (or an existing PVC). Optional reuse keys
+avoid re-provisioning on every iteration:
+
+| Key | Effect |
+| --- | ------ |
+| `pvc_name` / `pvc_namespace` | Reuse a bound RWX PVC |
+| `pod_name` | Reuse a Ready pod that mounts that PVC at `/data` (requires `pvc_name`) |
+
+See `vast/scripts/storage/README.md` or `weka/scripts/storage/README.md` for
+override YAML examples.
+
+## ConfigMap / Secret handoff (production)
+
+Document for customer ops; validation suite reads files directly in Phase 1a.
+
+| K8s object | Content | Default name |
+| ---------- | ------- | ------------ |
+| ConfigMap | `manifest.yaml` | `storage-provider-manifest` |
+| ConfigMap | `api.py` (+ optional `config.yaml`) | provider-chosen per provider |
+| Secret | API token / cloud creds | provider-chosen per provider |
+
+Runtime: mount manifest → set `manifest_path` to mount path; inject Secret as env vars the shim reads.
+
+## Unreleased check gate
+
+`StorageProviderApiCheck` is unreleased. Always:
+
+```bash
+ISVTEST_INCLUDE_UNRELEASED=1
+```
+
+Without it, orchestrator logs `Skipping unreleased validation 'StorageProviderApiCheck'`.
+
+## Demo mode
+
+While scaffolding:
+
+```bash
+ISVCTL_DEMO_MODE=1
+```
+
+Shim returns dummy data; useful before real API credentials exist.

--- a/.cursor/skills/storage-api-stub-authoring/references/intake-questions.md
+++ b/.cursor/skills/storage-api-stub-authoring/references/intake-questions.md
@@ -1,0 +1,141 @@
+# Intake questionnaire
+
+Ask these **before** writing code. Batch related questions; skip sections that
+don't apply (e.g. skip K8s block for bare-metal-only).
+
+Record answers in an "Implementation profile" the user can confirm.
+
+## Default workspace (read first)
+
+**Implement in place under `isvctl/configs/providers/my-isv/`** — do not copy
+files to a new provider directory unless the user explicitly asks for a separate
+handoff folder (e.g. `providers/weka/`).
+
+| File | Action |
+| ---- | ------ |
+| `scripts/storage/api.py` | Replace `TODO` blocks in the existing `MyStorageApi` class |
+| `config/storage-provider-manifest.yaml` | Update `providers[]`, `shim.module`, `csi`, `attributes` |
+| `config/storage.yaml` | Already wired; tweak `manifest_path` only if paths change |
+| `scripts/storage/README.md` | Document env vars when the stub is complete |
+
+Read AWS/VAST shims as **reference patterns only** — do not copy them into new
+paths. The flat `my-isv/scripts/storage/api.py` layout is the authoring target.
+
+**Scope reminder:** intake informs the manifest + `api.py` in `my-isv` only.
+Do not plan network/vm/k8s provider scaffolding unless the user explicitly
+expands scope.
+
+---
+
+## A. Customer and deployment context
+
+1. **Provider identity** — `providers[].name` and `properties()` values for this
+   backend (stays in `my-isv`; not a new directory slug).
+2. **Storage product** — vendor + protocol (NFS, Lustre, block, …)?
+3. **Deployment model**
+   - Managed Kubernetes (CSI provisions PVCs)?
+   - Bare-metal / standalone management host?
+   - Hybrid (K8s + external management API)?
+4. **Run StorageProviderApiCheck now?** If yes, use existing
+   `my-isv/config/storage.yaml` (update in place if needed).
+5. **Can I run discovery commands?** (kubectl, cloud CLI, curl to management API)
+   - If yes: which context/credentials are available?
+   - If no: ask user to paste `kubectl get sc`, management API sample response
+6. **Separate provider folder?** Default **no** — only create
+   `providers/<name>/` when the user explicitly wants a production handoff copy.
+
+---
+
+## B. CSI and volume lifecycle (drives create/delete vs list)
+
+7. **Is storage managed by a CSI driver on the target cluster?**
+   - If yes → `create_volume` / `delete_volume` → `NotSupportedError` (AWS/VAST pattern)
+   - If no → implement full create/delete lifecycle
+8. **CSI driver name** (`provisioner` field) — e.g. `fsx.csi.aws.com`, `scp.weka.io`
+9. **StorageClass name(s)** to validate — set via the `K8S_CSI_*` env vars / config overrides (not the manifest)
+10. **Volume handle format** in PV `spec.csi.volumeHandle` — ID vs path vs UUID?
+11. **Are any CSI-provisioned volumes already present?** CSI fallback needs ≥1 visible volume
+12. **fsType and mount options** the driver expects (for future mount checks)
+
+---
+
+## C. Management API and tenancy
+
+13. **Management API type** — REST, cloud SDK (boto3), CLI wrapper, gRPC?
+14. **Endpoint URL** — reachable from where tests run (laptop vs in-cluster runner pod)?
+15. **Authentication** — API token, basic auth, IAM/IRSA, OAuth?
+16. **Tenant isolation model**
+    - AWS account ID (STS)?
+    - Named tenant header (VAST `X-Tenant-Name`)?
+    - Organization name (WEKA)?
+    - Project/subscription/SVM ID?
+17. **Single-tenant or multi-tenant?** Multi → one manifest `providers[]` entry per tenant/path
+18. **Default tenant** — env var name (e.g. `STORAGE_TENANT_ID`, map in `__init__`)
+
+---
+
+## D. Quota semantics (get_tenant_quota)
+
+19. **Where does `hard_limit_bytes` come from?**
+    - Service quota (AWS)?
+    - Parent directory quota (VAST root path)?
+    - Filesystem budget (WEKA `total_budget`)?
+    - License/capacity pool?
+20. **What metric is `used_bytes`?** Allocated vs consumed vs effective
+21. **Minimum quota** — must be > 0 for N-021 to pass
+22. **Storage root path** — e.g. `VAST_STORAGE_PATH`, WEKA filesystem name, export path
+
+---
+
+## E. Volume inventory (list_volumes)
+
+23. **How are volumes enumerated?** API list, quota tree children, filesystem IDs, CRD inventory
+24. **Volume ID format** — stable identifier returned to callers
+25. **Tag/label support?** If none, `tag_filters` never match (VAST pattern)
+26. **State mapping** — backend states → `creating` | `available` | `failed` | `deleting`
+27. **Cross-tenant leakage** — must never return volumes outside resolved tenant
+
+---
+
+## F. Future capabilities (document now, implement later)
+
+28. **Directory quotas** — supported? Lustre-style vs VAST-style semantics?
+29. **User quotas** — supported?
+30. **Block storage** — separate provider entry with `type: block`?
+
+---
+
+## G. K8s config alignment
+
+31. **Which k8s suite config** will import? (`isvctl/configs/suites/k8s.yaml` via a provider `storage-k8s.yaml`?)
+32. **StorageClass → role mapping** (set via `K8S_CSI_*` env vars or literal config overrides; NOT the manifest)
+    - block → `K8S_CSI_BLOCK_SC`
+    - shared FS (incl. Lustre / other parallel FS) → `K8S_CSI_SHARED_FS_SC`
+    - NFS → `K8S_CSI_NFS_SC`
+33. **Which CSI checks matter for this backend?** (`K8sCsiStorageTypesCheck`, `K8sCsiProvisioningModesCheck`, …)
+34. **Node selector / tolerations** for test runner pods? (e.g. `dedicated=system-workload`)
+35. **NFS mount-option expectations** (`K8sNfsMountOptionsCheck`: version / proto / nconnect) — read off a live mount
+36. **ConfigMap mount path** in production for `manifest_path` (default: `storage-provider-manifest`)
+
+---
+
+## H. Credentials and handoff
+
+37. **Env var names** for endpoint, credentials, storage path (document in `scripts/storage/README.md`)
+38. **Secret keys** for cluster handoff (map 1:1 to env vars)
+39. **IAM actions** (AWS-style) or API scopes required — keep minimal
+40. **TLS** — custom CA, insecure skip (dev only)?
+
+---
+
+## Quick routing from answers
+
+| Answer | Implementation path |
+| ------ | ------------------- |
+| Default | Edit `my-isv/scripts/storage/api.py` TODO blocks + manifest in place |
+| CSI + dynamic provisioning | AWS/VAST pattern; focus on `list_volumes` |
+| API-managed volumes | Implement create/delete; keep `DEMO_MODE` until creds exist |
+| API only in-cluster | `kubectl run isvctl-runner` pod pattern (see provider READMEs) |
+| Multi tenant/path | Multiple `providers[]` entries in `my-isv` manifest |
+| No existing PVCs | User must create one before N-020 passes |
+| User wants prod handoff | Only then copy finished shim to `providers/<name>/` |

--- a/.cursor/skills/storage-api-stub-authoring/references/manifest-generation.md
+++ b/.cursor/skills/storage-api-stub-authoring/references/manifest-generation.md
@@ -1,0 +1,142 @@
+# Manifest generation (discover, then ask)
+
+How to fill `config/storage-provider-manifest.yaml` (schema **v1alpha2**) by
+**probing the environment first** and **asking the customer only for what you
+can't observe**. Discovery proposes values; Q&A confirms intent and fills gaps.
+
+The manifest drives `StorageProviderApiCheck` ONLY: it imports each
+`shim.module` and exercises the `StorageApi` contract — and **cross-checks the
+declared `identity`/`capabilities` against the live shim, failing on mismatch**
+(`manifest-consistency[<name>]`). It carries no CSI / topology / protocol data;
+the `K8sCsi*` / `K8sFilesystem*` checks get their StorageClass names and
+expectations from the suite/provider config or the `K8S_CSI_*` env vars (see
+[config-wiring.md](config-wiring.md)).
+
+So: **don't declare what you can't back up.** Discover it, or ask, or omit it
+(omitted keys skip the dependent check cleanly rather than failing).
+
+Two files ship beside the template:
+
+- `config/storage-provider-manifest.yaml` — the blank template to fill (edit in place).
+- `config/storage-provider-manifest.example.yaml` — a fully-populated multi-provider reference.
+- Schema: `isvctl/schemas/storage-provider-manifest.schema.json`.
+
+---
+
+## Workflow
+
+```text
+1. Discover  → run read-only probes (kubectl / cloud CLI / curl), draft values  → verify: probes return data
+2. Draft     → write a candidate manifest, mark every guessed field [ASSUMED]   → verify: it parses (adapter below)
+3. Ask       → confirm assumptions + fill un-discoverable fields via Q&A        → verify: customer signs off on profile
+4. Validate  → re-run the adapter + probe_shim.py                               → verify: storage classes / shim resolve
+```
+
+**Ask permission before running any discovery command.** If denied, paste the
+relevant Q&A prompts and ask the customer to run them and share output.
+
+### Validate the draft as you go
+
+The manifest adapter parses the manifest **without loading any shim** (no
+backend calls), so it is the fastest correctness loop while drafting:
+
+```bash
+STORAGE_PROVIDER_MANIFEST=isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml \
+  uv run python isvctl/configs/providers/shared/storage_manifest_to_steps.py | uv run python -m json.tool
+```
+
+Confirm the emitted `storage.manifest_path` resolves to your manifest. (The
+adapter only resolves the path for `StorageProviderApiCheck`; it does not load
+the shim.) For the full contract check, run `probe_shim.py` (Phase 4).
+
+---
+
+## Field-by-field: discover vs. ask
+
+Each section lists **how to observe the value** and **what to ask** when it
+isn't observable. Quote AWS account IDs / numeric tenant IDs to keep YAML from
+stripping leading zeros.
+
+### Provider identity (`name`, `type`, `tenant_id`, `identity`)
+
+| Field | Discover | Ask if not discoverable |
+| ----- | -------- | ----------------------- |
+| CSI provisioner (a hint for id/vendor inference, not a manifest field) | `kubectl get sc <name> -o jsonpath='{.provisioner}'`; `kubectl get csidriver` | "Which CSI driver / management product fronts this storage?" |
+| `identity.provider.domain` / `.id` | Infer from the driver name (e.g. `fsx.csi.aws.com` → `aws.amazon.com` / `fsx-lustre`) | "What DNS-form domain + short id should identify your shim? (forms the `<domain>/<id>` key)" |
+| `identity.provider.version` / `.vendor` / `.name` | `kubectl get csidriver <d> -o yaml` annotations; vendor docs | "Shim semver + vendor display name?" |
+| `identity.backend.*` | Backend API/version endpoint (see `health_check` call); product banner | "What storage system + version sits behind the shim?" |
+| `identity.storage_type` (`file`/`block`) | Provisioner family (FSx/NFS/Lustre → file; EBS/iSCSI/NVMe → block); `kubectl get sc <name> -o jsonpath='{.parameters}'` | "Is this a filesystem (RWX) or block (RWO) provider?" |
+| `identity.storage_protocol` | Inspect a mounted PV: `kubectl exec <pod> -- cat /proc/mounts` (nfs vers, lustre); SC `parameters` | "Wire protocol: lustre / nfsv4 / nfsv3 / smb / nvme / iscsi / nvme-of / fc?" |
+| `tenant_id` | Backend API tenant list; cloud account (`aws sts get-caller-identity`); VAST `X-Tenant-Name` | "Default backend tenant the checks should target?" |
+
+`name`/`type` are derived from `identity.provider.id` / `identity.storage_type`
+when omitted — but set them explicitly; `name` is the subtest tag.
+
+### Shim (`shim`)
+
+| Field | Discover | Ask if not discoverable |
+| ----- | -------- | ----------------------- |
+| `shim.kind` | Phase 1a is always `python` (in-process). `rest` is declared-but-skipped. | — |
+| `shim.module` | Keep `../scripts/storage/api.py` for the flat my-isv layout | — |
+| `shim.configmap` / `credentials_secret` | Production handoff names (not needed for local runs) | "ConfigMap/Secret names ops will mount in-cluster?" (informational) |
+
+**Omit the entire `shim:` block for providers with no management API** — the
+shim subtests skip for them.
+
+> StorageClass names, NFS mount-option expectations, node selectors, and kernel
+> modules are NOT manifest fields. The `K8sCsi*` / `K8sFilesystem*` checks read
+> them from the suite/provider config or the `K8S_CSI_*` env vars — see
+> [config-wiring.md](config-wiring.md).
+
+### Capabilities (`capabilities`)
+
+These are a **contract**, not documentation — and the manifest is the
+**single source of truth** for which surfaces are supported. For providers
+with a shim, `StorageProviderApiCheck` probes each capability declared
+supported at runtime and fails if the shim raises `NotSupportedError` /
+`NotImplementedError` for it. So set them from the shim implementation
+decision, not a guess.
+
+The block is hierarchical (`native` | `default` | `none`): a group state
+cascades to its leaves; a leaf overrides its group. `native`/`default` mean the
+surface is serviceable (the check probes it and expects no sentinel raise);
+`none` opts out (the surface is not probed — leave the method as a raising
+stub or base raise).
+
+| Capability | Determined by | Notes |
+| ---------- | ------------- | ----- |
+| `volumeManagement.create` / `.delete` | CSI-owned lifecycle → `none` (raise `NotSupportedError`); API-owned → `native` | Enforced in `volume-provisioning` |
+| `volumeManagement.list` / `.get` | Whether the shim enumerates / fetches volumes | usually `native` |
+| `tenantManagement.list` / `.get` / `.getQuota` | Whether the shim enumerates tenants / fetches a tenant / reports its quota | `getQuota` usually `native` |
+| `quotaManagement.directory.*` / `.user.*` | Whether the shim implements the directory / user quota methods | Deferred surface; usually `none` in Phase 1a |
+
+Omit a capability to leave it unchecked while the shim is still stubbed.
+
+---
+
+## When you can't run discovery
+
+If the user can't grant cluster/API access, send this copy-paste block and ask
+them to return the output, then map it into the manifest (identity / capabilities)
+and your test config (StorageClass names via `K8S_CSI_*`):
+
+```bash
+kubectl get storageclass -o wide
+kubectl get csidriver
+kubectl get sc <each-name> -o yaml          # provisioner + parameters + mountOptions
+```
+
+Fall back to [intake-questions.md](intake-questions.md) for everything the
+output doesn't reveal (tenant model, quota source, identity vendor/version).
+
+---
+
+## Draft → confirm loop
+
+1. Run discovery, fill the manifest, tag each guessed value with a `# ASSUMED`
+   comment.
+2. Run the adapter (above) and `probe_shim.py` (Phase 4) — fix anything that
+   resolves empty/wrong.
+3. Present an "Implementation profile" listing every `# ASSUMED` value and ask
+   the customer to confirm or correct in one pass.
+4. Remove the `# ASSUMED` tags once confirmed.

--- a/.cursor/skills/storage-api-stub-authoring/references/method-walkthrough.md
+++ b/.cursor/skills/storage-api-stub-authoring/references/method-walkthrough.md
@@ -1,0 +1,188 @@
+# Method walkthrough
+
+Implement **in this order**. After each method, run the probe in Phase 4.
+
+Subtests map to `StorageProviderApiCheck` (`isvtest/validations/storage_provider.py`):
+
+| Method | Subtest | Requirement |
+| ------ | ------- | ----------- |
+| `health_check` | `api-authentication[<name>]` | Authenticated round-trip; `AuthenticationError` on 401/403 |
+| `create_volume` or `list_volumes` | `volume-provisioning[<name>]` | Create+delete path OR CSI fallback with ≥1 volume |
+| `get_tenant_quota` | `tenant-quota[<name>]` | `hard_limit_bytes > 0` |
+
+---
+
+## 0. `build_api()` factory
+
+```python
+def build_api() -> StorageApi:
+    return MyStorageApi()
+```
+
+Module-level, no arguments. Loader: `isvtest.core.storage_provider.build_api_from_path`.
+
+**Target file:** `isvctl/configs/providers/my-isv/scripts/storage/api.py` — replace
+each `TODO` block in the existing `MyStorageApi` class; do not copy to a new path.
+
+---
+
+## 1. `__init__` — connection setup
+
+**Questions:**
+
+- Which env vars hold endpoint, credentials, default tenant, storage root path?
+- Should missing required env vars fail fast at construction or first call?
+- Multi-provider manifest: one shim class with env vars, or separate modules per entry?
+
+**Implement:**
+
+- Read config from env (Phase 1a) or mounted file path (future ConfigMap)
+- Build SDK client / HTTP session
+- Set `self._default_tenant` from env or leave `None` for required `tenant_id` arg
+
+**Probe:** Import module without calling cloud APIs (syntax + env validation only).
+
+---
+
+## 2. `properties()` — identity + L2 qualifiers
+
+**Questions:**
+
+- `provider_name`, `provider_implementor`, `provider_storage_type` (`file` | `block`)?
+- `provider_protocol` — `nfsv4`, `lustre`, `ext4`, …?
+- Directory/user quota supported? (declared in the **manifest**, not here)
+
+**Implement:** Return `ProviderProperties(...)` carrying identity and any L2
+qualifiers (via the `capability_qualifiers()` hook). `properties()` does *not*
+declare which surfaces are supported — that lives in the manifest's
+`capabilities:` block and is verified by runtime probing.
+
+**Probe:** `api.properties().provider_name` returns expected string.
+
+---
+
+## 3. `health_check()`
+
+**Questions:**
+
+- What is the **smallest authenticated call** that proves creds work?
+- What HTTP status / error code → `AuthenticationError`?
+- Transient errors — raise generic exception (fails subtest) vs retry?
+
+**Implement:**
+
+- One round-trip to management API
+- Return `None` on success
+- Raise `AuthenticationError` for auth failures only
+
+**Reference calls:**
+
+- AWS: `servicequotas:GetServiceQuota` (fsx service code)
+- VAST: `GET /api/quotas/`
+
+**Probe:** CLI equivalent + `probe_shim.py` authentication line.
+
+---
+
+## 4. `get_tenant_quota()`
+
+**Questions:**
+
+- How is tenant resolved (`tenant_id` arg vs default)?
+- Source of `hard_limit_bytes` — quota API, sum of children, service limit?
+- Source of `used_bytes` — allocation sum, metered usage, effective capacity?
+- Display `name` for tenant?
+
+**Implement:**
+
+```python
+return TenantQuota(
+    tenant_id=resolved,
+    hard_limit_bytes=int,  # MUST be > 0
+    used_bytes=int,
+    name=str | None,
+)
+```
+
+**Probe:** `probe_shim.py` tenant-quota line; verify `hard_limit_bytes > 0`.
+
+---
+
+## 5. Volume lifecycle
+
+### Branch A: CSI owns lifecycle (AWS, VAST, WEKA)
+
+**Questions:**
+
+- How to list existing volumes/PVC-backed exports?
+- How to map backend record → `Volume` dataclass?
+- Populate `Volume.csi` (`driver`, `volume_handle`) and/or `Volume.mount` (`source`)?
+- What exact volume-handle format does the CSI driver put on PVs?
+
+**Implement:**
+
+- `create_volume` / `delete_volume` → `raise NotSupportedError(...)`
+- `list_volumes` → yield `Volume` objects for tenant-scoped inventory
+- Honor `ids` filter; `tag_filters` if backend supports tags (else ignore safely)
+
+**Reference:**
+
+- AWS: `fsx:DescribeFileSystems` (LUSTRE only)
+- VAST: child directory quotas under `VAST_STORAGE_PATH`
+- WEKA: one filesystem per `weka/v2/<fs>` volume handle
+
+**Probe:** `list_volumes()` count ≥ 1 (user may need to create PVC first).
+
+### Branch B: API owns lifecycle
+
+**Questions:**
+
+- Create API parameters for name, size, volume_type, tags?
+- Sync or async creation — initial `state` `creating` vs `available`?
+- Delete idempotent?
+
+**Implement:**
+
+- `create_volume` — return `Volume` with `state` in `creating` | `available`
+- `delete_volume` — clean up; warn if create without delete (check logs)
+- Tag with `isvtest-run-id` and `provider` (check passes these)
+
+**Probe:** `probe_shim.py` with `--exercise-create` (if script supports) or manual call.
+
+---
+
+## 6. `list_volumes()` — always required for CSI path
+
+**Questions:**
+
+- Filter by `ids` — exact match on volume id?
+- `tag_filters` — AND semantics per `TagFilter`?
+- Foreign tenant volumes — must never appear even if filters would match
+
+**Implement:** Generator/`Iterable` of `Volume` with correct `tenant_id`, `size_bytes`, `state`.
+
+---
+
+## 7. Optional methods
+
+Leave as base-class `NotSupportedError` (or an explicit raising stub) unless
+needed:
+
+- `list_tenants`, `get_tenant`
+- `list/get/set/delete_directory_quota`
+- `list/get/set/delete_user_quota`
+
+When you implement any of these, declare the matching surface supported
+(`native`) in the **manifest** — that is what validation probes. Surfaces you
+leave as raising stubs stay `none`.
+
+---
+
+## Volume dataclass checklist
+
+Each `Volume` should set when known:
+
+- `id`, `name`, `tenant_id`, `size_bytes`, `state`, `volume_type`
+- `csi.driver`, `csi.volume_handle` — for K8s CSI backends
+- `mount.source` — NFS mount spec (VAST: `{vip_pool}:{path}`)
+- `tags` — if backend supports metadata

--- a/.cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py
+++ b/.cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated preflight for storage provider shims.
+
+Loads the provider manifest, exercises each Python shim in-process, and
+prints pass/fail per subtest. Run from repo root after ``uv sync``::
+
+    uv run python .cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py \\
+        --manifest isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml
+
+Exit code 0 when all providers pass; 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from isvtest.core.storage import ManifestError, load_provider_registry
+from isvtest.core.storage_provider import (
+    AuthenticationError,
+    CreateVolumeRequest,
+    GetTenantQuotaRequest,
+    ListVolumesRequest,
+    NotSupportedError,
+)
+
+
+def _probe_provider(name: str, api) -> bool:
+    """Return True when all three subtest areas pass."""
+    ok = True
+
+    try:
+        api.health_check()
+        print(f"  [PASS] api-authentication[{name}] health_check() ok")
+    except AuthenticationError as exc:
+        print(f"  [FAIL] api-authentication[{name}] AuthenticationError: {exc}")
+        print(f"  [SKIP] volume-provisioning[{name}] (auth failed)")
+        print(f"  [SKIP] tenant-quota[{name}] (auth failed)")
+        return False
+    except Exception as exc:
+        print(f"  [FAIL] api-authentication[{name}] {type(exc).__name__}: {exc}")
+        ok = False
+
+    try:
+        api.create_volume(CreateVolumeRequest(size_bytes=1 << 30, volume_type="file", name="probe-shim-test"))
+        print(f"  [PASS] volume-provisioning[{name}] create_volume succeeded")
+    except NotSupportedError:
+        try:
+            existing = list(api.list_volumes(ListVolumesRequest()).volumes)
+        except Exception as exc:
+            print(f"  [FAIL] volume-provisioning[{name}] list_volumes() raised {type(exc).__name__}: {exc}")
+            ok = False
+        else:
+            count = len(existing)
+            if count >= 1:
+                print(
+                    f"  [PASS] volume-provisioning[{name}] CSI fallback: observed {count} volume(s) via list_volumes()"
+                )
+            else:
+                print(
+                    f"  [WARN] volume-provisioning[{name}] CSI fallback: "
+                    f"observed 0 volumes — create a PVC against the StorageClass, then re-probe"
+                )
+                ok = False
+    except Exception as exc:
+        print(f"  [FAIL] volume-provisioning[{name}] create_volume raised {type(exc).__name__}: {exc}")
+        ok = False
+
+    try:
+        quota = api.get_tenant_quota(GetTenantQuotaRequest())
+    except Exception as exc:
+        print(f"  [FAIL] tenant-quota[{name}] get_tenant_quota() raised {type(exc).__name__}: {exc}")
+        ok = False
+    else:
+        if quota.hard_limit_bytes <= 0:
+            print(f"  [FAIL] tenant-quota[{name}] hard_limit_bytes={quota.hard_limit_bytes} (must be > 0)")
+            ok = False
+        else:
+            print(
+                f"  [PASS] tenant-quota[{name}] hard_limit_bytes={quota.hard_limit_bytes} used_bytes={quota.used_bytes}"
+            )
+
+    return ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Probe storage shims in isolation.")
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to storage-provider-manifest.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        providers = load_provider_registry({"manifest_path": args.manifest})
+    except ManifestError as exc:
+        print(f"[FAIL] manifest load: {exc}", file=sys.stderr)
+        return 1
+
+    shim_providers = [p for p in providers if p.has_shim]
+    if not shim_providers:
+        print("[WARN] no providers with Python shim loaded — nothing to probe")
+        return 0
+
+    all_ok = True
+    for provider in shim_providers:
+        print(f"Provider: {provider.name}")
+        assert provider.api is not None
+        if not _probe_provider(provider.name, provider.api):
+            all_ok = False
+        print()
+
+    if all_ok:
+        print("All shim probes passed.")
+        return 0
+    print("One or more shim probes failed.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -34,8 +34,15 @@
 #   - AWS_SKIP_TEARDOWN: Set to "true" to skip teardown and preserve resources (default: false)
 #   - NGC_API_KEY: NGC API key for NIM workloads
 #   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY: AWS credentials (if not using IAM roles)
+#   - AWS_REGION: Region for the FSx Lustre storage shim (required when running StorageProviderApiCheck)
+#   - FSX_DEPLOYMENT_TYPE: FSx deployment type for quota code resolution (default: PERSISTENT_2)
+#   - FSX_QUOTA_CODE: Override the quota code directly (optional)
+#   - AWS_ACCOUNT_ID: Override STS-resolved account id (optional)
 
-import: ../../../suites/k8s.yaml
+import:
+  - ../../../suites/k8s.yaml
+  # StorageProviderApiCheck + CSI/filesystem checks live in the storage suite.
+  - ../../../suites/storage.yaml
 
 version: "1.0"
 
@@ -210,6 +217,11 @@ tests:
   description: "AWS EKS GPU cluster validation"
 
   validations:
+    k8s_storage:
+      checks:
+        K8sCsiDriverHealthCheck: {}
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/aws/config/storage-provider-manifest.yaml"
     k8s_multi_cluster:
       checks:
         K8sMultiClusterSameVpcCheck:

--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -217,11 +217,13 @@ tests:
   description: "AWS EKS GPU cluster validation"
 
   validations:
+    storage_provider_api:
+      checks:
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/aws/config/storage-provider-manifest.yaml"
     k8s_storage:
       checks:
         K8sCsiDriverHealthCheck: {}
-        StorageProviderApiCheck:
-          manifest_path: "isvctl/configs/providers/aws/config/storage-provider-manifest.yaml"
     k8s_multi_cluster:
       checks:
         K8sMultiClusterSameVpcCheck:

--- a/isvctl/configs/providers/aws/config/storage-provider-manifest.yaml
+++ b/isvctl/configs/providers/aws/config/storage-provider-manifest.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AWS Storage Provider Manifest.
+#
+# Drives `StorageProviderApiCheck` against a live EKS + FSx Lustre cluster via
+# the boto3 shim under `../scripts/storage/fsx-lustre/api.py`.
+# Tenant = AWS account + region.
+#
+# v1alpha2 mirrors the upstream StorageProvider package manifest: a package-level
+# namespace + vendor, a per-provider `provider` identity block, and a
+# hierarchical `capabilities` block (native | default | none). The declared
+# identity + capabilities are a CONTRACT: StorageProviderApiCheck cross-checks
+# them against the running shim's properties(). Keep this in sync with
+# `../scripts/storage/fsx-lustre/api.py` (AwsFsxLustreApi's ProviderProperties
+# core).
+
+schema_version: v1alpha2
+
+# Package identity (the package manifest namespace + vendor). With each provider's id
+# this forms the registration key <namespace>/<id>.
+namespace: aws.amazon.com
+vendor:
+  vendorName: NVIDIA
+
+providers:
+  - id: fsx-lustre
+    name: aws-fsx-lustre
+    # tenant_id intentionally omitted - the shim resolves it from
+    # sts:GetCallerIdentity at construction time. Set AWS_ACCOUNT_ID to
+    # override (e.g. in CI where STS isn't reachable).
+    sdk_version: v1beta1
+
+    provider:
+      name: AWS FSx Lustre
+      description: AWS FSx for Lustre fronted by the boto3 shim
+      type: file
+      protocols: [lustre]
+      version: 0.1.0
+
+    shim:
+      kind: python
+      module: ../scripts/storage/fsx-lustre/api.py
+
+    capabilities:
+      tenantManagement:
+        list: none
+        get: none
+        getQuota: native
+      volumeManagement:
+        list: native
+        get: native
+        create: none
+        delete: none
+      quotaManagement: none
+
+    attributes:
+      deployment_type: PERSISTENT_2

--- a/isvctl/configs/providers/aws/scripts/storage/README.md
+++ b/isvctl/configs/providers/aws/scripts/storage/README.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AWS FSx Lustre storage shim
+
+Storage Provider Shim for AWS FSx Lustre. Drives
+[`StorageProviderApiCheck`](../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
+against a live EKS + FSx Lustre cluster.
+
+## How it works
+
+The manifest at [`../../config/storage-provider-manifest.yaml`](../../config/storage-provider-manifest.yaml)
+declares one `aws-fsx-lustre` provider; `shim.module` points at
+[`fsx-lustre/api.py`](fsx-lustre/api.py); `StorageProviderApiCheck` loads the shim in-process
+and runs three subtests against the AWS APIs below.
+
+| Subtest | AWS call |
+| ------- | -------- |
+| `api-authentication[aws-fsx-lustre]` | `servicequotas:GetServiceQuota` |
+| `volume-provisioning[aws-fsx-lustre]` | `fsx:DescribeFileSystems` (fallback) |
+| `tenant-quota[aws-fsx-lustre]` | `GetServiceQuota.Value` + sum of `DescribeFileSystems[].StorageCapacity` |
+
+The FSx CSI driver (`fsx.csi.aws.com`) owns volume lifecycle on EKS, so
+`create_volume` / `delete_volume` raise `NotSupportedError` and the
+acceptance suite falls back to inventorying existing volumes
+(the managed-K8s fallback path).
+
+## Required IAM actions
+
+The identity isvctl runs under (developer machine creds, EC2 instance
+profile, or pod-mounted IRSA) needs the following:
+
+| Action | Why |
+| ------ | --- |
+| `sts:GetCallerIdentity` | Resolves the AWS account id as the shim's tenant id |
+| `servicequotas:GetServiceQuota` (on `fsx` service code) | Reads the hard quota for the authentication and tenant-quota subtests |
+| `fsx:DescribeFileSystems` | Lists filesystems for volume-provisioning and tenant-quota subtests |
+
+Not needed (intentionally - keeps the IAM surface tight):
+
+- `cloudwatch:*` - the shim uses FSx `StorageCapacity` (allocation), not
+  CloudWatch consumption metrics. This matches what the AWS Service
+  Quota actually counts against.
+- `fsx:CreateFileSystem` / `fsx:DeleteFileSystem` - the CSI driver owns
+  provisioning.
+
+## Environment variables
+
+| Variable | Required? | Effect |
+| -------- | --------- | ------ |
+| `AWS_REGION` | Yes | Region for all AWS clients (Service Quotas, FSx, STS). Must match the cluster's FSx region. |
+| `AWS_PROFILE` _or_ `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` [+ `AWS_SESSION_TOKEN`] | Yes | Standard boto3 credential chain - no custom logic. |
+| `FSX_DEPLOYMENT_TYPE` | No (default `PERSISTENT_2`) | One of `PERSISTENT_2`, `PERSISTENT_1`, `SCRATCH_1`, `SCRATCH_2`. Chooses the Service Quota code. |
+| `FSX_QUOTA_CODE` | No | Overrides the `FSX_DEPLOYMENT_TYPE` -> quota-code mapping (e.g. for a code we don't ship). |
+| `AWS_ACCOUNT_ID` | No | Skips the `sts:GetCallerIdentity` lookup. Useful in CI / restricted envs. |
+
+## Deployment type to quota code
+
+| `FSX_DEPLOYMENT_TYPE` | Service Quota code | Display name |
+| --------------------- | ------------------ | ------------ |
+| `PERSISTENT_2` (default) | `L-8F1B9C74` | AWS FSx Lustre (PERSISTENT_2) |
+| `PERSISTENT_1` | `L-C8640C82` | AWS FSx Lustre (PERSISTENT_1) |
+| `SCRATCH_1` | `L-AD2FC696` | AWS FSx Lustre (SCRATCH) |
+| `SCRATCH_2` | `L-AD2FC696` | AWS FSx Lustre (SCRATCH) |
+
+Pick the value that matches your FSx Lustre StorageClass's
+`parameters.deploymentType`. If the cluster mixes tiers, run the suite
+once per tier (or set `FSX_QUOTA_CODE` directly).
+
+## Running on a cluster
+
+From the repo root:
+
+```bash
+export AWS_REGION=us-west-2          # match cluster region
+export AWS_PROFILE=...               # or AWS_ACCESS_KEY_ID/SECRET
+
+# Sanity-check creds + that the quota exists:
+aws sts get-caller-identity
+aws fsx describe-file-systems --max-results 1 --region "$AWS_REGION"
+aws service-quotas get-service-quota \
+  --service-code fsx --quota-code L-8F1B9C74 --region "$AWS_REGION"
+
+# Run the storage check (unreleased -> gate env var required):
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/aws/config/eks.yaml
+```
+
+`volume-provisioning[aws-fsx-lustre]` reports **skipped (passed)** with
+`created_volume not implemented; observed N CSI-provisioned volume(s)
+via list_volumes()` - that is the managed-K8s
+fallback, not a failure.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `api-authentication[...] FAILED ... AuthenticationError` | Missing creds, expired SSO, IAM role missing `servicequotas:GetServiceQuota` | Refresh creds; attach the IAM actions above |
+| `tenant-quota[...] FAILED ... hard_limit_bytes=0` | Wrong `FSX_DEPLOYMENT_TYPE` (account has zero of that tier) | Set `FSX_DEPLOYMENT_TYPE` to match your FSx SC's `parameters.deploymentType` |
+| `Failed to load provider manifest: ... not found` | Working dir is not the repo root | `cd` to repo root before `isvctl test run` |
+| Orchestrator logs `Skipping unreleased validation 'StorageProviderApiCheck'` | `ISVTEST_INCLUDE_UNRELEASED=1` not set | Re-run with the env var |
+| `AWS_REGION must be set` | `AWS_REGION` env var unset | `export AWS_REGION=...` matching the cluster region |
+| `volume-provisioning[...] SKIPPED ... observed 0 ...` | Account has no FSx Lustre filesystems yet | Create a PVC against the FSx StorageClass first, then re-run |
+
+## See also
+
+- [`isvtest/src/isvtest/core/storage_provider/api.py`](../../../../../../isvtest/src/isvtest/core/storage_provider/api.py) - the `StorageApi` ABC + value types (per-method contract docstrings)
+- [`isvctl/configs/providers/my-isv/scripts/storage/`](../../../my-isv/scripts/storage/) - generic provider template

--- a/isvctl/configs/providers/aws/scripts/storage/fsx-lustre/README.md
+++ b/isvctl/configs/providers/aws/scripts/storage/fsx-lustre/README.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AWS FSx Lustre storage shim
+
+Storage Provider Shim for AWS FSx Lustre. Drives
+[`StorageProviderApiCheck`](../../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
+against a live EKS + FSx Lustre cluster.
+
+## How it works
+
+The manifest at [`../../../config/storage-provider-manifest.yaml`](../../../config/storage-provider-manifest.yaml)
+declares one `aws-fsx-lustre` provider; `shim.module` points at
+[`api.py`](api.py); `StorageProviderApiCheck` loads the shim in-process
+and runs three subtests against the AWS APIs below.
+
+| Subtest | AWS call |
+| ------- | -------- |
+| `api-authentication[aws-fsx-lustre]` | `servicequotas:GetServiceQuota` |
+| `volume-provisioning[aws-fsx-lustre]` | `fsx:DescribeFileSystems` (fallback) |
+| `tenant-quota[aws-fsx-lustre]` | `GetServiceQuota.Value` + sum of `DescribeFileSystems[].StorageCapacity` |
+
+The FSx CSI driver (`fsx.csi.aws.com`) owns volume lifecycle on EKS, so
+`create_volume` / `delete_volume` raise `NotSupportedError` and the
+acceptance suite falls back to inventorying existing volumes
+(the managed-K8s fallback path).
+
+## Required IAM actions
+
+The identity isvctl runs under (developer machine creds, EC2 instance
+profile, or pod-mounted IRSA) needs the following:
+
+| Action | Why |
+| ------ | --- |
+| `sts:GetCallerIdentity` | Resolves the AWS account id as the shim's tenant id |
+| `servicequotas:GetServiceQuota` (on `fsx` service code) | Reads the hard quota for the authentication and tenant-quota subtests |
+| `fsx:DescribeFileSystems` | Lists filesystems for volume-provisioning and tenant-quota subtests |
+
+Not needed (intentionally - keeps the IAM surface tight):
+
+- `cloudwatch:*` - the shim uses FSx `StorageCapacity` (allocation), not
+  CloudWatch consumption metrics. This matches what the AWS Service
+  Quota actually counts against.
+- `fsx:CreateFileSystem` / `fsx:DeleteFileSystem` - the CSI driver owns
+  provisioning.
+
+## Environment variables
+
+| Variable | Required? | Effect |
+| -------- | --------- | ------ |
+| `AWS_REGION` | Yes | Region for all AWS clients (Service Quotas, FSx, STS). Must match the cluster's FSx region. |
+| `AWS_PROFILE` _or_ `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` [+ `AWS_SESSION_TOKEN`] | Yes | Standard boto3 credential chain - no custom logic. |
+| `FSX_DEPLOYMENT_TYPE` | No (default `PERSISTENT_2`) | One of `PERSISTENT_2`, `PERSISTENT_1`, `SCRATCH_1`, `SCRATCH_2`. Chooses the Service Quota code. |
+| `FSX_QUOTA_CODE` | No | Overrides the `FSX_DEPLOYMENT_TYPE` -> quota-code mapping (e.g. for a code we don't ship). |
+| `AWS_ACCOUNT_ID` | No | Skips the `sts:GetCallerIdentity` lookup. Useful in CI / restricted envs. |
+
+## Deployment type to quota code
+
+| `FSX_DEPLOYMENT_TYPE` | Service Quota code | Display name |
+| --------------------- | ------------------ | ------------ |
+| `PERSISTENT_2` (default) | `L-8F1B9C74` | AWS FSx Lustre (PERSISTENT_2) |
+| `PERSISTENT_1` | `L-C8640C82` | AWS FSx Lustre (PERSISTENT_1) |
+| `SCRATCH_1` | `L-AD2FC696` | AWS FSx Lustre (SCRATCH) |
+| `SCRATCH_2` | `L-AD2FC696` | AWS FSx Lustre (SCRATCH) |
+
+Pick the value that matches your FSx Lustre StorageClass's
+`parameters.deploymentType`. If the cluster mixes tiers, run the suite
+once per tier (or set `FSX_QUOTA_CODE` directly).
+
+## Running on a cluster
+
+From the repo root:
+
+```bash
+export AWS_REGION=us-west-2          # match cluster region
+export AWS_PROFILE=...               # or AWS_ACCESS_KEY_ID/SECRET
+
+# Sanity-check creds + that the quota exists:
+aws sts get-caller-identity
+aws fsx describe-file-systems --max-results 1 --region "$AWS_REGION"
+aws service-quotas get-service-quota \
+  --service-code fsx --quota-code L-8F1B9C74 --region "$AWS_REGION"
+
+# Run the storage check (unreleased -> gate env var required):
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/aws/config/eks.yaml
+```
+
+`volume-provisioning[aws-fsx-lustre]` reports **skipped (passed)** with
+`created_volume not implemented; observed N CSI-provisioned volume(s)
+via list_volumes()` - that is the managed-K8s
+fallback, not a failure.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `api-authentication[...] FAILED ... AuthenticationError` | Missing creds, expired SSO, IAM role missing `servicequotas:GetServiceQuota` | Refresh creds; attach the IAM actions above |
+| `tenant-quota[...] FAILED ... hard_limit_bytes=0` | Wrong `FSX_DEPLOYMENT_TYPE` (account has zero of that tier) | Set `FSX_DEPLOYMENT_TYPE` to match your FSx SC's `parameters.deploymentType` |
+| `Failed to load provider manifest: ... not found` | Working dir is not the repo root | `cd` to repo root before `isvctl test run` |
+| Orchestrator logs `Skipping unreleased validation 'StorageProviderApiCheck'` | `ISVTEST_INCLUDE_UNRELEASED=1` not set | Re-run with the env var |
+| `AWS_REGION must be set` | `AWS_REGION` env var unset | `export AWS_REGION=...` matching the cluster region |
+| `volume-provisioning[...] SKIPPED ... observed 0 ...` | Account has no FSx Lustre filesystems yet | Create a PVC against the FSx StorageClass first, then re-run |
+
+## See also
+
+- [`isvtest/src/isvtest/core/storage_provider/api.py`](../../../../../../../isvtest/src/isvtest/core/storage_provider/api.py) - the `StorageApi` ABC + value types (per-method contract docstrings)
+- [`isvctl/configs/providers/my-isv/scripts/storage/`](../../../../my-isv/scripts/storage/) - generic provider template

--- a/isvctl/configs/providers/aws/scripts/storage/fsx-lustre/api.py
+++ b/isvctl/configs/providers/aws/scripts/storage/fsx-lustre/api.py
@@ -18,8 +18,10 @@
 * `health_check` / `get_tenant_quota.hard_limit_bytes`
   via ``servicequotas:GetServiceQuota(ServiceCode="fsx", QuotaCode=...)``.
 * `get_tenant_quota.used_bytes` via ``fsx:DescribeFileSystems`` summed
-  ``StorageCapacity`` (matches ``storageRequested`` in
-  ``nv_storage_controller.go:reconcileStatus``).
+  ``StorageCapacity`` for filesystems matching ``FSX_DEPLOYMENT_TYPE``
+  (matches ``storageRequested`` in
+  ``nv_storage_controller.go:reconcileStatus``). When ``FSX_QUOTA_CODE``
+  overrides the quota code, usage still filters on ``FSX_DEPLOYMENT_TYPE``.
 * `list_volumes` via ``fsx:DescribeFileSystems``, one ``Volume`` per
   filesystem (``get_volume`` is served by the SDK base via ``list_volumes``).
 * `create_volume` / `delete_volume` are left unimplemented - the
@@ -282,6 +284,9 @@ class AwsFsxLustreApi(Implementation):
 
         used_bytes = 0
         for fs in self._iter_lustre_filesystems():
+            fs_deployment_type = (fs.get("LustreConfiguration") or {}).get("DeploymentType")
+            if fs_deployment_type and fs_deployment_type != self._deployment_type:
+                continue
             capacity_gib = fs.get("StorageCapacity") or 0
             used_bytes += int(capacity_gib) * GIB
 

--- a/isvctl/configs/providers/aws/scripts/storage/fsx-lustre/api.py
+++ b/isvctl/configs/providers/aws/scripts/storage/fsx-lustre/api.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS FSx Lustre ``StorageProvider`` shim.
+
+* `health_check` / `get_tenant_quota.hard_limit_bytes`
+  via ``servicequotas:GetServiceQuota(ServiceCode="fsx", QuotaCode=...)``.
+* `get_tenant_quota.used_bytes` via ``fsx:DescribeFileSystems`` summed
+  ``StorageCapacity`` (matches ``storageRequested`` in
+  ``nv_storage_controller.go:reconcileStatus``).
+* `list_volumes` via ``fsx:DescribeFileSystems``, one ``Volume`` per
+  filesystem (``get_volume`` is served by the SDK base via ``list_volumes``).
+* `create_volume` / `delete_volume` are left unimplemented - the
+  FSx CSI driver (``fsx.csi.aws.com``) owns volume lifecycle on EKS, so
+  the acceptance suite falls back to inventorying via ``list_volumes``.
+
+The shim subclasses ``Implementation`` and is served through
+``new_implementation()``: it implements only the surfaces it backs, and the SDK
+*detects* which are supported. Which surfaces are *supported* is also declared in
+the sibling ``config/storage-provider-manifest.yaml`` (the contract); the
+validation suite probes each declared-supported surface at runtime. Surfaces this
+shim does NOT back (tenant enumeration, volume lifecycle, directory/user quotas)
+are simply left undefined - detected as unimplemented and gated - and the
+manifest declares them ``none``.
+
+Tenant = AWS account + region. ``tenant_id`` is resolved from
+``sts:GetCallerIdentity`` at construction time (with ``AWS_ACCOUNT_ID``
+override for environments without STS access).
+
+Environment variables:
+    AWS_REGION              Required. Region the AWS clients target.
+    AWS_PROFILE / AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY [+ AWS_SESSION_TOKEN]
+                            Standard boto3 credential chain - no custom logic.
+    FSX_DEPLOYMENT_TYPE     Optional. One of PERSISTENT_2 (default),
+                            PERSISTENT_1, SCRATCH_1, SCRATCH_2. Chooses
+                            which AWS Service Quota code we read. Overrides
+                            the manifest's attributes.deployment_type.
+    FSX_QUOTA_CODE          Optional override for the deployment-type
+                            mapping (e.g. for a quota code we don't know
+                            about). Wins over FSX_DEPLOYMENT_TYPE.
+    AWS_ACCOUNT_ID          Optional override for the STS-resolved
+                            tenant id (useful in CI / restricted envs).
+
+Required IAM actions:
+    sts:GetCallerIdentity, servicequotas:GetServiceQuota,
+    fsx:DescribeFileSystems
+
+See ``isvctl/configs/providers/aws/scripts/storage/README.md``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from boto3.session import Session as Boto3Session
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    NoCredentialsError,
+    ProfileNotFound,
+    TokenRetrievalError,
+)
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    AuthenticationError,
+    CsiSpec,
+    GetTenantQuotaRequest,
+    Implementation,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    ProviderProperties,
+    StorageApiError,
+    StorageProvider,
+    TagFilter,
+    TenantQuota,
+    VersionMetadata,
+    Volume,
+    VolumeState,
+    new_implementation,
+)
+
+GIB = 1024**3
+FSX_SERVICE_CODE = "fsx"
+
+# Maps FSx Lustre deployment types to the matching AWS Service Quota code.
+DEPLOYMENT_TYPE_TO_QUOTA_CODE: dict[str, str] = {
+    "PERSISTENT_2": "L-8F1B9C74",
+    "PERSISTENT_1": "L-C8640C82",
+    "SCRATCH_1": "L-AD2FC696",
+    "SCRATCH_2": "L-AD2FC696",
+}
+DEFAULT_DEPLOYMENT_TYPE = "PERSISTENT_2"
+
+# ClientError codes we surface as AuthenticationError so the acceptance
+# suite can distinguish auth failures from other errors.
+_AUTH_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "AccessDenied",
+        "AccessDeniedException",
+        "UnauthorizedOperation",
+        "InvalidClientTokenId",
+        "AuthFailure",
+        "ExpiredToken",
+        "ExpiredTokenException",
+        "SignatureDoesNotMatch",
+        "InvalidSignatureException",
+    }
+)
+
+# Map FSx Lifecycle (DescribeFileSystems response) onto the shim's
+# VolumeState literal. Anything unknown -> "failed" so the acceptance
+# suite's state assertion catches it instead of silently passing.
+_LIFECYCLE_TO_STATE: dict[str, VolumeState] = {
+    "AVAILABLE": "available",
+    "CREATING": "creating",
+    "DELETING": "deleting",
+    "FAILED": "failed",
+    "MISCONFIGURED": "failed",
+    "MISCONFIGURED_UNAVAILABLE": "failed",
+    "UPDATING": "available",
+}
+
+
+def _resolve_quota_code(deployment_type: str) -> str:
+    """Resolve an AWS service quota code by quota name."""
+    try:
+        return DEPLOYMENT_TYPE_TO_QUOTA_CODE[deployment_type]
+    except KeyError as exc:
+        valid = ", ".join(sorted(DEPLOYMENT_TYPE_TO_QUOTA_CODE))
+        raise StorageApiError(
+            f"FSX_DEPLOYMENT_TYPE={deployment_type!r} not recognised; "
+            f"expected one of {valid}, or set FSX_QUOTA_CODE explicitly"
+        ) from exc
+
+
+def _classify_client_error(exc: Exception, *, context: str) -> StorageApiError:
+    """Convert a boto3 exception into the shim's error taxonomy."""
+    if isinstance(exc, NoCredentialsError):
+        return AuthenticationError(f"{context}: AWS credentials not found")
+    if isinstance(exc, ProfileNotFound):
+        return AuthenticationError(f"{context}: AWS profile not found: {exc}")
+    if isinstance(exc, TokenRetrievalError):
+        return AuthenticationError(f"{context}: AWS credentials expired")
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in _AUTH_ERROR_CODES:
+            return AuthenticationError(f"{context}: {code}: {exc}")
+        return StorageApiError(f"{context}: {code or 'ClientError'}: {exc}")
+    if isinstance(exc, BotoCoreError):
+        return StorageApiError(f"{context}: {exc}")
+    return StorageApiError(f"{context}: {type(exc).__name__}: {exc}")
+
+
+def _tag_list_to_dict(tags: Any) -> dict[str, str]:
+    """Convert AWS ``[{'Key': ..., 'Value': ...}, ...]`` to a flat dict."""
+    if not isinstance(tags, list):
+        return {}
+    return {t["Key"]: t.get("Value", "") for t in tags if isinstance(t, dict) and "Key" in t}
+
+
+class AwsFsxLustreApi(Implementation):
+    """``StorageProvider`` over AWS FSx Lustre + Service Quotas + STS.
+
+    Single-tenant: each instance is scoped to one AWS account in one
+    region. To validate multiple accounts, declare multiple provider
+    entries in the manifest (each shim load gets its own AWS clients).
+    """
+
+    def __init__(
+        self,
+        *,
+        region: str | None = None,
+        deployment_type: str | None = None,
+        quota_code: str | None = None,
+        account_id: str | None = None,
+        attributes: Mapping[str, str] | None = None,
+        session: Boto3Session | None = None,
+    ) -> None:
+        """Initialize the object with its configured dependencies."""
+        resolved_region = region or os.environ.get("AWS_REGION")
+        if not resolved_region:
+            raise StorageApiError("AWS_REGION must be set (env var or constructor arg) for the FSx Lustre shim")
+        self._region = resolved_region
+
+        resolved_deployment_type = (
+            deployment_type
+            or os.environ.get("FSX_DEPLOYMENT_TYPE")
+            or (attributes or {}).get("deployment_type")
+            or DEFAULT_DEPLOYMENT_TYPE
+        )
+        self._deployment_type = resolved_deployment_type
+        self._quota_code = (
+            quota_code or os.environ.get("FSX_QUOTA_CODE") or _resolve_quota_code(resolved_deployment_type)
+        )
+
+        core = ProviderProperties(
+            provider_namespace="aws.amazon.com",
+            provider_id="fsx-lustre",
+            provider_metadata=VersionMetadata(
+                vendor_name="NVIDIA",
+                name="AWS FSx Lustre",
+                version="0.1.0",
+            ),
+            sdk_version=API_VERSION,
+            storage_type="file",
+            storage_protocols=["lustre"],
+            attributes={"region": self._region, "deployment_type": self._deployment_type},
+        )
+        self._core = core
+
+        self._session = session or Boto3Session(region_name=self._region)
+        self._sq = self._session.client("service-quotas", region_name=self._region)
+        self._fsx = self._session.client("fsx", region_name=self._region)
+        self._sts = self._session.client("sts", region_name=self._region)
+
+        self._default_tenant = account_id or os.environ.get("AWS_ACCOUNT_ID") or self._resolve_tenant_from_sts()
+
+    def _resolve_tenant_from_sts(self) -> str:
+        """Resolve the AWS tenant account ID via STS."""
+        try:
+            identity = self._sts.get_caller_identity()
+        except Exception as exc:
+            raise _classify_client_error(exc, context="sts:GetCallerIdentity") from exc
+        account = identity.get("Account")
+        if not account:
+            raise StorageApiError("sts:GetCallerIdentity returned no Account")
+        return str(account)
+
+    def _resolve_tenant(self, tenant_id: str | None) -> str:
+        """Resolve and validate the request tenant for this shim."""
+        resolved = tenant_id or self._default_tenant
+        if resolved != self._default_tenant:
+            raise StorageApiError(
+                f"tenant_id={resolved!r} does not match this shim's account "
+                f"{self._default_tenant!r}; declare a separate provider entry per account"
+            )
+        return resolved
+
+    def health_check(self) -> None:
+        """Authenticated round-trip via ``GetServiceQuota``."""
+        try:
+            self._sq.get_service_quota(ServiceCode=FSX_SERVICE_CODE, QuotaCode=self._quota_code)
+        except Exception as exc:
+            raise _classify_client_error(
+                exc,
+                context=f"servicequotas:GetServiceQuota(ServiceCode={FSX_SERVICE_CODE}, QuotaCode={self._quota_code})",
+            ) from exc
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        """Hard limit from Service Quotas; used bytes summed from FSx StorageCapacity."""
+        resolved = self._resolve_tenant(req.tenant_id)
+
+        try:
+            quota_response = self._sq.get_service_quota(ServiceCode=FSX_SERVICE_CODE, QuotaCode=self._quota_code)
+        except Exception as exc:
+            raise _classify_client_error(
+                exc,
+                context=f"servicequotas:GetServiceQuota(QuotaCode={self._quota_code})",
+            ) from exc
+
+        quota = quota_response.get("Quota", {})
+        quota_value_gib = quota.get("Value")
+        if quota_value_gib is None:
+            raise StorageApiError(f"Service Quota {self._quota_code!r} returned no Value: {quota_response!r}")
+        hard_limit_bytes = int(float(quota_value_gib) * GIB)
+        quota_name = quota.get("QuotaName") or self._quota_code
+
+        used_bytes = 0
+        for fs in self._iter_lustre_filesystems():
+            capacity_gib = fs.get("StorageCapacity") or 0
+            used_bytes += int(capacity_gib) * GIB
+
+        return TenantQuota(
+            tenant_id=resolved,
+            hard_limit_bytes=hard_limit_bytes,
+            used_bytes=used_bytes,
+            name=quota_name,
+        )
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        """Yield one ``Volume`` per FSx Lustre filesystem in the account+region."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        wanted_ids = set(req.ids) if req.ids else None
+        filters = list(req.tag_filters)
+
+        result: list[Volume] = []
+        for fs in self._iter_lustre_filesystems():
+            volume = self._fs_to_volume(fs, tenant_id=resolved)
+            if wanted_ids is not None and volume.id not in wanted_ids:
+                continue
+            if not all(_tag_matches(volume.tags, f) for f in filters):
+                continue
+            result.append(volume)
+        return ListVolumesResponse(volumes=tuple(result))
+
+    # Volume lifecycle (create_volume / delete_volume) is intentionally NOT
+    # implemented: the FSx CSI driver (fsx.csi.aws.com) owns it on EKS. The
+    # methods fall back to the base raise (NotSupportedError), the manifest
+    # declares volume.create / volume.delete ``none``, and the acceptance suite
+    # falls back to inventorying via list_volumes.
+
+    def _iter_lustre_filesystems(self) -> Iterator[dict[str, Any]]:
+        """Yield each FSx Lustre filesystem dict, filtering out other file-system types."""
+        try:
+            paginator = self._fsx.get_paginator("describe_file_systems")
+            for page in paginator.paginate():
+                for fs in page.get("FileSystems", []):
+                    if fs.get("FileSystemType") != "LUSTRE":
+                        continue
+                    yield fs
+        except Exception as exc:
+            raise _classify_client_error(exc, context="fsx:DescribeFileSystems") from exc
+
+    def _fs_to_volume(self, fs: dict[str, Any], *, tenant_id: str) -> Volume:
+        """Convert an FSx filesystem row to a Volume."""
+        fs_id = fs.get("FileSystemId", "")
+        tags = _tag_list_to_dict(fs.get("Tags"))
+        capacity_gib = int(fs.get("StorageCapacity") or 0)
+        lifecycle = str(fs.get("Lifecycle") or "").upper()
+        state: VolumeState = _LIFECYCLE_TO_STATE.get(lifecycle, "failed")
+
+        lustre = fs.get("LustreConfiguration") or {}
+        deployment_type = lustre.get("DeploymentType") or self._deployment_type
+        created_at = fs.get("CreationTime") or datetime.now(UTC)
+
+        return Volume(
+            tenant_id=tenant_id,
+            id=fs_id,
+            size_bytes=capacity_gib * GIB,
+            created_at=created_at,
+            type="file",
+            state=state,
+            name=tags.get("Name") or tags.get("CSIVolumeName") or fs_id,
+            csi=CsiSpec(
+                driver="fsx.csi.aws.com",
+                volume_handle=fs_id,
+                fs_type="lustre",
+            ),
+            tier=deployment_type,
+            tags=tags,
+            attributes={
+                "region": self._region,
+                "dns_name": str(fs.get("DNSName") or ""),
+                "deployment_type": str(deployment_type),
+                "cluster_env_tag": tags.get("env", ""),
+                "lifecycle": lifecycle,
+            },
+        )
+
+
+def _tag_matches(tags: Mapping[str, str], f: TagFilter) -> bool:
+    """Return whether a tag filter matches filesystem tags."""
+    if f.key not in tags:
+        return False
+    if not f.values:
+        return True
+    return tags[f.key] in f.values
+
+
+def build_api(attributes: Mapping[str, str] | None = None) -> StorageProvider:
+    """Entry point isvtest calls. Single hook the provider commits to.
+
+    ``attributes`` is the provider's manifest ``attributes`` block (passed by the
+    loader). Composes ``AwsFsxLustreApi`` into a served ``StorageProvider`` via
+    ``new_implementation``: capabilities are detected from the overridden methods.
+    """
+    impl = AwsFsxLustreApi(attributes=attributes)
+    return new_implementation(core=impl._core, impl=impl)

--- a/isvctl/configs/providers/my-isv/config/storage-k8s.yaml
+++ b/isvctl/configs/providers/my-isv/config/storage-k8s.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# K8s storage validation - my-isv living example
+# =============================================================================
+# Runs the canonical Kubernetes suite against an EXISTING cluster (kubectl must
+# already be configured). Two independent inputs:
+#
+#   1. StorageProviderApiCheck is driven from storage-provider-manifest.yaml:
+#      the `setup` step resolves the manifest path and emits
+#      steps.setup.storage.manifest_path, which the check loads in-process.
+#
+#   2. The K8sCsi* / K8sFilesystem* / K8sNfsMountOptions checks get their
+#      StorageClass names from the K8S_CSI_* env vars (or literal overrides in
+#      this file), exactly like every other suite check. Anything left unset
+#      makes that check skip cleanly.
+#
+# Point the checks at your StorageClasses via env vars, e.g.:
+#
+#   export K8S_CSI_SHARED_FS_SC=my-isv-rwx
+#   ISVTEST_INCLUDE_UNRELEASED=1 \
+#     uv run isvctl test run \
+#       -f isvctl/configs/providers/my-isv/config/storage-k8s.yaml \
+#       -- -v -s -k "K8sCsi or K8sFile or K8sNfs or StorageProviderApi"
+#
+# Or set the StorageClass per check under the validations block below.
+
+import:
+  - ../../../suites/k8s.yaml
+  - ../../../suites/storage.yaml
+
+version: "1.0"
+
+commands:
+  kubernetes:
+    steps:
+      # Replaces the suite's cluster-provisioning setup with a manifest read.
+      # Targets a pre-existing cluster: it does not create nodes, so the
+      # kubernetes.* checks fall back to their suite defaults.
+      - name: setup
+        phase: setup
+        command: "python ../../shared/storage_manifest_to_steps.py"
+        timeout: 30
+        env:
+          STORAGE_PROVIDER_MANIFEST: "storage-provider-manifest.yaml"
+          STORAGE_STEP_PLATFORM: "kubernetes"
+      - name: teardown
+        phase: teardown
+        command: "echo"
+        args: ['{"success": true, "platform": "kubernetes", "test_name": "teardown"}']
+        timeout: 10
+
+tests:
+  description: "Kubernetes storage validation (my-isv)"

--- a/isvctl/configs/providers/my-isv/config/storage-k8s.yaml
+++ b/isvctl/configs/providers/my-isv/config/storage-k8s.yaml
@@ -16,7 +16,7 @@
 # =============================================================================
 # K8s storage validation - my-isv living example
 # =============================================================================
-# Runs the canonical Kubernetes suite against an EXISTING cluster (kubectl must
+# Runs the canonical storage suite Kubernetes checks against an EXISTING cluster (kubectl must
 # already be configured). Two independent inputs:
 #
 #   1. StorageProviderApiCheck is driven from storage-provider-manifest.yaml:
@@ -34,12 +34,12 @@
 #   ISVTEST_INCLUDE_UNRELEASED=1 \
 #     uv run isvctl test run \
 #       -f isvctl/configs/providers/my-isv/config/storage-k8s.yaml \
+#       --capability kubernetes \
 #       -- -v -s -k "K8sCsi or K8sFile or K8sNfs or StorageProviderApi"
 #
 # Or set the StorageClass per check under the validations block below.
 
 import:
-  - ../../../suites/k8s.yaml
   - ../../../suites/storage.yaml
 
 version: "1.0"

--- a/isvctl/configs/providers/my-isv/config/storage-provider-manifest.example.yaml
+++ b/isvctl/configs/providers/my-isv/config/storage-provider-manifest.example.yaml
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# Storage Provider Manifest - FULLY-POPULATED EXAMPLE (schema v1alpha2)
+# =============================================================================
+#
+# This file is a reference showing every field a customer can supply. It is NOT
+# wired into any test config - copy `storage-provider-manifest.yaml` (the blank
+# template) instead and fill it in for your environment. See
+# `../scripts/storage/README.md` and the schema
+# `isvctl/schemas/storage-provider-manifest.schema.json`.
+#
+# v1alpha2 mirrors the upstream StorageProvider package manifest:
+#   * package-level `namespace` + `vendor` (registration domain + vendor meta);
+#   * an optional package-wide `defaultCapabilities` policy;
+#   * a per-provider `provider` identity block (name / description / type /
+#     protocols / version) + optional `backend` metadata;
+#   * a hierarchical `capabilities` block using native | default | none with
+#     group cascade, plus optional L2 `capability_qualifiers`.
+#
+# The manifest drives `StorageProviderApiCheck` (N-019/N-020/N-021) ONLY: it
+# imports each provider's `shim.module` in-process and exercises the StorageApi
+# contract. The declared identity + capabilities are a CONTRACT cross-checked
+# against the shim's properties(). The CSI / NFS / POSIX filesystem checks get
+# their StorageClass names and protocol expectations from their own config
+# (suite/provider YAML literals or K8S_CSI_* env vars), NOT from this manifest.
+#
+# It models a multi-backend cluster: one managed shared-filesystem provider with
+# a management-API shim, and one backend that has no management shim yet (so the
+# StorageProvider API check skips it).
+
+schema_version: v1alpha2
+
+# Package identity (the package manifest namespace + vendor). With each provider's id
+# this forms the registration key <namespace>/<id>.
+namespace: acme.example.com
+vendor:
+  vendorName: ACME Storage
+  vendorDocs: https://docs.acme.example.com/storage
+
+# Package-wide capability policy. A provider's own capabilities block overrides
+# this; a `default:` here applies to any leaf neither block declares.
+defaultCapabilities:
+  default: none
+
+providers:
+  # ---------------------------------------------------------------------------
+  # Provider 1: managed shared filesystem (NFS/RWX) with a management shim.
+  # The shim drives the StorageProvider API checks; the CSI driver owns the
+  # volume lifecycle, so volume.create/volume.delete are declared `none`
+  # (create_volume raises NotSupportedError and the check falls back to
+  # list_volumes()).
+  # ---------------------------------------------------------------------------
+  - id: shared-fs
+    name: acme-shared-fs
+    # Default backend tenant. Round-trips on Volume.tenant_id / TenantQuota.
+    tenant_id: tenant-a
+    sdk_version: v1alpha1
+
+    # Implementor identity (mirrors ProviderProperties / VersionMetadata). type
+    # + protocols + version are cross-checked against the shim's properties().
+    provider:
+      name: ACME Shared FS
+      description: ACME managed shared filesystem fronting VAST
+      type: file # file | block (FILE/BLOCK also accepted)
+      protocols: [nfsv4] # lustre | nfsv4 | nfsv3 | smb | nvme | iscsi ...
+      version: 1.2.0 # implementor semver
+
+    # The storage system fronted (optional, may differ from the implementor).
+    # version is an opaque vendor passthrough.
+    backend:
+      vendorName: VAST Data
+      name: VAST
+      version: "5.1"
+
+    shim:
+      kind: python # python (in-process) | rest (Phase 2 endpoint, skipped today)
+      # Resolved relative to this manifest's parent directory. In a real
+      # cluster this names a key inside the per-provider ConfigMap below.
+      module: ../scripts/storage/api.py
+      configmap: shim-acme-shared-fs # (k8s) ConfigMap holding the shim
+      credentials_secret: creds-acme-shared-fs # (k8s) Secret holding the credentials
+
+    # Hierarchical capabilities (native | default | none). Lowered by the loader
+    # to a cap_id -> supported? map and cross-checked against properties():
+    # StorageProviderApiCheck fails if a declared surface disagrees with the
+    # shim. A group state cascades to its leaves; a leaf overrides its group.
+    capabilities:
+      tenantManagement: native # tenant.list / tenant.get / tenant.getQuota / tenant.listQuotas
+      volumeManagement:
+        list: native
+        get: native
+        create: none # CSI driver owns provisioning
+        delete: none
+      quotaManagement: native # quota.directory.* + quota.user.*
+
+    # Optional L2 semantic facts (ProviderProperties capability qualifiers),
+    # keyed by capability id or dotted group prefix.
+    capability_qualifiers:
+      quota.directory:
+        idAssignment: backend # VAST mints directory-quota ids (vs "caller" for Lustre)
+
+    tiers: ["standard", "performance"]
+
+    attributes:
+      region: us-east-1
+      storage_path: /tenant-a
+
+  # ---------------------------------------------------------------------------
+  # Provider 2: a block backend with no management shim yet. The StorageProvider
+  # API checks skip it (nothing to test at the management layer). It is listed
+  # here to show how a not-yet-onboarded provider appears in the manifest.
+  # ---------------------------------------------------------------------------
+  - id: block
+    name: acme-block
+    type: block
+    tenant_id: "123456789012" # quoted so YAML keeps leading zeros
+
+    provider:
+      name: ACME Block
+      type: block
+      protocols: [nvme]
+      version: 1.2.0
+
+    # No `shim:` block -> backend has no management API to test, so its
+    # capabilities are not contract-checked.
+
+    attributes:
+      region: us-east-1

--- a/isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml
+++ b/isvctl/configs/providers/my-isv/config/storage-provider-manifest.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Storage Provider Manifest - my-isv living example.
+#
+# v1alpha2 mirrors the upstream StorageProvider package manifest: a package-level
+# namespace + vendor, a per-provider `provider` identity block, and a
+# hierarchical `capabilities` block (native | default | none). At handover this
+# file ships as data["manifest.yaml"] inside a ConfigMap (default name:
+# storage-provider-manifest); in bare-metal mode isvtest reads it from disk.
+#
+# The declared identity + capabilities are a CONTRACT: StorageProviderApiCheck
+# cross-checks them against the running shim's properties(). Keep this in sync
+# with scripts/storage/api.py (MyStorageApi's ProviderProperties core).
+
+schema_version: v1alpha2
+
+# Package identity (the package manifest namespace + vendor). With each provider's id
+# this forms the registration key <namespace>/<id>.
+namespace: my-isv.example.com
+vendor:
+  vendorName: My ISV
+
+providers:
+  # Single sample provider for the my-isv living example. Real handovers
+  # typically list one entry per backend (e.g. a managed shared-FS plus
+  # FSx/EBS for block).
+  - id: my-isv-shared-fs
+    name: my-isv-shared-fs
+    # Cross-check assertion only (NOT the knob): the shim resolves its tenant
+    # from STORAGE_TENANT_ID (default `my-isv-tenant`). StorageProviderApiCheck
+    # fails if get_tenant_quota().tenant_id disagrees, so keep the two in sync.
+    tenant_id: my-isv-tenant
+    sdk_version: v1beta1
+
+    # Implementor identity (mirrors ProviderProperties / VersionMetadata). type
+    # + protocols + version are cross-checked against the shim's properties().
+    provider:
+      name: My ISV Shared FS
+      description: my-isv managed shared filesystem (living example)
+      type: file
+      protocols: [nfsv4]
+      version: 0.1.0
+
+    shim:
+      kind: python
+      # Resolved relative to this manifest's parent directory. In a real
+      # cluster this names a key inside the per-provider ConfigMap
+      # (providers[].shim.configmap) instead.
+      module: ../scripts/storage/api.py
+
+    # Hierarchical capabilities (native | default | none), lowered by the loader
+    # to a cap_id -> supported? map. This example backs tenant-quota visibility
+    # and volume read (list/get); the CSI driver owns volume lifecycle, so
+    # create/delete are `none` (flip them to native only if your shim provisions
+    # volumes itself). No tenant enumeration or directory/user quotas - matching
+    # the MyStorageApi surface in scripts/storage/api.py.
+    capabilities:
+      tenantManagement:
+        list: none
+        get: none
+        getQuota: native
+      volumeManagement:
+        list: native
+        get: native
+        create: none # CSI driver owns volume lifecycle
+        delete: none
+      quotaManagement: none
+
+    attributes:
+      region: my-isv-region

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -31,7 +31,7 @@ template, then fill in the TODOs.
 | `control-plane/` | 11 | [`suites/control-plane.yaml`](../../../suites/control-plane.yaml) | [`config/control-plane.yaml`](../config/control-plane.yaml) | [`providers/aws/scripts/control-plane/`](../../aws/scripts/control-plane/) |
 | `vm/` | 12 | [`suites/vm.yaml`](../../../suites/vm.yaml) | [`config/vm.yaml`](../config/vm.yaml) | [`providers/aws/scripts/vm/`](../../aws/scripts/vm/) |
 | `bare_metal/` | 14 | [`suites/bare_metal.yaml`](../../../suites/bare_metal.yaml) | [`config/bare_metal.yaml`](../config/bare_metal.yaml) | [`providers/aws/scripts/bare_metal/`](../../aws/scripts/bare_metal/) |
-| `storage/` | 20 | [`suites/storage.yaml`](../../../suites/storage.yaml) | [`config/storage.yaml`](../config/storage.yaml) | [`providers/aws/scripts/storage/`](../../aws/scripts/storage/) |
+| `storage/` | 21 | [`suites/storage.yaml`](../../../suites/storage.yaml) | [`config/storage.yaml`](../config/storage.yaml) | [`providers/aws/scripts/storage/`](../../aws/scripts/storage/) |
 | `network/` | 24 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |
 | `observability/` | 5 | [`suites/observability.yaml`](../../../suites/observability.yaml) | [`config/observability.yaml`](../config/observability.yaml) | [`providers/aws/scripts/observability/`](../../aws/scripts/observability/) |
 | `image-registry/` | 7 | [`suites/image-registry.yaml`](../../../suites/image-registry.yaml) | [`config/image-registry.yaml`](../config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../aws/scripts/image-registry/) |
@@ -42,6 +42,14 @@ template, then fill in the TODOs.
 The `k8s/` and `slurm/` examples drive a **real** cluster (validations shell out
 to `kubectl` / `sinfo`), so they are not part of `make demo-test` — a
 dummy-success stub has nothing to return for them.
+
+> The `storage/` domain is the first to use the Storage
+> Provider Shim (the [`StorageApi`](../../../../../isvtest/src/isvtest/core/storage_provider/api.py)
+> ABC) instead of
+> per-test-case scripts: one [`api.py`](storage/api.py) per backend
+> subclasses `StorageApi` and a [provider manifest](../config/storage-provider-manifest.yaml)
+> declares which `api.py` to load. See [`storage/README.md`](storage/README.md)
+> for the authoring guide.
 
 See [`suites/README.md`](../../../suites/README.md) for the per-step / per-field breakdown.
 

--- a/isvctl/configs/providers/my-isv/scripts/storage/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/storage/README.md
@@ -1,0 +1,170 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# my-isv storage shim
+
+Storage Provider Shim - one Python file per backend storage
+provider implementing the [`StorageApi`](../../../../../../isvtest/src/isvtest/core/storage_provider/api.py)
+ABC. Drives the storage acceptance subsets that
+the [`StorageProviderApiCheck`](../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
+validation runs.
+
+## The two pieces
+
+```text
+config/storage-provider-manifest.yaml   <- declares the provider(s)
+                                            (see the JSON schema)
+                  │
+                  ▼ providers[].shim.module points at
+scripts/storage/api.py                  <- StorageApi subclass +
+                                            build_api() factory
+```
+
+The manifest is the discovery surface. `StorageProviderApiCheck` reads
+the manifest from `manifest_path`, iterates each `providers[]` entry
+with a `shim:` block, calls `build_api()`, and runs N-019/N-020/N-021
+against the returned `StorageApi`. CSI-only providers (no `shim:` block)
+are skipped at the shim layer and exercised by the existing `K8sCsi*`
+checks instead.
+
+## Manifest structure (schema v1alpha2)
+
+The manifest describes the storage provider's shim contract — it drives
+`StorageProviderApiCheck` only. At the package level it carries `namespace`
+(the DNS domain you control) and optional `vendor` metadata; with each
+provider's `id` the namespace forms the registration key `<namespace>/<id>`.
+Per provider it carries:
+
+- `provider` — implementor identity block (`name`, `description`, `type`,
+  `protocols`, `version`) mirroring `ProviderProperties` / `VersionMetadata`.
+  `type` + `protocols` + `version` are cross-checked against the shim's
+  `properties()`. Top-level `name`/`type` are derived from it when omitted.
+- `backend` — optional metadata for the storage system fronted (its `version`
+  is an opaque vendor passthrough).
+- `shim` — `kind` + `module` (plus production `configmap`/`credentials_secret`).
+- `capabilities` — a hierarchical `native | default | none` block
+  (`tenantManagement`, `volumeManagement`, `quotaManagement`).
+
+StorageClass names, NFS mount-option expectations, node selectors, and kernel
+modules are NOT in the manifest: the `K8sCsi*` / `K8sFilesystem*` checks read
+them from the suite/provider config or the `K8S_CSI_*` env vars.
+
+### The manifest is a contract
+
+Declared identity (the `provider` block) and `capabilities` are not
+documentation: for providers
+with a `shim:` block, `StorageProviderApiCheck` cross-checks each declared
+value and **fails on a mismatch** (a `manifest-consistency[<name>]` subtest,
+plus `volumeManagement.create` enforced in `volume-provisioning` and
+`tenant_id` in `tenant-quota`). Identity fields are checked against the shim's
+`properties()`; each capability declared **supported** is **probed at
+runtime** — the shim must not raise `NotSupportedError` / `NotImplementedError`
+for it. So you can't declare `provider.protocols: [lustre]` or
+`quotaManagement.directory: native` unless the shim actually backs it. Omit a
+field to leave it unchecked; declare a surface `none` to leave it unprobed.
+
+Two artifacts ship beside this README under `../../config/`:
+
+- `storage-provider-manifest.yaml` — the **blank template** (one working
+  provider, heavily commented). Copy and fill it in.
+- `storage-provider-manifest.example.yaml` — a **fully-populated** multi-
+  provider reference showing every field.
+
+The schema is `isvctl/schemas/storage-provider-manifest.schema.json`.
+`v1alpha1` manifests still load.
+
+## Driving the tests
+
+The manifest drives `StorageProviderApiCheck` ONLY. `storage_manifest_to_steps.py`
+(`../../../shared/`) resolves the manifest path in a setup step and emits
+`steps.setup.storage.manifest_path`, which the check loads in-process.
+
+The CSI / NFS / POSIX filesystem checks are config-driven like every other suite
+check: set their StorageClass names via the `K8S_CSI_*` env vars (or literal
+overrides in your config). Resolution is **explicit YAML → `K8S_CSI_*` env var →
+skip**. Two configs wire this up:
+
+- `../../config/storage.yaml` — bare-metal shim-only run (no cluster):
+
+  ```bash
+  ISVCTL_DEMO_MODE=1 ISVTEST_INCLUDE_UNRELEASED=1 \
+    uv run isvctl test run -f isvctl/configs/providers/my-isv/config/storage.yaml
+  ```
+
+- `../../config/storage-k8s.yaml` — runs the Kubernetes storage suite against an
+  existing cluster (StorageProviderApiCheck from the manifest; CSI/filesystem
+  checks from `K8S_CSI_*` env vars):
+
+  ```bash
+  export K8S_CSI_SHARED_FS_SC=my-isv-rwx
+  ISVTEST_INCLUDE_UNRELEASED=1 \
+    uv run isvctl test run \
+      -f isvctl/configs/providers/my-isv/config/storage-k8s.yaml \
+      -- -k "K8sCsi or K8sFile or K8sNfs or StorageProviderApi"
+  ```
+
+## Authoring checklist
+
+1. **Backend connection.** Edit `MyStorageApi.__init__` in
+   [`api.py`](api.py) to read your endpoint URL / credentials from
+   environment variables (or `/etc/shim/config.yaml` once the per-provider
+   ConfigMap topology lands).
+2. **`health_check`** - authenticated round-trip to the management API.
+   Raise `AuthenticationError` on 401/403; return `None` on success.
+   Drives N-019.
+3. **`get_tenant_quota`** - return `TenantQuota(tenant_id, hard_limit_bytes,
+   used_bytes, name)`. Drives N-021. The shim's default tenant comes from the
+   `STORAGE_TENANT_ID` env var (the knob); the manifest's `tenant_id` is a
+   cross-check assertion that must match what `get_tenant_quota` returns.
+4. **`list_volumes`** - enumerate volumes in the selected tenant, honoring
+   the optional `ids` / `tag_filters` arguments. Never leak foreign-tenant
+   volumes regardless of filters.
+5. **`create_volume` / `delete_volume`** (optional, off by default) - the
+   scaffold ships these raising `NotSupportedError` with
+   `volumeManagement.create` / `.delete` declared `none`: the managed-K8s
+   default where the CSI driver owns provisioning, so the suite falls back to
+   inventorying existing volumes via `list_volumes` (N-020). Implement both and
+   flip those two entries to `native` only if your shim provisions volumes
+   itself.
+6. **Directory / user quota methods** (optional) - the scaffold ships
+   these as stubs that raise `NotSupportedError`. Implement the ones your
+   backend backs and declare the matching surface `native` in the
+   manifest's `quotaManagement` block; leave the rest as raising stubs and
+   declare them `none`. Validation probes each surface declared supported
+   and fails if it raises the sentinel. Attach L2 qualifiers via the
+   `capability_qualifiers()` hook.
+
+Every method has a `TODO` block marking the spot to replace.
+
+## Demo mode
+
+The skeleton ships with a `DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE")
+== "1"` gate on the implemented surfaces (`health_check`, `get_tenant_quota`,
+`list_volumes`): real runs raise `NotImplementedError` /
+`AuthenticationError` to make it obvious the backend isn't wired up; demo runs
+return dummy data so the validation passes end-to-end. The optional
+`create_volume` / `delete_volume` stay raising `NotSupportedError` either way
+(volume-provisioning then reports a clean skip). To exercise the storage check
+in demo mode (the new check ships unreleased, so the orchestrator skips it by
+default):
+
+```bash
+ISVCTL_DEMO_MODE=1 ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run -f isvctl/configs/providers/my-isv/config/storage.yaml
+```
+
+## What ships at handover
+
+Once your `api.py` is real, the production delivery bundles:
+
+- The manifest (`config/storage-provider-manifest.yaml`) into a well-known
+  ConfigMap (default name `storage-provider-manifest`).
+- Each provider's `api.py` (plus optional `config.yaml`) into a
+  provider-chosen per-provider ConfigMap.
+- Per-provider credentials into a provider-chosen Secret.
+
+The future operator sidecar (out of scope for this iteration) will load
+the same `api.py` from its ConfigMap mount and serve the canonical REST
+contract on `localhost:9090`.

--- a/isvctl/configs/providers/my-isv/scripts/storage/api.py
+++ b/isvctl/configs/providers/my-isv/scripts/storage/api.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Storage shim template (copy and fill in for your backend).
+
+Each method has a ``TODO`` block - swap in your backend's SDK / REST / CLI
+calls and return the appropriate dataclass. The ``ISVCTL_DEMO_MODE=1`` gate
+returns dummy data so a demo acceptance run passes end-to-end before the real
+backend is wired up (see the demo command in ``README.md``).
+
+The shim subclasses ``Implementation`` and is composed by ``new_implementation()``
+in ``build_api()``. You declare identity once as a static ``ProviderProperties``
+*core*, then implement ONLY the surfaces your backend serves. Which capabilities
+are supported is *detected* from the methods you override; ``new_implementation``
+gates everything else. This is the key rule of the detection model:
+
+  **To say "not supported", simply do NOT define the method** - inherit the base.
+  Do NOT ship a stub that raises: an overridden method reads as *supported* and
+  fails the suite when probed.
+
+The sibling ``config/storage-provider-manifest.yaml`` is the contract the
+validation suite probes: every capability it marks ``supported`` must answer,
+and a surface you did not implement must be declared ``none``. Keep the two in
+sync - detection and the manifest must agree.
+
+Authoring checklist:
+
+  1. Replace the ``_CORE`` identity declaration with your backend's values.
+  2. Replace ``MyStorageApi.__init__`` with your backend connection setup.
+  3. Fill in ``health_check`` with an authenticated round-trip.
+  4. Fill in ``get_tenant_quota`` and ``list_volumes``.
+  5. To back a surface your backend offers (volume create/delete, directory- or
+     user-quota CRUD, tenant enumeration): ADD the method, declare any L2
+     semantics in ``capability_qualifiers()``, and flip the matching manifest
+     entry to ``native``. To NOT offer one, leave the method undefined and
+     declare it ``none`` (the managed-K8s default is that the CSI driver owns
+     volume lifecycle, so ``create_volume`` / ``delete_volume`` are omitted here
+     and the suite falls back to ``list_volumes``).
+  6. Keep ``config/storage-provider-manifest.yaml`` in sync: every capability it
+     marks ``native``/``default`` must be implemented (the suite enforces it).
+"""
+
+from __future__ import annotations
+
+import os
+
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    GetTenantQuotaRequest,
+    Implementation,
+    ImplementationCapabilities,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    ProviderProperties,
+    StorageProvider,
+    TenantQuota,
+    VersionMetadata,
+    Volume,
+    new_implementation,
+)
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+# ----------------------------------------------------------------------
+# TODO: Replace the identity fields with your backend's values.
+#
+# provider_namespace + provider_id form the registration key
+# <namespace>/<id>; provider_metadata.version MUST be semver.
+# backend_metadata is the storage system you front (version is an
+# opaque vendor passthrough). Capabilities are NOT declared here - they
+# are detected from which methods MyStorageApi overrides.
+# ----------------------------------------------------------------------
+_CORE = ProviderProperties(
+    provider_namespace="my-isv.example.com",
+    provider_id="my-isv-shared-fs",
+    provider_metadata=VersionMetadata(
+        vendor_name="My ISV",
+        name="My ISV Shared FS",
+        version="0.1.0",
+    ),
+    sdk_version=API_VERSION,
+    storage_type="file",
+    storage_protocols=["nfsv4"],
+)
+
+
+class MyStorageApi(Implementation):
+    """Replace the TODO blocks with real backend calls.
+
+    Overrides only the surfaces my-isv backs: ``health_check``,
+    ``get_tenant_quota``, ``list_volumes`` (and, by base delegation,
+    ``get_volume``). Everything else is left undefined -> detected as
+    unsupported -> gated by ``new_implementation``.
+    """
+
+    def __init__(self) -> None:
+        # ----------------------------------------------------------------------
+        # TODO: Replace this block with your backend connection setup
+        #
+        # 1. Read endpoint + credentials from env / a sidecar config file
+        #    (e.g. /etc/shim/config.yaml, mounted from the per-provider
+        #    ConfigMap referenced by providers[].shim.configmap).
+        # 2. Build any SDK client / HTTP session you need.
+        # ----------------------------------------------------------------------
+        if DEMO_MODE:
+            self._demo_volumes: dict[str, Volume] = {}
+            self._demo_hard_limit_bytes = 100 * 1024**3
+
+    def health_check(self) -> None:
+        """Authenticated round-trip to the backend management API."""
+        # ----------------------------------------------------------------------
+        # TODO: Issue an authenticated GET against your management API
+        # (e.g. a /healthz or /version endpoint). Raise AuthenticationError
+        # on a 401/403; return None on success.
+        # ----------------------------------------------------------------------
+        if DEMO_MODE:
+            return
+        raise NotImplementedError(
+            "Not implemented - replace with your platform's authenticated round-trip "
+            "(raise AuthenticationError on a 401/403)"
+        )
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        """Overall storage utilization for the tenant.
+
+        ``req.tenant_id`` is already resolved to the configured default (see
+        ``build_api``'s ``default_tenant``) by the time it reaches here.
+        """
+        resolved = req.tenant_id
+        # ----------------------------------------------------------------------
+        # TODO: Call your tenant-quota API for `resolved` and return a
+        # TenantQuota(tenant_id, hard_limit_bytes, used_bytes, name).
+        # ----------------------------------------------------------------------
+        if DEMO_MODE:
+            used = sum(v.size_bytes for v in self._demo_volumes.values() if v.tenant_id == resolved)
+            return TenantQuota(
+                tenant_id=resolved,
+                hard_limit_bytes=self._demo_hard_limit_bytes,
+                used_bytes=used,
+                name="my-isv demo tenant",
+            )
+        raise NotImplementedError("Not implemented - replace with your platform's tenant-quota query logic")
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        """Return volumes in the tenant, optionally filtered."""
+        resolved = req.tenant_id
+        wanted_ids = set(req.ids) if req.ids else None
+        filters = list(req.tag_filters)
+        # ----------------------------------------------------------------------
+        # TODO: Query your backend for volumes in `resolved` tenant, honoring
+        # `wanted_ids` and ANDing every TagFilter in `filters`. Keep the
+        # listing scoped to the selected tenant - never leak foreign tenants.
+        # ----------------------------------------------------------------------
+        if DEMO_MODE:
+            result: list[Volume] = []
+            for vol in self._demo_volumes.values():
+                if vol.tenant_id != resolved:
+                    continue
+                if wanted_ids is not None and vol.id not in wanted_ids:
+                    continue
+                if not all(f.key in vol.tags and (not f.values or vol.tags[f.key] in f.values) for f in filters):
+                    continue
+                result.append(vol)
+            return ListVolumesResponse(volumes=tuple(result))
+        raise NotImplementedError("Not implemented - replace with your platform's volume-list logic")
+
+    # ----------------------------------------------------------------------
+    # Optional L2 semantics hook.
+    #
+    # Declare semantic facts a caller needs to behave correctly on a surface
+    # you back (NOT whether it is supported - that is detected). Amend the typed
+    # view in place; a fact set on a group inherits to its leaves, e.g.:
+    #
+    #   from isvtest.core.storage_provider import QUAL_ID_ASSIGNMENT
+    #   caps.quota().directory().set_id_assignment("backend").set_inodes(True)
+    #
+    # `set_state(...)` on a node narrows its runtime availability
+    # ("unavailable" / "disabled") but can never enable an unimplemented surface.
+    # ----------------------------------------------------------------------
+    def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+        return None
+
+
+def build_api() -> StorageProvider:
+    """Entry point isvtest calls. Single hook the provider commits to.
+
+    Composes ``MyStorageApi`` into a served ``StorageProvider`` via
+    ``new_implementation``: capabilities are detected from the overridden
+    methods, and ``default_tenant`` (from ``STORAGE_TENANT_ID``) is injected into
+    any request that leaves ``tenant_id`` unset - so the impl always sees a
+    resolved tenant. That env var is the knob that actually selects the tenant.
+
+    The manifest's ``tenant_id`` field does NOT configure the shim; it is a
+    cross-check assertion. ``StorageProviderApiCheck`` fails if
+    ``get_tenant_quota().tenant_id`` disagrees with the manifest value, so keep
+    ``STORAGE_TENANT_ID`` (or the fallback below) in sync with the manifest's
+    ``tenant_id``.
+    """
+    default_tenant = os.environ.get("STORAGE_TENANT_ID", "my-isv-tenant")
+    return new_implementation(core=_CORE, impl=MyStorageApi(), default_tenant=default_tenant)

--- a/isvctl/configs/providers/shared/storage_manifest_to_steps.py
+++ b/isvctl/configs/providers/shared/storage_manifest_to_steps.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Storage manifest -> step output adapter (provider-neutral).
+
+Resolves a ``storage-provider-manifest.yaml`` to an absolute path and prints
+the JSON the orchestrator stores under ``steps.<name>.storage.manifest_path``,
+which ``StorageProviderApiCheck`` consumes to load the provider shims.
+
+The manifest drives the StorageProvider API check ONLY. The CSI / NFS / POSIX
+filesystem checks get their StorageClass names and protocol expectations from
+their own config (suite/provider YAML literals or ``K8S_CSI_*`` env vars), not
+from this manifest.
+
+This only *resolves* the path - it does NOT load the provider shims (no backend
+connections), so it is safe to run in a setup phase. The authoritative manifest
+parsing happens when ``StorageProviderApiCheck`` loads the manifest in-process.
+
+The manifest path is taken from ``STORAGE_PROVIDER_MANIFEST`` (or the first CLI
+arg) and resolved to an absolute path so the emitted ``storage.manifest_path``
+works regardless of the consumer's cwd. When unset, an empty path is emitted so
+``StorageProviderApiCheck`` skips cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _fail(message: str) -> int:
+    """Emit a failure payload and return a non-zero exit code."""
+    print(json.dumps({"success": False, "error": message}))
+    return 1
+
+
+def _resolve_manifest_path() -> Path | None:
+    raw = (sys.argv[1] if len(sys.argv) > 1 else "") or os.environ.get("STORAGE_PROVIDER_MANIFEST", "")
+    raw = raw.strip()
+    if not raw:
+        return None
+    candidate = Path(raw).expanduser()
+    # Try as-given (relative to cwd), then relative to the repo root walking up.
+    if candidate.is_file():
+        return candidate.resolve()
+    if not candidate.is_absolute():
+        for base in (Path.cwd(), *Path.cwd().parents):
+            probe = base / candidate
+            if probe.is_file():
+                return probe.resolve()
+    return candidate  # non-existent; reported by the caller
+
+
+def main() -> int:
+    platform = os.environ.get("STORAGE_STEP_PLATFORM", "storage")
+    manifest_path = _resolve_manifest_path()
+    if manifest_path is None:
+        # No manifest configured: emit an empty path so StorageProviderApiCheck
+        # skips, and the step still succeeds.
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "platform": platform,
+                    "test_name": "storage_manifest",
+                    "storage": {"manifest_path": ""},
+                }
+            )
+        )
+        return 0
+
+    if not manifest_path.is_file():
+        return _fail(f"storage manifest not found: {manifest_path}")
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "platform": platform,
+                "test_name": "storage_manifest",
+                "storage": {"manifest_path": str(manifest_path)},
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/vast/config/storage-k8s.yaml
+++ b/isvctl/configs/providers/vast/config/storage-k8s.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# K8s storage validation - VAST
+# =============================================================================
+# Runs the canonical Kubernetes suite against the EXISTING cluster your kubectl
+# points at. Two independent inputs:
+#
+#   1. StorageProviderApiCheck is driven from storage-provider-manifest.yaml
+#      (the setup step emits steps.setup.storage.manifest_path). It needs the
+#      VAST_* env vars (see scripts/storage/README.md). To run ONLY the
+#      CSI/filesystem checks without VAST creds, deselect it, e.g.
+#      `-k "K8sCsi or K8sFile or K8sNfs"`.
+#
+#   2. The K8sCsi* / K8sFilesystem* checks target the VAST StorageClass via the
+#      K8S_CSI_* env vars. VAST exposes one RWX NFS class that fills both the
+#      shared_fs and nfs roles. The NFS mount-option expectations are VAST
+#      specific and set as literals under K8sNfsMountOptionsCheck below.
+#
+# Full storage run (CSI + filesystem + shim):
+#
+#   export VAST_ENDPOINT=vms.example.com VAST_TOKEN=... \
+#          VAST_STORAGE_PATH=/exports/k8s
+#   export K8S_CSI_SHARED_FS_SC=vast-nfs \
+#          K8S_CSI_NFS_SC=vast-nfs
+#   ISVTEST_INCLUDE_UNRELEASED=1 \
+#     uv run isvctl test run \
+#       -f isvctl/configs/providers/vast/config/storage-k8s.yaml \
+#       -- -v -s -k "K8sCsi or K8sFile or K8sNfs or StorageProviderApi"
+
+import:
+  - ../../../suites/k8s.yaml
+  - ../../../suites/storage.yaml
+
+version: "1.0"
+
+commands:
+  kubernetes:
+    steps:
+      - name: setup
+        phase: setup
+        command: "python ../../shared/storage_manifest_to_steps.py"
+        timeout: 30
+        env:
+          STORAGE_PROVIDER_MANIFEST: "storage-provider-manifest.yaml"
+          STORAGE_STEP_PLATFORM: "kubernetes"
+      - name: teardown
+        phase: teardown
+        command: "echo"
+        args: ['{"success": true, "platform": "kubernetes", "test_name": "teardown"}']
+        timeout: 10
+
+tests:
+  description: "Kubernetes storage validation (VAST)"
+
+  validations:
+    k8s_storage:
+      checks:
+        # VAST NFS mount-option expectations (StorageClass mountOptions:
+        # vers=4.1, proto=tcp, nconnect=16). read_ahead_kb is
+        # host/BDI-dependent and not set by the SC, so it is left empty (that
+        # subtest skips). StorageClass names come from K8S_CSI_NFS_SC /
+        # K8S_CSI_SHARED_FS_SC. Lives under k8s_storage in suites/storage.yaml.
+        K8sNfsMountOptionsCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}
+          expected_version: "4.1"
+          expected_proto: "tcp"
+          expected_nconnect: "16"
+          expected_read_ahead_kb: ""
+    k8s_filesystem:
+      checks:
+        # Restrict probe pods to nodes where the VAST CSI driver
+        # (scd.vastdata.com) is registered. The example selector below assumes
+        # those nodes carry the GPU-present label; change it if your cluster
+        # uses a different scheduling label. Verify the matching nodes carry
+        # the VAST driver with:
+        #   kubectl get nodes -l nvidia.com/gpu.present=true
+        #   kubectl get csinodes -o custom-columns=NODE:.metadata.name,DRIVERS:'.spec.drivers[*].name'
+        K8sFileLockingCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}
+        K8sCrossNodeWriteVisibilityCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}
+        K8sCrossNodeAttrConsistencyCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}
+        K8sLargeDirListingFilesCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}
+        K8sLargeDirListingDirsCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}
+        K8sPosixComplianceCheck:
+          node_selector: {nvidia.com/gpu.present: "true"}

--- a/isvctl/configs/providers/vast/config/storage-k8s.yaml
+++ b/isvctl/configs/providers/vast/config/storage-k8s.yaml
@@ -16,7 +16,7 @@
 # =============================================================================
 # K8s storage validation - VAST
 # =============================================================================
-# Runs the canonical Kubernetes suite against the EXISTING cluster your kubectl
+# Runs the canonical storage suite Kubernetes checks against the EXISTING cluster your kubectl
 # points at. Two independent inputs:
 #
 #   1. StorageProviderApiCheck is driven from storage-provider-manifest.yaml
@@ -39,10 +39,10 @@
 #   ISVTEST_INCLUDE_UNRELEASED=1 \
 #     uv run isvctl test run \
 #       -f isvctl/configs/providers/vast/config/storage-k8s.yaml \
+#       --capability kubernetes \
 #       -- -v -s -k "K8sCsi or K8sFile or K8sNfs or StorageProviderApi"
 
 import:
-  - ../../../suites/k8s.yaml
   - ../../../suites/storage.yaml
 
 version: "1.0"

--- a/isvctl/configs/providers/vast/config/storage-provider-manifest.yaml
+++ b/isvctl/configs/providers/vast/config/storage-provider-manifest.yaml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VAST Storage Provider Manifest (schema v1alpha2).
+#
+# Drives StorageProviderApiCheck ONLY, via the VMS REST API shim
+# (../scripts/storage/vast/api.py) - config/storage.yaml (no cluster).
+#
+# v1alpha2 mirrors the upstream StorageProvider package manifest: a package-level
+# namespace + vendor, a per-provider `provider` identity block, and a
+# hierarchical `capabilities` block (native | default | none). The declared
+# identity + capabilities are a CONTRACT: StorageProviderApiCheck cross-checks
+# them against the running shim's properties(). Keep this in sync with
+# ../scripts/storage/vast/api.py (VastApi's ProviderProperties core).
+#
+# The K8sCsi* / K8sFilesystem* / K8sNfsMountOptions checks get their StorageClass
+# names and NFS expectations from config/storage-k8s.yaml (or K8S_CSI_* env
+# vars), NOT from this manifest. One entry per (tenant, storage_path) pair; add
+# entries to validate more.
+
+schema_version: v1alpha2
+
+# Package identity (the package manifest namespace + vendor). With each provider's id
+# this forms the registration key <namespace>/<id>.
+namespace: vastdata.com
+vendor:
+  vendorName: NVIDIA
+
+providers:
+  - id: vast-nfs
+    name: vast-nfs
+    # tenant_id is the VAST tenant name sent as the `X-Tenant-Name` header.
+    # Omit (or leave empty) to use the VMS default tenant. When set, it is
+    # cross-checked against get_tenant_quota().tenant_id and must equal the
+    # shim's VAST_TENANT at runtime.
+    # tenant_id: my-vast-tenant
+    sdk_version: v1beta1
+
+    # Implementor identity (mirrors ProviderProperties / VersionMetadata). type
+    # + version are cross-checked against the shim's properties().
+    provider:
+      name: VAST NFS
+      description: VAST Data shared filesystem fronted by the VMS REST API shim
+      type: file
+      protocols: [nfsv4]
+      version: 0.1.0
+      # protocols is cross-checked against the shim's properties() (which
+      # reports "nfsv4"). The on-wire NFS version (vers=4.1) is asserted by
+      # K8sNfsMountOptionsCheck (config/storage-k8s.yaml).
+
+    # The storage system fronted. version is an opaque vendor passthrough
+    # (StorageClass label helm.sh/chart: vast-2.6.4); not contract-checked.
+    backend:
+      vendorName: VAST Data
+      name: VAST
+      version: "2.6.4"
+
+    # Management-API shim: drives StorageProviderApiCheck (health_check, tenant +
+    # volume read, directory + user quota CRUD). create/delete are unimplemented
+    # (the CSI driver owns lifecycle). Needs VAST_ENDPOINT, VAST_TOKEN (or
+    # VAST_USERNAME+VAST_PASSWORD) and VAST_STORAGE_PATH at runtime.
+    shim:
+      kind: python
+      # Resolved relative to this manifest's parent directory.
+      module: ../scripts/storage/vast/api.py
+
+    # Hierarchical capabilities (native | default | none), lowered by the loader
+    # to a cap_id -> supported? map and cross-checked against properties():
+    # StorageProviderApiCheck fails if a declared surface disagrees with the
+    # shim. Matches the VastApi capability core in scripts/storage/vast/api.py:
+    # tenant + volume read + full directory/user quota. Volume lifecycle is
+    # CSI-owned, so create/delete stay `none`.
+    capabilities:
+      tenantManagement: native # single tenant (tenant.list/get/getQuota/listQuotas)
+      volumeManagement:
+        list: native
+        get: native
+        create: none # CSI owns lifecycle -> create_volume is unimplemented
+        delete: none
+      quotaManagement: native # quota.directory.* + quota.user.*
+
+    # Optional L2 semantic facts (ProviderProperties capability qualifiers),
+    # keyed by capability id or dotted group prefix. Mirrors the shim's
+    # capability_qualifiers() hook (qualifier keys documented in api.py).
+    # Multi-tenant=false is set on the shim's capability_qualifiers() hook.
+    capability_qualifiers:
+      quota.directory:
+        idAssignment: backend # VAST mints directory-quota ids; path is the key
+        accounting: nested # overlapping subjects charge the most-restrictive cap
+        inodes: "true"
+      quota.user:
+        defaultUserSlot: "true" # default_user_quota slot supported
+        inodes: "true"
+
+    attributes:
+      # MUST match VAST_STORAGE_PATH at runtime (informational here; the shim
+      # reads the env var directly). Matches the StorageClass root_export.
+      storage_path: /exports/k8s

--- a/isvctl/configs/providers/vast/config/storage.yaml
+++ b/isvctl/configs/providers/vast/config/storage.yaml
@@ -46,7 +46,6 @@ commands:
 tests:
   cluster_name: "vast-storage-validation"
   description: "VAST storage shim validation"
-  platform: storage
 
   validations:
     storage_provider_api:

--- a/isvctl/configs/providers/vast/config/storage.yaml
+++ b/isvctl/configs/providers/vast/config/storage.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VAST Storage Provider Shim - Standalone validation config.
+#
+# Drives StorageProviderApiCheck against a live VAST cluster via the VMS
+# REST API shim. No Kubernetes cluster required: the shim is imported
+# in-process.
+#
+# Required environment variables (see scripts/storage/README.md):
+#   VAST_ENDPOINT       VMS hostname or URL
+#   VAST_TOKEN          API token  (or VAST_USERNAME + VAST_PASSWORD)
+#   VAST_STORAGE_PATH   Root export path (e.g. /exports/k8s)
+#
+# StorageProviderApiCheck is unreleased and skipped by default; set
+# ISVTEST_INCLUDE_UNRELEASED=1 to exercise it:
+#
+#   ISVTEST_INCLUDE_UNRELEASED=1 \
+#     uv run isvctl test run \
+#       -f isvctl/configs/providers/vast/config/storage.yaml
+
+version: "1.0"
+
+commands:
+  storage:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      - name: preflight
+        phase: setup
+        command: "echo"
+        args: ['{"success": true, "platform": "storage", "test_name": "preflight"}']
+        timeout: 10
+
+tests:
+  cluster_name: "vast-storage-validation"
+  description: "VAST storage shim validation"
+  platform: storage
+
+  validations:
+    storage_provider_api:
+      checks:
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/vast/config/storage-provider-manifest.yaml"
+          volume_size_bytes: 1073741824 # 1 GiB

--- a/isvctl/configs/providers/vast/scripts/storage/README.md
+++ b/isvctl/configs/providers/vast/scripts/storage/README.md
@@ -1,0 +1,274 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VAST storage shim
+
+Storage Provider Shim for VAST Data. Drives
+[`StorageProviderApiCheck`](../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
+against a live VAST cluster via the VMS REST API.
+
+## How it works
+
+The manifest at [`../../config/storage-provider-manifest.yaml`](../../config/storage-provider-manifest.yaml)
+(schema `v1alpha2`) declares one `vast-nfs` provider and drives the management
+API check:
+
+- **Management API** — `shim.module` points at [`vast/api.py`](vast/api.py);
+  `StorageProviderApiCheck` loads the shim in-process and runs the subtests
+  below (config [`../../config/storage.yaml`](../../config/storage.yaml), no
+  cluster needed).
+
+The **Kubernetes CSI / filesystem** checks (`K8sCsi*` / `K8sFilesystem*` /
+`K8sNfsMountOptions`) are config-driven, not manifest-driven: their StorageClass
+names come from the `K8S_CSI_*` env vars and their NFS expectations are literal
+overrides in [`../../config/storage-k8s.yaml`](../../config/storage-k8s.yaml)
+(existing cluster). See "Kubernetes storage checks" below.
+
+`StorageProviderApiCheck` reports a `manifest-consistency[vast-nfs]` subtest
+that cross-checks the manifest's declared `type` / `capabilities` against the
+shim's `properties()` (so the manifest is a contract, not just metadata) — it
+probes every declared-`native` surface (tenant, volume read, and the
+directory/user quota CRUD below) — plus the three subtests:
+
+| Subtest | VMS call |
+| ------- | -------- |
+| `api-authentication[vast-nfs]` | `GET /api/quotas/` (validates credentials) |
+| `volume-provisioning[vast-nfs]` | `GET /api/quotas/` (fallback — CSI driver owns lifecycle) |
+| `tenant-quota[vast-nfs]` | `GET /api/quotas/` — aggregate `hard_limit` + `used_effective_capacity` |
+
+Quota aggregation logic:
+
+- If a directory quota exists at exactly `VAST_STORAGE_PATH`, its
+  `hard_limit` is the tenant capacity ceiling.
+- Otherwise the ceiling is the sum of all child-quota hard limits.
+- Used bytes = sum of `used_effective_capacity` from child quotas.
+
+The shim also implements `list_tenants` / `list_tenant_quotas` for the single
+configured tenant (`VAST_TENANT`, empty = VMS default), declared
+`tenantManagement: native`.
+
+The VAST CSI driver (`csi.vastdata.com` / `scd.vastdata.com`) owns
+volume lifecycle, so `create_volume` / `delete_volume` fall back to the
+base raise (`NotSupportedError`), are declared `none` in the manifest,
+and the acceptance suite falls back to inventorying existing volumes via
+`list_volumes`.
+
+## Directory and user quotas
+
+The shim backs the directory- and user-quota surfaces (declared
+`quotaManagement: native` in the manifest) and wraps the VMS quota
+endpoints. `manifest-consistency[vast-nfs]` cross-checks these capabilities
+(and the L2 qualifiers below) against the shim's `properties()`.
+
+| Surface | VMS call |
+| ------- | -------- |
+| `list_directory_quotas(volume_id)` | `GET /api/quotas/` — the quota subtree rooted at the volume's path |
+| `get_directory_quota(path \| id)` | `GET /api/quotas/?path=…` or `GET /api/quotas/<id>/` |
+| `set_directory_quota(path, hard)` | `POST /api/quotas/` (create) or `PATCH /api/quotas/<id>/` (update `hard_limit` / `hard_limit_inodes`) |
+| `delete_directory_quota(path \| id)` | `DELETE /api/quotas/<id>/` |
+| `list_user_quotas(volume_id)` | `GET /api/quotas/<id>/` (`default_user_quota`) + `GET /api/userquotas/?quota_system_id=<id>` |
+| `set_user_quota(user=None, hard)` | `PATCH /api/quotas/<id>/` (`is_user_quota` + `default_user_quota.hard_limit`) |
+| `set_user_quota(user, hard)` | `POST /api/userquotas/` (`quota_id` / `identifier` / `identifier_type` / `hard_limit`) |
+| `delete_user_quota(user)` | `DELETE /api/userquotas/<id>/` (override) or `PATCH` clearing `default_user_quota` |
+
+Semantics (declared as capability qualifiers via `capability_qualifiers()`):
+
+- **Directory quotas** — VAST mints the quota id (`idAssignment: backend`).
+  `DirectoryQuota.path` is **volume-relative** (per the StorageProvider
+  contract): the shim joins it under the volume's absolute export path for VMS
+  calls and returns volume-relative paths, so `volume_id` + `path` addresses a
+  quota the same way across providers. Overlapping subjects use `nested`
+  accounting (the most-restrictive cap binds); inode limits are honored.
+- **User quotas** — attach to a volume's directory quota via VAST's
+  `quota_system_id` (== the volume/quota id). `user=None` addresses the fs-wide
+  default-user slot (`defaultUserSlot: true`); a non-`None` user is an override
+  whose identifier kind is inferred from the value (numeric → `uid`, otherwise
+  → `username`). Inode limits are honored.
+
+> NOTE: `StorageProviderApiCheck` in this suite drives only N-019/N-020/N-021
+> (auth, volume-provisioning, tenant-quota) plus `manifest-consistency`. The
+> directory/user-quota acceptance subtests (N-022…N-031) are not wired up here
+> yet; the quota methods are exercised by the hermetic unit tests in
+> `isvtest/tests/test_vast_shim.py`.
+
+## Environment variables
+
+| Variable | Required? | Effect |
+| -------- | --------- | ------ |
+| `VAST_ENDPOINT` | Yes | VMS hostname or URL (e.g. `vms.example.com` or `https://vms.example.com`). |
+| `VAST_TOKEN` | Yes¹ | API token (`Authorization: Api-Token <token>`). |
+| `VAST_USERNAME` | Yes¹ | VMS username for basic auth. |
+| `VAST_PASSWORD` | Yes¹ | VMS password (required when `VAST_USERNAME` is set). |
+| `VAST_STORAGE_PATH` | Yes | Root export path to scope to (matches StorageClass `root_export`, e.g. `/exports/k8s`). |
+| `VAST_TENANT` | No | VAST tenant name (`X-Tenant-Name` header). Empty = VMS default tenant. |
+| `VAST_VIP_POOL` | No | VIP pool FQDN or name; used to build the NFS `MountSpec.source` for each volume. |
+| `VAST_INSECURE_SKIP_VERIFY` | No | `1` / `true` to disable TLS cert verification (dev/test only). |
+
+¹ Either `VAST_TOKEN` or `VAST_USERNAME` + `VAST_PASSWORD` must be provided.
+
+## Network locality requirement
+
+The shim makes direct HTTPS calls to the VAST VMS (`VAST_ENDPOINT`).
+Unlike the K8s checks — which go through `kubectl` and work from any
+machine with a valid kubeconfig — the storage shim must run from a host
+that has network access to the VMS endpoint.
+
+In many deployments the VMS is only reachable from within the cluster
+network. If `curl https://$VAST_ENDPOINT/api/quotas/` times out from
+your laptop, use `isvctl deploy run` to execute the suite on a cluster
+node instead:
+
+```bash
+# Run on a node that can reach the VMS (env vars are forwarded automatically)
+uv run isvctl deploy run <node-ip> \
+  -f isvctl/configs/providers/vast/config/storage.yaml
+
+# If the node is behind a bastion:
+uv run isvctl deploy run <node-ip> -j <jumphost> \
+  -f isvctl/configs/providers/vast/config/storage.yaml
+```
+
+## Running against a cluster
+
+From the repo root (on a machine that can reach the VMS):
+
+```bash
+export VAST_ENDPOINT=vms.example.com
+export VAST_TOKEN=<your-api-token>        # or VAST_USERNAME + VAST_PASSWORD
+export VAST_STORAGE_PATH=/exports/k8s     # match your StorageClass root_export
+
+# Sanity-check network access and credentials:
+curl -sS -H "Authorization: Api-Token $VAST_TOKEN" \
+  "https://$VAST_ENDPOINT/api/quotas/" | python3 -m json.tool | head -40
+
+# Run the storage checks (unreleased -> gate env var required):
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/vast/config/storage.yaml
+```
+
+`volume-provisioning[vast-nfs]` reports **skipped (passed)** with
+`created_volume not implemented; observed N CSI-provisioned volume(s)
+via list_volumes()` — that is the expected fallback when the CSI driver
+owns volume lifecycle, not a failure.
+
+## Kubernetes storage checks
+
+[`../../config/storage-k8s.yaml`](../../config/storage-k8s.yaml) imports the
+canonical Kubernetes suite. StorageClass names come from the `K8S_CSI_*` env
+vars; the VAST NFS mount-option expectations are literal overrides in that
+config (`K8sNfsMountOptionsCheck`: `vers=4.1`, `proto=tcp`, `nconnect=16`). These
+run over `kubectl` against the existing cluster (no VMS access needed):
+
+```bash
+# CSI + filesystem checks only (no VAST creds required):
+export K8S_CSI_SHARED_FS_SC=vast-nfs \
+       K8S_CSI_NFS_SC=vast-nfs
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/vast/config/storage-k8s.yaml \
+    -- -v -s -k "K8sCsi or K8sFile or K8sNfs"
+```
+
+Because the manifest declares a `shim:` block, adding `StorageProviderApiCheck`
+to the selection (or running everything) also loads the shim, which needs the
+`VAST_*` env vars above:
+
+```bash
+export VAST_ENDPOINT=vms.example.com VAST_TOKEN=<token> \
+       VAST_STORAGE_PATH=/exports/k8s
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/vast/config/storage-k8s.yaml \
+    -- -v -s -k "K8sCsi or K8sFile or K8sNfs or StorageProviderApi"
+```
+
+> NOTE: the shim's `properties()` reports protocol `nfsv4` and the manifest
+> declares `provider.protocols: [nfsv4]`; the on-wire NFS version (`vers=4.1`)
+> is asserted by `K8sNfsMountOptionsCheck` (config/storage-k8s.yaml).
+
+### Faster repeat runs of the quota check
+
+`StorageDirectoryQuotaEnforcementCheck` spends most of its wall time
+provisioning a PVC and waiting for a BusyBox pod to go Ready. When iterating,
+create those once and point the check at them with `pvc_name` / `pvc_namespace`
+/ `pod_name`. Each run then only creates its own probe subdirectory and quota
+and removes both afterwards, leaving the pod and PVC for the next run:
+
+```yaml
+# quota-probe.yaml - apply once into a namespace you create
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: { name: quota-probe, namespace: isvtest-quota }
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: vast-nfs
+  resources: { requests: { storage: 5Gi } }
+---
+apiVersion: v1
+kind: Pod
+metadata: { name: quota-probe, namespace: isvtest-quota }
+spec:
+  # Match the harness pod's identity, or writes into /data may be squashed.
+  securityContext: { runAsUser: 65534, runAsGroup: 65534, fsGroup: 65534 }
+  containers:
+    - name: probe
+      image: busybox:1.36
+      command: ["sh", "-c", "while true; do sleep 3600; done"]
+      volumeMounts: [{ name: data, mountPath: /data }]
+  volumes:
+    - name: data
+      persistentVolumeClaim: { claimName: quota-probe }
+```
+
+Then pass an override alongside the usual config (`-f` files deep-merge, so the
+suite's `manifest_path` is retained):
+
+```yaml
+# quota-reuse.yaml
+tests:
+  validations:
+    k8s_storage:
+      checks:
+        StorageDirectoryQuotaEnforcementCheck:
+          pvc_namespace: isvtest-quota
+          pvc_name: quota-probe
+          pod_name: quota-probe
+```
+
+```bash
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/vast/config/storage-k8s.yaml \
+    -f quota-reuse.yaml \
+    -- -v -s -k "StorageDirectoryQuotaEnforcement"
+```
+
+Delete the namespace when you are done - nothing reclaims it for you.
+
+## Multiple tenants or storage paths
+
+To validate multiple VAST tenants or root exports, add extra provider
+entries to `storage-provider-manifest.yaml` and set the corresponding
+env vars.  Each provider entry gets its own `build_api()` call.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| All subtests time out (~75s each) | VMS not reachable from this machine | Use `isvctl deploy run <node-ip> -f ...` to run from inside the cluster network |
+| `api-authentication[...] FAILED ... AuthenticationError` | Invalid token / expired password / wrong endpoint | Verify creds with a raw `curl` call (see above) |
+| `api-authentication[...] FAILED ... SSL` | Self-signed VMS cert | Set `VAST_INSECURE_SKIP_VERIFY=1` (test only) |
+| `tenant-quota[...] FAILED ... hard_limit_bytes=0` | No quotas exist under `VAST_STORAGE_PATH` | Check `VAST_STORAGE_PATH` matches your VMS quota tree |
+| `volume-provisioning[...] SKIPPED ... observed 0 ...` | No PVCs provisioned against the VAST StorageClass | Create a PVC first, then re-run |
+| `VAST_ENDPOINT must be set` | Env var unset | `export VAST_ENDPOINT=...` |
+| `VAST_STORAGE_PATH must be set` | Env var unset | `export VAST_STORAGE_PATH=...` |
+| Orchestrator logs `Skipping unreleased validation 'StorageProviderApiCheck'` | `ISVTEST_INCLUDE_UNRELEASED=1` not set | Re-run with the env var |
+
+## See also
+
+- [`isvtest/src/isvtest/core/storage_provider/`](../../../../../../isvtest/src/isvtest/core/storage_provider/) — `StorageApi` ABC + value types
+- [`isvctl/configs/providers/aws/scripts/storage/fsx-lustre/`](../../../aws/scripts/storage/fsx-lustre/) — AWS FSx Lustre reference implementation
+- [VAST quota documentation](https://kb.vastdata.com/documentation/docs/overview-of-quotas-1)

--- a/isvctl/configs/providers/vast/scripts/storage/README.md
+++ b/isvctl/configs/providers/vast/scripts/storage/README.md
@@ -9,6 +9,12 @@ Storage Provider Shim for VAST Data. Drives
 [`StorageProviderApiCheck`](../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
 against a live VAST cluster via the VMS REST API.
 
+This implementation is a working reference example for exercising the storage
+provider contract against representative VAST environments. It is not an
+officially supported integration or a compatibility guarantee; validate the
+behavior against your VAST release, topology, CSI driver, API permissions, and
+quota model before relying on the results.
+
 ## How it works
 
 The manifest at [`../../config/storage-provider-manifest.yaml`](../../config/storage-provider-manifest.yaml)

--- a/isvctl/configs/providers/vast/scripts/storage/vast/api.py
+++ b/isvctl/configs/providers/vast/scripts/storage/vast/api.py
@@ -222,9 +222,12 @@ def _volume_matches_quota(q: dict[str, Any], volume_id: str) -> bool:
         return False
     if str(q.get("id") or "") == volume_id:
         return True
-    qpath = _norm_path(q.get("path") or "")
-    if not qpath:
+    # Test the raw path before normalising: _norm_path("") becomes "/", which
+    # would otherwise match almost any absolute volume_id / CSI handle.
+    raw_path = (q.get("path") or "").strip("/")
+    if not raw_path:
         return False
+    qpath = _norm_path(raw_path)
     if qpath == _norm_path(volume_id):
         return True
     return volume_id.endswith(qpath) or qpath in volume_id
@@ -350,10 +353,10 @@ class VastApi(Implementation):
         """Aggregate hard limit and used capacity for all quotas under ``storage_path``.
 
         * If a quota exists at exactly ``storage_path``, its ``hard_limit``
-          is the tenant capacity ceiling.
-        * Otherwise the ceiling is the sum of all child-quota hard limits.
-        * Used bytes is always the sum of ``used_effective_capacity`` from
-          child quotas.
+          is the tenant capacity ceiling and its ``used_effective_capacity``
+          is the reported usage (covers the common single-root-quota layout).
+        * Otherwise the ceiling and usage are the sum of child-quota hard
+          limits / ``used_effective_capacity``.
         """
         resolved = self._resolve_tenant(req.tenant_id)
         quotas = self._list_quotas_all()
@@ -371,11 +374,11 @@ class VastApi(Implementation):
         if parent is not None:
             hard_limit_bytes = int(parent.get("hard_limit") or 0)
             name = str(parent.get("name") or storage_path)
+            used_bytes = int(parent.get("used_effective_capacity") or 0)
         else:
             hard_limit_bytes = sum(int(q.get("hard_limit") or 0) for q in children)
             name = f"VAST {storage_path}"
-
-        used_bytes = sum(int(q.get("used_effective_capacity") or 0) for q in children)
+            used_bytes = sum(int(q.get("used_effective_capacity") or 0) for q in children)
 
         return TenantQuota(
             tenant_id=resolved,

--- a/isvctl/configs/providers/vast/scripts/storage/vast/api.py
+++ b/isvctl/configs/providers/vast/scripts/storage/vast/api.py
@@ -1,0 +1,894 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VAST Data ``StorageProvider`` shim.
+
+Calls the VAST VMS REST API. The shim subclasses ``Implementation`` and is
+served through ``new_implementation()``: it implements only the surfaces it
+backs, and the SDK *detects* which are supported. Which surfaces are *supported*
+is also declared in the sibling ``config/storage-provider-manifest.yaml`` (the
+contract); the validation suite probes each declared-supported surface at
+runtime and fails if it raises ``NotSupportedError``. Surfaces this shim does not
+back (volume lifecycle) are left undefined - detected as unimplemented and gated.
+L2 semantics are declared via ``capability_qualifiers()``.
+
+* ``health_check`` — authenticated GET ``/api/quotas/`` (validates credentials).
+* ``list_tenants`` / ``get_tenant`` — the single configured tenant
+  (``VAST_TENANT``, empty = VMS default).
+* ``get_tenant_quota`` / ``list_tenant_quotas`` — aggregate ``hard_limit`` /
+  ``used_effective_capacity`` across all directory quotas under
+  ``VAST_STORAGE_PATH``.
+* ``list_volumes`` — one ``Volume`` per directory quota under
+  ``VAST_STORAGE_PATH``.  Volume lifecycle is owned by the VAST CSI driver
+  (``csi.vastdata.com`` / ``scd.vastdata.com``); ``create_volume`` /
+  ``delete_volume`` are advertised ``unimplemented`` and the acceptance suite
+  falls back to inventorying existing CSI-provisioned volumes.
+
+Quota model
+-----------
+The directory- and user-quota surfaces wrap the VMS quota endpoints:
+
+* A **volume** is a VAST directory quota (a ``/api/quotas/`` row) that is a
+  child of ``VAST_STORAGE_PATH``; ``volume.id`` is the VAST quota id.
+* **Directory quotas** are the same ``/api/quotas/`` rows. Per the
+  StorageProvider contract their ``path`` is **volume-relative**: the shim
+  joins it under the volume's absolute export path (``_join_vol_path``) for VMS
+  calls and returns volume-relative paths (``_rel_under``). Rows are keyed on
+  the backend numeric ``id`` (``id_assignment=backend``).
+  ``list_directory_quotas(volume_id)`` returns the quota tree rooted at the
+  volume's path (the volume's own quota and any nested quotas); ``set`` PATCHes
+  an existing row or POSTs a new one; ``delete`` removes it.
+* **User quotas** attach to a volume's directory quota via VAST's
+  ``quota_system_id`` (== the volume/quota id). The default-user slot
+  (``user=None``) maps to the directory quota's ``default_user_quota``; per-user
+  overrides map to ``/api/userquotas/`` rows. The backend infers the identifier
+  kind from the value (numeric -> ``uid``, otherwise -> ``username``).
+
+Tenant scoping
+--------------
+``tenant_id`` maps to the VAST tenant **name** sent as the
+``X-Tenant-Name`` HTTP header.  The default is read from ``VAST_TENANT``
+(empty string = omit the header and use the VMS default tenant).  To
+validate multiple tenants, declare one provider entry per tenant in the
+manifest.
+
+Environment variables
+---------------------
+VAST_ENDPOINT             Required. VMS hostname or URL (e.g. ``vms.example.com``
+                          or ``https://vms.example.com``).
+VAST_TOKEN                API token (``Authorization: Api-Token <token>``).
+                          Either ``VAST_TOKEN`` or ``VAST_USERNAME`` +
+                          ``VAST_PASSWORD`` must be set.
+VAST_USERNAME             VMS username for basic auth.
+VAST_PASSWORD             VMS password for basic auth.
+VAST_TENANT               Optional. VAST tenant name (``X-Tenant-Name`` header).
+                          Empty = VMS default tenant.
+VAST_STORAGE_PATH         Required. Root export path the shim is scoped to
+                          (matches StorageClass ``root_export`` parameter,
+                          e.g. ``/exports/k8s``). Quotas are filtered to this
+                          path and its children.
+VAST_VIP_POOL             Optional. VIP pool FQDN or name used to build the
+                          NFS ``MountSpec.source`` for each volume.
+VAST_INSECURE_SKIP_VERIFY Optional. Set to ``1`` / ``true`` to disable TLS
+                          certificate verification (dev/test only).
+
+See ``scripts/storage/README.md`` (sibling directory).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from base64 import b64encode
+from datetime import UTC, datetime
+from typing import Any
+
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    AuthenticationError,
+    ConflictError,
+    CsiSpec,
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DirectoryQuota,
+    GetDirectoryQuotaRequest,
+    GetTenantQuotaRequest,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    Implementation,
+    ImplementationCapabilities,
+    ListDirectoryQuotasRequest,
+    ListDirectoryQuotasResponse,
+    ListTenantQuotasRequest,
+    ListTenantQuotasResponse,
+    ListTenantsRequest,
+    ListTenantsResponse,
+    ListUserQuotasRequest,
+    ListUserQuotasResponse,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    MountSpec,
+    NotFoundError,
+    ProviderProperties,
+    QuotaLimits,
+    QuotaUsage,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    StorageApiError,
+    StorageProvider,
+    Tenant,
+    TenantQuota,
+    UserQuota,
+    ValidationError,
+    VersionMetadata,
+    Volume,
+    VolumeState,
+    new_implementation,
+)
+
+# Maximum pages for paginated /api/quotas/ and /api/userquotas/ responses
+# (defensive cap).
+_MAX_PAGES = 1000
+
+# Map VAST quota ``state`` field -> shim VolumeState.
+# VAST states are "ok", "exceeded" (hard limit breached), and implementation-
+# defined variants. Anything unrecognised falls through to "failed" so the
+# validation catches it rather than silently passing.
+_QUOTA_STATE_MAP: dict[str, VolumeState] = {
+    "ok": "available",
+    "exceeded": "available",  # still usable; hard limit enforced by VAST
+    "softlimit": "available",
+}
+
+# HTTP status codes that indicate authentication / authorisation failures.
+_AUTH_STATUS_CODES: frozenset[int] = frozenset({401, 403})
+
+# Surfaces this shim backs (declared ``native`` in the manifest, probed by the
+# acceptance suite):
+#   * tenant.list/get/getQuota/listQuotas - the single configured tenant
+#   * volume.list/get   - one Volume per directory quota (get via the SDK base)
+#   * quota.directory.* - /api/quotas/ CRUD (list/get/set/delete)
+#   * quota.user.*      - /api/userquotas/ + the directory quota default-user slot
+# ``get_*`` surfaces ride their ``list_*`` sibling through the SDK base, so only
+# list/set/delete are overridden where needed. Volume lifecycle (create/delete)
+# is owned by the VAST CSI driver, so those methods are left unimplemented
+# (absent) - the base raises NotSupportedError, the manifest declares them
+# ``none``, and the acceptance suite falls back to inventorying existing
+# CSI-provisioned volumes.
+
+
+def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
+    """Build the TLS context for provider API calls."""
+    ctx = ssl.create_default_context()
+    if insecure:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _norm_path(path: str) -> str:
+    """Normalise a VAST export path to a leading-slash, no-trailing-slash form."""
+    return "/" + path.strip("/")
+
+
+def _join_vol_path(root: str, rel: str) -> str:
+    """Join a volume-relative directory-quota ``rel`` path under the volume ``root``.
+
+    Directory-quota paths in the StorageProvider contract are volume-relative
+    (``DirectoryQuota.path``); VAST addresses quotas by absolute VMS path, so
+    the shim joins the two. ``rel`` empty addresses the volume's own directory.
+    """
+    rel = (rel or "").strip("/")
+    base = _norm_path(root).rstrip("/")
+    if not rel:
+        return base or "/"
+    return f"{base}/{rel}" if base else f"/{rel}"
+
+
+def _rel_under(root: str, abs_path: str) -> str:
+    """Return ``abs_path`` expressed relative to the volume ``root`` (``""`` for root)."""
+    an = _norm_path(abs_path)
+    rn = _norm_path(root)
+    if an == rn:
+        return ""
+    prefix = rn.rstrip("/") + "/"
+    return an[len(prefix) :] if an.startswith(prefix) else an.lstrip("/")
+
+
+def _volume_matches_quota(q: dict[str, Any], volume_id: str) -> bool:
+    """True when ``volume_id`` identifies quota ``q`` by VMS id, path, or CSI handle.
+
+    Accepts the backend numeric id, the absolute VMS path, or a CSI
+    ``volumeHandle`` that embeds the export path (the VAST CSI driver keys
+    volumes on their export path), mirroring the WEKA shim's resolver.
+    """
+    if not volume_id:
+        return False
+    if str(q.get("id") or "") == volume_id:
+        return True
+    qpath = _norm_path(q.get("path") or "")
+    if not qpath:
+        return False
+    if qpath == _norm_path(volume_id):
+        return True
+    return volume_id.endswith(qpath) or qpath in volume_id
+
+
+def _identifier_type(user: str) -> str:
+    """Infer VAST ``identifier_type`` from a user value (numeric -> uid)."""
+    return "uid" if user.isdigit() else "username"
+
+
+class VastApi(Implementation):
+    """``StorageProvider`` over the VAST VMS REST API.
+
+    Single-tenant per instance: the shim is scoped to one VAST tenant + one
+    ``storage_path`` prefix.  To validate multiple tenants or storage paths,
+    declare separate provider entries in the manifest.
+    """
+
+    def __init__(
+        self,
+        *,
+        endpoint: str | None = None,
+        token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        tenant: str | None = None,
+        storage_path: str | None = None,
+        vip_pool: str | None = None,
+        insecure_skip_verify: bool | None = None,
+    ) -> None:
+        """Initialize the object with its configured dependencies."""
+        raw_endpoint = endpoint or os.environ.get("VAST_ENDPOINT", "")
+        if not raw_endpoint:
+            raise StorageApiError("VAST_ENDPOINT must be set (env var or constructor arg) for the VAST shim")
+        self._base_url = self._normalise_endpoint(raw_endpoint)
+
+        self._token = token or os.environ.get("VAST_TOKEN", "")
+        self._username = username or os.environ.get("VAST_USERNAME", "")
+        self._password = password or os.environ.get("VAST_PASSWORD", "")
+        if not self._token and not self._username:
+            raise StorageApiError("VAST_TOKEN or VAST_USERNAME + VAST_PASSWORD must be set for the VAST shim")
+        if self._username and not self._password:
+            raise StorageApiError("VAST_PASSWORD must be set when VAST_USERNAME is used for authentication")
+
+        self._tenant = tenant if tenant is not None else os.environ.get("VAST_TENANT", "")
+
+        raw_path = storage_path or os.environ.get("VAST_STORAGE_PATH", "")
+        if not raw_path:
+            raise StorageApiError("VAST_STORAGE_PATH must be set (env var or constructor arg) for the VAST shim")
+        self._storage_path = _norm_path(raw_path)
+
+        self._vip_pool = vip_pool or os.environ.get("VAST_VIP_POOL", "")
+
+        if insecure_skip_verify is not None:
+            skip = insecure_skip_verify
+        else:
+            val = os.environ.get("VAST_INSECURE_SKIP_VERIFY", "")
+            skip = val.lower() in ("1", "true", "yes")
+        self._ssl_ctx = _build_ssl_context(skip)
+
+        # Identity + capability core (mirrors ProviderProperties). provider
+        # version is "0.1.0" until a future revision queries VMS at construction;
+        # it MUST stay in sync with the manifest's provider.version. The backend
+        # version is an opaque vendor passthrough ("unknown" until queried).
+        core = ProviderProperties(
+            provider_namespace="vastdata.com",
+            provider_id="vast-nfs",
+            provider_metadata=VersionMetadata(
+                vendor_name="NVIDIA",
+                name="VAST NFS",
+                version="0.1.0",
+            ),
+            sdk_version=API_VERSION,
+            storage_type="file",
+            storage_protocols=["nfsv4"],
+            backend_metadata=VersionMetadata(
+                vendor_name="VAST Data",
+                vendor_docs="https://kb.vastdata.com/documentation/docs/overview-of-quotas-1",
+                name="VAST",
+                version="unknown",
+            ),
+            attributes={"storage_path": self._storage_path},
+        )
+        self._core = core
+
+    # ------------------------------------------------------------------
+    # Capability narrowing hooks
+    # ------------------------------------------------------------------
+
+    def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+        """L2 semantic facts for VAST (qualifier keys documented in api.py).
+
+        VAST mints directory-quota ids (path is the natural key), accounts
+        nested overlapping subjects against the most-restrictive cap, enforces
+        inode limits, and exposes the fs-wide default-user slot. The shim is
+        scoped to a single tenant. A fact set on a group inherits to its leaves.
+        """
+        caps.quota().directory().set_id_assignment("backend").set_accounting("nested").set_inodes(True)
+        caps.quota().user().set_default_user_slot(True).set_inodes(True)
+        caps.tenant().set_multi_tenant(False)
+
+    # ------------------------------------------------------------------
+    # StorageProvider: discovery / tenant / volume
+    # ------------------------------------------------------------------
+
+    def health_check(self) -> None:
+        """Authenticated GET ``/api/quotas/`` — validates credentials."""
+        self._request("GET", "/api/quotas/")
+
+    def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+        """Return the single tenant this shim is scoped to."""
+        tenant = Tenant(id=self._tenant, name=self._tenant or "default")
+        if not req.ids or self._tenant in req.ids:
+            return ListTenantsResponse(tenants=(tenant,))
+        return ListTenantsResponse(tenants=())
+
+    def list_tenant_quotas(self, req: ListTenantQuotasRequest) -> ListTenantQuotasResponse:
+        """Return the sole tenant's quota as a one-element list."""
+        quota = self.get_tenant_quota(GetTenantQuotaRequest(tenant_id=req.tenant_id))
+        return ListTenantQuotasResponse(tenant_quotas=(quota,))
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        """Aggregate hard limit and used capacity for all quotas under ``storage_path``.
+
+        * If a quota exists at exactly ``storage_path``, its ``hard_limit``
+          is the tenant capacity ceiling.
+        * Otherwise the ceiling is the sum of all child-quota hard limits.
+        * Used bytes is always the sum of ``used_effective_capacity`` from
+          child quotas.
+        """
+        resolved = self._resolve_tenant(req.tenant_id)
+        quotas = self._list_quotas_all()
+        storage_path = self._storage_path.rstrip("/")
+
+        parent: dict[str, Any] | None = None
+        children: list[dict[str, Any]] = []
+        for q in quotas:
+            path_norm = (q.get("path") or "").rstrip("/")
+            if path_norm == storage_path:
+                parent = q
+            elif path_norm.startswith(storage_path + "/"):
+                children.append(q)
+
+        if parent is not None:
+            hard_limit_bytes = int(parent.get("hard_limit") or 0)
+            name = str(parent.get("name") or storage_path)
+        else:
+            hard_limit_bytes = sum(int(q.get("hard_limit") or 0) for q in children)
+            name = f"VAST {storage_path}"
+
+        used_bytes = sum(int(q.get("used_effective_capacity") or 0) for q in children)
+
+        return TenantQuota(
+            tenant_id=resolved,
+            hard_limit_bytes=hard_limit_bytes,
+            used_bytes=used_bytes,
+            name=name,
+        )
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        """Yield one ``Volume`` per directory quota that is a child of ``storage_path``."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        wanted_ids = set(req.ids) if req.ids else None
+        filters = list(req.tag_filters)
+
+        result: list[Volume] = []
+        for q in self._list_quotas_children():
+            vol = self._quota_to_volume(q, tenant_id=resolved)
+            if wanted_ids is not None and vol.id not in wanted_ids:
+                continue
+            if filters:
+                # VAST quotas have no tag concept; tag filters never match.
+                continue
+            result.append(vol)
+        return ListVolumesResponse(volumes=tuple(result))
+
+    def get_volume(self, req: GetVolumeRequest) -> Volume:
+        """Return one volume by VAST id, absolute path, or CSI volume handle."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        q = self._volume_quota(req.volume_id)
+        return self._quota_to_volume(q, tenant_id=resolved)
+
+    # Volume lifecycle (create_volume / delete_volume) is intentionally NOT
+    # implemented: the VAST CSI driver (csi.vastdata.com / scd.vastdata.com) owns
+    # it. The methods fall back to the base raise (NotSupportedError) and the
+    # manifest declares volume.create / volume.delete ``none``.
+
+    # ------------------------------------------------------------------
+    # StorageProvider: directory quotas
+    # ------------------------------------------------------------------
+
+    def list_directory_quotas(self, req: ListDirectoryQuotasRequest) -> ListDirectoryQuotasResponse:
+        """Return the VAST quota tree rooted at ``req.volume_id``'s path (volume-relative)."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        root = _norm_path(self._volume_quota(req.volume_id).get("path") or "")
+        result = [
+            self._quota_to_directory_quota(q, tenant_id=resolved, volume_id=req.volume_id, root=root)
+            for q in self._list_quotas_all()
+            if self._is_at_or_under(q.get("path") or "", root)
+        ]
+        return ListDirectoryQuotasResponse(directory_quotas=tuple(result))
+
+    def get_directory_quota(self, req: GetDirectoryQuotaRequest) -> DirectoryQuota:
+        """Lookup a directory quota by volume-relative ``path`` and/or VAST ``id``."""
+        if req.path is None and req.id is None:
+            raise ValidationError("get_directory_quota requires at least one of `path` or `id`")
+        resolved = self._resolve_tenant(req.tenant_id)
+        root = _norm_path(self._volume_quota(req.volume_id).get("path") or "")
+
+        # VAST mints quota ids (id_assignment="backend"), so path is the natural
+        # key. ``path`` is volume-relative and joined under the volume root.
+        abs_path = _join_vol_path(root, req.path) if req.path is not None else None
+        if abs_path is not None:
+            q = self._get_quota_by_path(abs_path)
+        else:
+            # /api/quotas/<id>/ is cluster-wide: a row outside the volume root is
+            # not this volume's quota (list_directory_quotas would not yield it).
+            q = self._get_quota_by_id(req.id)  # type: ignore[arg-type]
+            if q is not None and not self._is_at_or_under(q.get("path") or "", root):
+                q = None
+        if q is None:
+            raise NotFoundError(
+                f"directory quota not found (volume_id={req.volume_id!r}, path={req.path!r}, id={req.id!r})"
+            )
+        if req.id is not None and str(q.get("id")) != str(req.id):
+            raise ConflictError(
+                f"directory quota lookup mismatch: requested path={req.path!r}, "
+                f"id={req.id!r}; found path={q.get('path')!r}, id={q.get('id')!r}"
+            )
+        if abs_path is not None and (q.get("path") or "").rstrip("/") != abs_path.rstrip("/"):
+            raise ConflictError(
+                f"directory quota lookup mismatch: requested path={req.path!r}, "
+                f"id={req.id!r}; found path={q.get('path')!r}, id={q.get('id')!r}"
+            )
+        return self._quota_to_directory_quota(q, tenant_id=resolved, volume_id=req.volume_id, root=root)
+
+    def set_directory_quota(self, req: SetDirectoryQuotaRequest) -> DirectoryQuota:
+        """Upsert a directory-tree quota (``hard.bytes`` / ``hard.inodes``).
+
+        ``quota.path`` is volume-relative (VAST assigns the quota id) and joined
+        under the volume's export path. An existing row at that absolute path is
+        PATCHed; otherwise a new ``/api/quotas/`` row is created.
+        ``quota.hard=None`` clears both caps on an existing row.
+        """
+        quota = req.quota
+        resolved = self._resolve_tenant(quota.tenant_id)
+        if quota.path is None:
+            raise ValidationError("set_directory_quota requires `quota.path` (VAST id_assignment='backend')")
+        root = _norm_path(self._volume_quota(quota.volume_id).get("path") or "")
+        abs_path = _join_vol_path(root, quota.path)
+
+        body: dict[str, Any] = self._hard_to_body(quota.hard)
+        existing = self._get_quota_by_path(abs_path)
+        if existing is None:
+            body["path"] = abs_path
+            # VMS requires a ``name`` on create; default to the directory's leaf
+            # (truncated to VMS's 64-char limit) when the caller supplies none.
+            body["name"] = quota.attributes.get("name") or abs_path.rstrip("/").rsplit("/", 1)[-1][:64]
+            stored = self._request("POST", "/api/quotas/", body=body)
+        else:
+            stored = self._request("PATCH", f"/api/quotas/{existing['id']}/", body=body)
+        return self._quota_to_directory_quota(stored, tenant_id=resolved, volume_id=quota.volume_id, root=root)
+
+    def delete_directory_quota(self, req: DeleteDirectoryQuotaRequest) -> None:
+        """Remove a directory-tree quota (no-op if already absent)."""
+        if req.path is None and req.id is None:
+            raise ValidationError("delete_directory_quota requires at least one of `path` or `id`")
+        self._resolve_tenant(req.tenant_id)
+        root = _norm_path(self._volume_quota(req.volume_id).get("path") or "")
+
+        if req.path is not None:
+            q = self._get_quota_by_path(_join_vol_path(root, req.path))
+        else:
+            # A cluster-wide id hit outside the volume root belongs to another
+            # volume; treat it as absent rather than deleting it.
+            q = self._get_quota_by_id(req.id)  # type: ignore[arg-type]
+            if q is not None and not self._is_at_or_under(q.get("path") or "", root):
+                q = None
+        if q is None:
+            return
+        if req.id is not None and str(q.get("id")) != str(req.id):
+            raise ConflictError(
+                f"directory quota lookup mismatch: requested path={req.path!r}, "
+                f"id={req.id!r}; found path={q.get('path')!r}, id={q.get('id')!r}"
+            )
+        self._request("DELETE", f"/api/quotas/{q['id']}/", expect_json=False)
+
+    # ------------------------------------------------------------------
+    # StorageProvider: user quotas
+    # ------------------------------------------------------------------
+
+    def list_user_quotas(self, req: ListUserQuotasRequest) -> ListUserQuotasResponse:
+        """Enumerate user quotas attached to ``req.volume_id`` (default slot + overrides)."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        volume = self._get_quota_by_id(req.volume_id)
+        if volume is None:
+            raise NotFoundError(f"volume {req.volume_id!r} not found")
+
+        result: list[UserQuota] = []
+        default = volume.get("default_user_quota") or {}
+        if default.get("hard_limit") is not None:
+            result.append(
+                UserQuota(
+                    tenant_id=resolved,
+                    volume_id=req.volume_id,
+                    user=None,
+                    hard=self._limits_from(default.get("hard_limit"), default.get("hard_limit_inodes")),
+                )
+            )
+        for row in self._list_user_quota_rows(req.volume_id):
+            entity = row.get("entity") or {}
+            if entity.get("is_group"):
+                continue
+            result.append(
+                UserQuota(
+                    tenant_id=resolved,
+                    volume_id=req.volume_id,
+                    user=str(entity.get("identifier")),
+                    hard=self._limits_from(row.get("hard_limit"), row.get("hard_limit_inodes")),
+                    usage=QuotaUsage(
+                        bytes=int(row.get("used_capacity") or 0),
+                        inodes=int(row["used_inodes"]) if row.get("used_inodes") is not None else None,
+                    ),
+                )
+            )
+        return ListUserQuotasResponse(user_quotas=tuple(result))
+
+    def set_user_quota(self, req: SetUserQuotaRequest) -> UserQuota:
+        """Upsert a per-user (or default-user slot) quota on a volume.
+
+        ``quota.user=None`` enables user quotas on the directory quota and sets
+        its ``default_user_quota.hard_limit``. A non-None user POSTs an override
+        to ``/api/userquotas/`` (enabling user quotas on the parent first).
+        """
+        quota = req.quota
+        resolved = self._resolve_tenant(quota.tenant_id)
+        volume_id_int = self._volume_id_int(quota.volume_id)
+        hard_bytes = quota.hard.bytes if quota.hard else None
+        hard_inodes = quota.hard.inodes if quota.hard else None
+
+        if quota.user is None:
+            if hard_bytes is None:
+                raise ValidationError("set_user_quota for the default-user slot requires hard.bytes")
+            self._request(
+                "PATCH",
+                f"/api/quotas/{volume_id_int}/",
+                body={
+                    "is_user_quota": True,
+                    "default_user_quota": {
+                        "hard_limit": hard_bytes,
+                        "hard_limit_inodes": hard_inodes,
+                    },
+                },
+            )
+        else:
+            self._ensure_user_quota_enabled(volume_id_int)
+            self._request(
+                "POST",
+                "/api/userquotas/",
+                body={
+                    "quota_id": volume_id_int,
+                    "identifier": quota.user,
+                    "identifier_type": _identifier_type(quota.user),
+                    "hard_limit": hard_bytes or 0,
+                    "hard_limit_inodes": hard_inodes,
+                    "soft_limit": 0,
+                    "is_group": False,
+                },
+                expect_json=False,
+            )
+        return self.get_user_quota(GetUserQuotaRequest(tenant_id=resolved, volume_id=quota.volume_id, user=quota.user))
+
+    def delete_user_quota(self, req: DeleteUserQuotaRequest) -> None:
+        """Remove a user quota record (no-op if already absent)."""
+        self._resolve_tenant(req.tenant_id)
+        volume_id_int = self._volume_id_int(req.volume_id)
+
+        if req.user is None:
+            # Clear the fs-wide default-user slot.
+            self._request(
+                "PATCH",
+                f"/api/quotas/{volume_id_int}/",
+                body={"default_user_quota": {"hard_limit": None, "hard_limit_inodes": None}},
+            )
+            return
+        for row in self._list_user_quota_rows(req.volume_id):
+            entity = row.get("entity") or {}
+            if entity.get("is_group"):
+                continue
+            if str(entity.get("identifier")) == req.user:
+                self._request("DELETE", f"/api/userquotas/{row['id']}/", expect_json=False)
+                return
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalise_endpoint(endpoint: str) -> str:
+        """Normalize and validate the VAST API endpoint URL."""
+        endpoint = endpoint.strip()
+        if endpoint.startswith("http://"):
+            raise StorageApiError("VAST_ENDPOINT must use https://")
+        if endpoint.startswith("https://"):
+            return endpoint.rstrip("/")
+        return "https://" + endpoint.rstrip("/")
+
+    def _resolve_tenant(self, tenant_id: str | None) -> str:
+        """Resolve and validate the request tenant for this shim."""
+        resolved = tenant_id if tenant_id is not None else self._tenant
+        if tenant_id is not None and tenant_id != self._tenant:
+            raise StorageApiError(
+                f"tenant_id={tenant_id!r} does not match this shim's configured tenant "
+                f"{self._tenant!r}; declare a separate provider entry per tenant"
+            )
+        return resolved
+
+    @staticmethod
+    def _volume_id_int(volume_id: str) -> int:
+        """Parse a VAST volume identifier as an integer quota ID."""
+        try:
+            return int(volume_id)
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(f"volume_id {volume_id!r} is not a VAST quota id") from exc
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Build authentication and tenant headers for VAST requests."""
+        headers: dict[str, str] = {}
+        if self._token:
+            headers["Authorization"] = f"Api-Token {self._token}"
+        else:
+            creds = b64encode(f"{self._username}:{self._password}".encode()).decode()
+            headers["Authorization"] = f"Basic {creds}"
+        if self._tenant:
+            headers["X-Tenant-Name"] = self._tenant
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        not_found_ok: bool = False,
+        expect_json: bool = True,
+    ) -> Any:
+        """Send an authenticated provider API request."""
+        url = self._base_url + path
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {**self._auth_headers(), "Accept": "application/json"}
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, context=self._ssl_ctx, timeout=30) as resp:
+                raw = resp.read()
+                if not expect_json:
+                    return None
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as exc:
+            if not_found_ok and exc.code == 404:
+                return None
+            if exc.code in _AUTH_STATUS_CODES:
+                raise AuthenticationError(f"VAST VMS {method} {path}: HTTP {exc.code} {exc.reason}") from exc
+            raise StorageApiError(f"VAST VMS {method} {path}: HTTP {exc.code} {exc.reason}") from exc
+        except urllib.error.URLError as exc:
+            raise StorageApiError(f"VAST VMS {method} {path}: {exc.reason}") from exc
+
+    def _list_quotas_all(self) -> list[dict[str, Any]]:
+        """Fetch all quotas from ``/api/quotas/``, handling pagination."""
+        return self._paginate("/api/quotas/")
+
+    def _paginate(self, start_path: str) -> list[dict[str, Any]]:
+        """Walk a Django-REST-style paginated collection (``results`` + ``next``)."""
+        url = start_path
+        items: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for _ in range(_MAX_PAGES):
+            data = self._request("GET", url)
+            if isinstance(data, list):
+                items.extend(data)
+                break
+            if isinstance(data, dict) and "results" in data:
+                items.extend(data["results"])
+                next_url = data.get("next") or ""
+                if not next_url:
+                    break
+                next_path = self._extract_path(next_url)
+                if not next_path or next_path in seen:
+                    break
+                seen.add(next_path)
+                url = next_path
+            else:
+                break
+        return items
+
+    def _list_quotas_children(self) -> list[dict[str, Any]]:
+        """Return quotas that are strict children of ``storage_path`` (not the root itself)."""
+        storage_path = self._storage_path.rstrip("/")
+        return [q for q in self._list_quotas_all() if (q.get("path") or "").rstrip("/").startswith(storage_path + "/")]
+
+    def _list_user_quota_rows(self, volume_id: str) -> list[dict[str, Any]]:
+        """Fetch ``/api/userquotas/?quota_system_id=<id>`` rows, handling pagination."""
+        quota_system_id = self._volume_id_int(volume_id)
+        return self._paginate(f"/api/userquotas/?quota_system_id={quota_system_id}")
+
+    def _get_quota_by_id(self, quota_id: str) -> dict[str, Any] | None:
+        """GET ``/api/quotas/<id>/``; returns None when the id is unknown (404)."""
+        quota_id_int = self._volume_id_int(quota_id)
+        return self._request("GET", f"/api/quotas/{quota_id_int}/", not_found_ok=True)
+
+    def _get_quota_by_path(self, path: str) -> dict[str, Any] | None:
+        """GET ``/api/quotas/?path=<path>`` and return the exact-path match, else None."""
+        target = _norm_path(path)
+        query = "/api/quotas/?path=" + urllib.parse.quote(target, safe="")
+        data = self._request("GET", query)
+        rows = data.get("results", []) if isinstance(data, dict) else (data or [])
+        for q in rows:
+            if (q.get("path") or "").rstrip("/") == target.rstrip("/"):
+                return q
+        return None
+
+    def _volume_quota(self, volume_id: str) -> dict[str, Any]:
+        """Resolve the directory quota backing ``volume_id`` (VMS id, path, or CSI handle).
+
+        Accepts the numeric VAST quota id, an absolute export path, or the PV's
+        CSI ``volumeHandle``. The VAST CSI driver names each volume's directory
+        after its handle under the root export (``<storage_path>/<handle>``), so
+        a non-path, non-numeric id is resolved by that convention. Raises
+        ``NotFoundError`` when nothing matches.
+        """
+        if volume_id and volume_id.isdigit():
+            q = self._get_quota_by_id(volume_id)
+            if q is not None:
+                return q
+        if volume_id.startswith("/"):
+            q = self._get_quota_by_path(volume_id)
+            if q is not None:
+                return q
+        elif volume_id:
+            # VAST CSI volume handle -> leaf directory under the root export.
+            q = self._get_quota_by_path(_join_vol_path(self._storage_path, volume_id))
+            if q is not None:
+                return q
+        for q in self._list_quotas_all():
+            if _volume_matches_quota(q, volume_id):
+                return q
+        raise NotFoundError(f"volume {volume_id!r} not found")
+
+    def _ensure_user_quota_enabled(self, volume_id_int: int) -> None:
+        """Enable user quotas on the directory quota if not already enabled."""
+        quota = self._request("GET", f"/api/quotas/{volume_id_int}/", not_found_ok=True)
+        if quota is None:
+            raise NotFoundError(f"volume {volume_id_int!r} not found")
+        if not quota.get("is_user_quota"):
+            self._request("PATCH", f"/api/quotas/{volume_id_int}/", body={"is_user_quota": True})
+
+    @staticmethod
+    def _is_at_or_under(path: str, root: str) -> bool:
+        """Return whether a path is at or below a root path."""
+        path_norm = path.rstrip("/")
+        root_norm = root.rstrip("/")
+        return path_norm == root_norm or path_norm.startswith(root_norm + "/")
+
+    @staticmethod
+    def _hard_to_body(hard: QuotaLimits | None) -> dict[str, Any]:
+        """Translate ``QuotaLimits`` to the VAST quota PATCH/POST body.
+
+        ``hard=None`` clears both caps; a per-dimension ``None`` clears that
+        dimension (VAST treats null / 0 as unlimited).
+        """
+        if hard is None:
+            return {"hard_limit": None, "hard_limit_inodes": None}
+        return {"hard_limit": hard.bytes, "hard_limit_inodes": hard.inodes}
+
+    @staticmethod
+    def _limits_from(hard_limit: Any, hard_limit_inodes: Any) -> QuotaLimits | None:
+        """Convert VAST hard-limit values to QuotaLimits."""
+        bytes_value = int(hard_limit) if hard_limit else None
+        inodes_value = int(hard_limit_inodes) if hard_limit_inodes else None
+        if bytes_value is None and inodes_value is None:
+            return None
+        return QuotaLimits(bytes=bytes_value, inodes=inodes_value)
+
+    def _quota_to_directory_quota(
+        self, q: dict[str, Any], *, tenant_id: str, volume_id: str, root: str
+    ) -> DirectoryQuota:
+        """Convert a VAST quota row to a DirectoryQuota."""
+        usage = QuotaUsage(
+            bytes=int(q.get("used_effective_capacity") or q.get("used_capacity") or 0),
+            inodes=int(q["used_inodes"]) if q.get("used_inodes") is not None else None,
+        )
+        return DirectoryQuota(
+            tenant_id=tenant_id,
+            volume_id=volume_id,
+            path=_rel_under(root, q.get("path") or ""),
+            id=str(q.get("id")),
+            hard=self._limits_from(q.get("hard_limit"), q.get("hard_limit_inodes")),
+            usage=usage,
+        )
+
+    def _quota_to_volume(self, q: dict[str, Any], *, tenant_id: str) -> Volume:
+        """Convert a VAST quota row to a Volume."""
+        quota_id = str(q.get("id", ""))
+        path = str(q.get("path") or "")
+        name = str(q.get("name") or path)
+        hard_limit = int(q.get("hard_limit") or 0)
+        used_eff = int(q.get("used_effective_capacity") or 0)
+        state_raw = str(q.get("state") or "").lower()
+        state: VolumeState = _QUOTA_STATE_MAP.get(state_raw, "failed")
+
+        csi = CsiSpec(
+            driver="scd.vastdata.com",
+            volume_handle=path,
+            fs_type="nfs",
+        )
+
+        mount: MountSpec | None = None
+        if self._vip_pool:
+            mount = MountSpec(
+                fs_type="nfs",
+                source=f"{self._vip_pool}:{path}",
+                options="vers=4.1",
+            )
+
+        return Volume(
+            tenant_id=tenant_id,
+            id=quota_id,
+            size_bytes=hard_limit,
+            created_at=datetime.now(UTC),
+            type="file",
+            state=state,
+            name=name,
+            mount=mount,
+            csi=csi,
+            used_bytes=used_eff,
+            available_bytes=max(0, hard_limit - used_eff),
+            attributes={
+                "path": path,
+                "storage_path": self._storage_path,
+                "vip_pool": self._vip_pool,
+            },
+        )
+
+    def _extract_path(self, url: str) -> str:
+        """Extract the path+query portion from an absolute URL returned by the paginator."""
+        url = url.strip()
+        if url.startswith("http://") or url.startswith("https://"):
+            parsed = urllib.parse.urlparse(url)
+            path = parsed.path
+            if parsed.query:
+                path = path + "?" + parsed.query
+            return path
+        return url
+
+
+def build_api() -> StorageProvider:
+    """Entry point isvtest calls. Single hook the provider commits to.
+
+    Composes ``VastApi`` into a served ``StorageProvider`` via
+    ``new_implementation``: capabilities are detected from the overridden
+    methods. VAST resolves its own default tenant internally, so no
+    ``default_tenant`` wrapping is applied here.
+    """
+    impl = VastApi()
+    return new_implementation(core=impl._core, impl=impl)

--- a/isvctl/configs/providers/weka/config/storage-k8s.yaml
+++ b/isvctl/configs/providers/weka/config/storage-k8s.yaml
@@ -16,7 +16,7 @@
 # =============================================================================
 # K8s storage validation - WEKA
 # =============================================================================
-# Runs the canonical Kubernetes suite against the EXISTING cluster your kubectl
+# Runs the canonical storage suite Kubernetes checks against the EXISTING cluster your kubectl
 # points at. Two independent inputs:
 #
 #   1. StorageProviderApiCheck is driven from storage-provider-manifest.yaml
@@ -35,10 +35,10 @@
 #   ISVTEST_INCLUDE_UNRELEASED=1 \
 #     uv run isvctl test run \
 #       -f isvctl/configs/providers/weka/config/storage-k8s.yaml \
+#       --capability kubernetes \
 #       -- -v -s -k "K8sCsiDriverHealth or K8sCsiProvisioningModes or K8sCsiStorageTypes or K8sPosixCompliance"
 
 import:
-  - ../../../suites/k8s.yaml
   - ../../../suites/storage.yaml
 
 version: "1.0"

--- a/isvctl/configs/providers/weka/config/storage-k8s.yaml
+++ b/isvctl/configs/providers/weka/config/storage-k8s.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# K8s storage validation - WEKA
+# =============================================================================
+# Runs the canonical Kubernetes suite against the EXISTING cluster your kubectl
+# points at. Two independent inputs:
+#
+#   1. StorageProviderApiCheck is driven from storage-provider-manifest.yaml
+#      (the setup step emits steps.setup.storage.manifest_path).
+#
+#   2. The K8sCsi* / K8sFilesystem* checks target the WEKA StorageClass via the
+#      K8S_CSI_* env vars. The example StorageClass `weka-rwx` is the native
+#      wekafs POSIX client (provisioner csi.weka.io); it fills the shared_fs
+#      role, so set K8S_CSI_SHARED_FS_SC to your WEKA RWX class. wekafs is NOT NFS, so
+#      K8sNfsMountOptionsCheck skips (leave K8S_CSI_NFS_SC unset).
+#
+# CSI health + provisioning + POSIX (no WEKA creds needed - shim check filtered
+# out with -k):
+#
+#   export K8S_CSI_SHARED_FS_SC=weka-rwx
+#   ISVTEST_INCLUDE_UNRELEASED=1 \
+#     uv run isvctl test run \
+#       -f isvctl/configs/providers/weka/config/storage-k8s.yaml \
+#       -- -v -s -k "K8sCsiDriverHealth or K8sCsiProvisioningModes or K8sCsiStorageTypes or K8sPosixCompliance"
+
+import:
+  - ../../../suites/k8s.yaml
+  - ../../../suites/storage.yaml
+
+version: "1.0"
+
+commands:
+  kubernetes:
+    steps:
+      - name: setup
+        phase: setup
+        command: "python ../../shared/storage_manifest_to_steps.py"
+        timeout: 30
+        env:
+          STORAGE_PROVIDER_MANIFEST: "storage-provider-manifest.yaml"
+          STORAGE_STEP_PLATFORM: "kubernetes"
+      - name: teardown
+        phase: teardown
+        command: "echo"
+        args: ['{"success": true, "platform": "kubernetes", "test_name": "teardown"}']
+        timeout: 10
+
+tests:
+  description: "Kubernetes storage validation (WEKA)"
+
+  validations:
+    k8s_storage:
+      checks:
+        # WEKA is shared-fs only (no block class), so point the dynamic
+        # provisioning probe (mount + write/read canary) at the wekafs RWX class
+        # instead of the suite's default block class. Static-PV subtest stays
+        # disabled (empty handle/driver -> skipped): we exercise dynamic
+        # provisioning via csi.weka.io rather than pinning a pre-provisioned
+        # volume handle.
+        K8sCsiProvisioningModesCheck:
+          dynamic_storage_class: "{{ env.K8S_CSI_SHARED_FS_SC | default('', true) }}"
+          static_pv:
+            volume_handle: ""
+            csi_driver: ""
+            fs_type: "wekafs"
+            capacity: "1Gi"
+            access_mode: "ReadWriteMany"
+          bind_timeout_s: 180
+          namespace_prefix: "isvtest-csi-prov"

--- a/isvctl/configs/providers/weka/config/storage-provider-manifest.yaml
+++ b/isvctl/configs/providers/weka/config/storage-provider-manifest.yaml
@@ -98,15 +98,17 @@ providers:
 
     # Optional L2 semantic facts (ProviderProperties capability qualifiers).
     # WEKA mints directory-quota ids (quota_id), so id_assignment is `backend`
-    # and set_directory_quota requires a path. Byte-only quotas are set on the
-    # shim's capability_qualifiers() hook.
+    # and set_directory_quota requires a path. Quotas are byte-only (no inode
+    # enforcement); mirrors the shim's capability_qualifiers() hook.
     capability_qualifiers:
       quota.directory:
         idAssignment: backend
+        inodes: "false"
       quota.user:
         # WEKA addresses one uid per call; there is no filesystem-wide
         # default-user slot, so user=None is refused.
         defaultUserSlot: "false"
+        inodes: "false"
 
     # Attributes are arbitrary fields about the provider's configuration that can be
     # used as values in testing.

--- a/isvctl/configs/providers/weka/config/storage-provider-manifest.yaml
+++ b/isvctl/configs/providers/weka/config/storage-provider-manifest.yaml
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WEKA Storage Provider Manifest (schema v1alpha2).
+#
+# Drives StorageProviderApiCheck ONLY, via the WEKA REST API shim
+# (../scripts/storage/weka/api.py) - config/storage.yaml (no cluster required).
+# The K8sCsi* / K8sFilesystem* checks get the WEKA StorageClass name from
+# config/storage-k8s.yaml (or K8S_CSI_* env vars), NOT from this manifest.
+#
+# v1alpha2 mirrors the upstream StorageProvider package manifest: a package-level
+# namespace + vendor, a per-provider `provider` identity block, and a
+# hierarchical `capabilities` block (native | default | none). The declared
+# identity + capabilities are a CONTRACT: StorageProviderApiCheck cross-checks
+# them against the running shim's properties(). Keep this in sync with
+# ../scripts/storage/weka/api.py (WekaApi's ProviderProperties core).
+#
+# Needs WEKA_ENDPOINTS (or WEKA_ENDPOINT), WEKA_USERNAME, WEKA_PASSWORD and
+# WEKA_FILESYSTEM at runtime:
+#
+#   ISVTEST_INCLUDE_UNRELEASED=1 \
+#     uv run isvctl test run -f isvctl/configs/providers/weka/config/storage.yaml
+#
+# Tenant = WEKA organization name (defaults to `Root` via WEKA_ORGANIZATION).
+
+schema_version: v1alpha2
+
+# Package identity (the package manifest namespace + vendor). With each provider's id
+# this forms the registration key <namespace>/<id>.
+namespace: weka.io
+vendor:
+  vendorName: NVIDIA
+
+providers:
+  - id: shared-fs
+    name: weka-shared-fs
+    # tenant_id maps to the WEKA organization name. It is cross-checked against
+    # get_tenant_quota().tenant_id and must equal the shim's WEKA_ORGANIZATION
+    # (default `Root`) at runtime.
+    tenant_id: Root
+    sdk_version: v1beta1
+
+    # Implementor identity (mirrors ProviderProperties / VersionMetadata). type
+    # + protocols + version are cross-checked against the shim's properties().
+    # WEKA uses its native POSIX client (wekafs), not NFS.
+    provider:
+      name: WEKA shared filesystem
+      description: WEKA shared filesystem fronted by the WEKA REST API shim
+      type: file
+      protocols: [wekafs]
+      version: 0.1.0
+
+    # The storage system fronted. version is an opaque vendor passthrough
+    # (the live cluster build is not surfaced by the REST API today);
+    # not contract-checked.
+    backend:
+      vendorName: WekaIO
+      name: WEKA
+
+    # Management-API shim: drives StorageProviderApiCheck (health_check, tenant +
+    # volume read, directory and user quota CRUD). volume create/delete are
+    # NotSupported (the CSI driver csi.weka.io owns lifecycle), so they are
+    # declared `none`. Needs WEKA_ENDPOINTS (or WEKA_ENDPOINT), WEKA_USERNAME,
+    # WEKA_PASSWORD and WEKA_FILESYSTEM at runtime.
+    shim:
+      kind: python
+      # Resolved relative to this manifest's parent directory.
+      module: ../scripts/storage/weka/api.py
+
+    # Hierarchical capabilities (native | default | none), lowered by the loader
+    # to a cap_id -> supported? map and cross-checked against properties():
+    # StorageProviderApiCheck fails if a declared surface disagrees with the
+    # shim. Matches the WekaApi capability core in scripts/storage/weka/api.py:
+    # tenant + volume read and directory + user quotas (REST). Volume lifecycle
+    # is CSI-owned, so create/delete stay `none`.
+    capabilities:
+      tenantManagement: native # single organization (tenant.list/get/getQuota/listQuotas)
+      volumeManagement:
+        list: native
+        get: native
+        create: none # CSI owns lifecycle -> create_volume is unimplemented
+        delete: none
+      quotaManagement:
+        directory: native # quota.directory.* via the documented REST API
+        user: native # quota.user.* via /fileSystems/<uid>/quota/user (WEKA 5.1.26+)
+
+    # Optional L2 semantic facts (ProviderProperties capability qualifiers).
+    # WEKA mints directory-quota ids (quota_id), so id_assignment is `backend`
+    # and set_directory_quota requires a path. Byte-only quotas are set on the
+    # shim's capability_qualifiers() hook.
+    capability_qualifiers:
+      quota.directory:
+        idAssignment: backend
+      quota.user:
+        # WEKA addresses one uid per call; there is no filesystem-wide
+        # default-user slot, so user=None is refused.
+        defaultUserSlot: "false"
+
+    # Attributes are arbitrary fields about the provider's configuration that can be
+    # used as values in testing.
+    attributes:
+      # Filesystem used for tenant quota. MUST match WEKA_FILESYSTEM at runtime
+      # (informational here; the shim reads the env var directly) and the
+      # StorageClass `filesystemName` (e.g. `test_fs` in a test environment).
+      filesystem: test_fs

--- a/isvctl/configs/providers/weka/config/storage.yaml
+++ b/isvctl/configs/providers/weka/config/storage.yaml
@@ -47,7 +47,6 @@ commands:
 tests:
   cluster_name: "weka-storage-validation"
   description: "WEKA storage shim validation"
-  platform: storage
 
   validations:
     storage_provider_api:

--- a/isvctl/configs/providers/weka/config/storage.yaml
+++ b/isvctl/configs/providers/weka/config/storage.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WEKA Storage Provider Shim - Standalone validation config.
+#
+# Drives StorageProviderApiCheck against a live WEKA cluster via the
+# REST API shim. No Kubernetes cluster required for the shim itself, but
+# the WEKA API endpoints must be reachable from the test host.
+#
+# Required environment variables (see scripts/storage/README.md):
+#   WEKA_ENDPOINTS      Comma-separated host:port list
+#   WEKA_USERNAME       Cluster username
+#   WEKA_PASSWORD       Cluster password
+#   WEKA_FILESYSTEM     Filesystem name (e.g. default)
+#
+# StorageProviderApiCheck is unreleased and skipped by default; set
+# ISVTEST_INCLUDE_UNRELEASED=1 to exercise it:
+#
+#   ISVTEST_INCLUDE_UNRELEASED=1 \
+#     uv run isvctl test run \
+#       -f isvctl/configs/providers/weka/config/storage.yaml
+
+version: "1.0"
+
+commands:
+  storage:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      - name: preflight
+        phase: setup
+        command: "echo"
+        args: ['{"success": true, "platform": "storage", "test_name": "preflight"}']
+        timeout: 10
+
+tests:
+  cluster_name: "weka-storage-validation"
+  description: "WEKA storage shim validation"
+  platform: storage
+
+  validations:
+    storage_provider_api:
+      checks:
+        StorageProviderApiCheck:
+          manifest_path: "isvctl/configs/providers/weka/config/storage-provider-manifest.yaml"
+          volume_size_bytes: 1073741824 # 1 GiB

--- a/isvctl/configs/providers/weka/scripts/storage/README.md
+++ b/isvctl/configs/providers/weka/scripts/storage/README.md
@@ -1,0 +1,253 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# WEKA storage shim
+
+Storage Provider Shim for WEKA. Drives
+[`StorageProviderApiCheck`](../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
+against a live WEKA cluster via the REST API (`/api/v2`).
+
+## How it works
+
+The manifest at [`../../config/storage-provider-manifest.yaml`](../../config/storage-provider-manifest.yaml)
+(schema `v1alpha2`) declares one `weka-shared-fs` provider; `shim.module` points
+at [`weka/api.py`](weka/api.py); `StorageProviderApiCheck` loads the shim
+in-process and runs the subtests below.
+
+`StorageProviderApiCheck` reports a `manifest-consistency[weka-shared-fs]`
+subtest that cross-checks the manifest's declared `type` / `provider.protocols`
+/ `provider.version` / `capabilities` against the shim's `properties()` (so the
+manifest is a contract, not just metadata) — it probes every declared-`native`
+surface (tenant, volume read, and the directory + user quota CRUD below) — plus
+the three subtests:
+
+| Subtest | WEKA call |
+| ------- | --------- |
+| `api-authentication[weka-shared-fs]` | `GET /api/v2/fileSystems` (validates credentials) |
+| `volume-provisioning[weka-shared-fs]` | `GET /api/v2/fileSystems` (fallback — CSI driver owns lifecycle) |
+| `tenant-quota[weka-shared-fs]` | `GET /api/v2/fileSystems` — `total_budget` / `used_total` |
+
+When `WEKA_STORAGE_PATH` is set, tenant quota follows the VAST-style
+directory-quota aggregation model (parent hard limit or sum of child limits;
+used bytes = sum of child `total_bytes`).
+
+The WEKA CSI driver (`csi.weka.io`) owns volume lifecycle. The shim assumes
+`weka/v2`: each PVC is a filesystem and its volume id is
+`weka/v2/<filesystem>`. `list_volumes` inventories WEKA filesystems;
+`get_volume` and directory-quota methods accept that handle or the bare
+filesystem name.
+
+`create_volume` / `delete_volume` fall back to the base raise
+(`NotSupportedError`), are declared `none` in the manifest, and
+`StorageProviderApiCheck` volume-provisioning uses the `list_volumes` CSI
+fallback.
+
+## Quotas
+
+The shim implements directory and user quotas over the documented REST API
+(`quotaManagement.directory: native`, `quotaManagement.user: native`):
+
+| Surface | WEKA API |
+| ------- | -------- |
+| `quota.directory.{list,get,set,delete}` | REST — `resolvePath` + `PUT` / `PATCH` / `DELETE` on `/api/v2/fileSystems/{uid}/quota/{inode}` |
+
+Directory quotas use `idAssignment: backend` (WEKA mints the `quota_id`), so
+`set_directory_quota` requires a volume-relative `path`. Quotas are byte-only
+(no inode enforcement). Creating a quota on a **non-empty** directory over REST
+requires a Data Services container on the backend; without one WEKA restricts
+`PUT` to empty directories (`PATCH` / `DELETE` on an existing quota — e.g. the
+per-PVC quota the CSI driver already sets — are unaffected). The shim surfaces
+that backend rule verbatim.
+
+### End-to-end lifecycle + enforcement (`StorageDirectoryQuotaEnforcementCheck`)
+
+Where `StorageProviderApiCheck` only *probes* the quota surfaces with sentinel ids,
+[`StorageDirectoryQuotaEnforcementCheck`](../../../../../../isvtest/src/isvtest/validations/storage_quota_enforcement.py)
+exercises the directory quota for real and proves it is enforced. It runs only
+under the K8s config (it needs a mounted PVC) and reports two subtests:
+
+| Subtest | What it does |
+| ------- | ------------ |
+| `directory-quota-crud[weka-shared-fs]` | Provisions an RWX PVC, mounts it, creates an empty subdirectory, then drives `set` (create) → `get` (verify hard limit) → `set` (update) → `get` → `list` (present) → `delete` → `get` (gone) over the shim. |
+| `directory-quota-enforcement[weka-shared-fs]` | With the hard limit set on that subdirectory, writes below the limit (must succeed) and above it (must be blocked with a no-space / quota-exceeded error) from inside the pod. |
+
+The subdirectory is empty at create time, so the `PUT` restriction above does
+not apply. Pass a pre-provisioned PVC with `pvc_name` / `pvc_namespace`
+(and optionally `pod_name` for a Ready mount pod at `/data`) instead of
+provisioning one; tune limits with `pvc_size` / `create_hard_bytes` /
+`enforcement_hard_bytes`. The check is skipped cleanly when no shared-fs
+StorageClass is configured or no cluster is reachable.
+
+### Faster repeat runs of the quota check
+
+Most wall time is PVC provision + pod Ready. Create those once and pass
+`pvc_name` / `pvc_namespace` / `pod_name`; each run only creates and removes
+its probe subdirectory and quota:
+
+```yaml
+# quota-reuse.yaml — deep-merge with storage-k8s.yaml
+tests:
+  validations:
+    k8s_storage:
+      checks:
+        StorageDirectoryQuotaEnforcementCheck:
+          pvc_namespace: isvtest-quota
+          pvc_name: quota-probe
+          pod_name: quota-probe
+```
+
+Match the harness pod identity (`runAsUser`/`runAsGroup`/`fsGroup` 65534) so
+writes into `/data` are not squashed. See the VAST storage README for a full
+PVC+pod manifest example.
+
+### User quotas (`quota.user: native`, WEKA 5.1.26+)
+
+| Surface | WEKA API |
+| ------- | -------- |
+| `quota.user.{list,get,set,delete}` | REST — `GET` / `POST` / `DELETE` on `/api/v2/fileSystems/{uid}/quota/user` |
+
+`{uid}` is the filesystem UUID, not its name. Arguments (`user_id`,
+`hard_limit_bytes`, `soft_limit_bytes`) travel as query parameters, and `GET`
+paginates via `next_token`. WEKA exposes no per-UID read, so `get_user_quota`
+filters the list.
+
+User subjects must be numeric UIDs — WEKA has no username form on this route, so
+a non-numeric subject raises `ValidationError`. A hard limit of `0` means
+unlimited on the backend and is surfaced as an absent limit rather than a
+zero-byte allowance.
+
+WEKA addresses one UID per call and has no filesystem-wide default-user slot, so
+the shim advertises `defaultUserSlot: false` and refuses a request with
+`user=None` (`NotSupportedError`). User quotas are also accepted only for
+filesystem-backed (`weka/v2`) volumes: WEKA scopes them to a whole filesystem, so
+applying one to a directory-backed volume would bind every other PVC sharing that
+filesystem.
+
+Clusters older than 5.1.26 answer the route with a 404 naming the route; the shim
+reports that as `NotSupportedError` (a capability gap) rather than
+`NotFoundError` (a missing quota), and names the required release.
+
+Two backend prerequisites apply before the limits take effect:
+
+1. Filesystems created before WEKA 5.1.20 need a one-time
+   `weka fs quota enable-users`, which requires a Data Services container.
+   Filesystems created on 5.1.20 or later have user quota accounting enabled
+   automatically.
+2. Enabling user quotas on an existing filesystem starts a background
+   `QUOTA_COLORING` pass that stamps existing files with their UID. Quotas are
+   not enforced on pre-existing data until it completes.
+
+Ownership changes (`chown`) reattribute capacity asynchronously, so usage
+counters may briefly still reflect the previous owner.
+
+See [WEKA quota management](https://docs.weka.io/weka-filesystems-and-object-stores/quota-management)
+for directory, filesystem, and tenant quota semantics on the backend.
+
+## Environment variables
+
+| Variable | Required? | Effect |
+| -------- | --------- | ------ |
+| `WEKA_ENDPOINTS` | Yes¹ | Comma-separated `host:port` list (matches CSI secret `endpoints`). |
+| `WEKA_ENDPOINT` | Yes¹ | Single `host:port` fallback. |
+| `WEKA_SCHEME` | No | URL scheme (default `https`). |
+| `WEKA_USERNAME` | Yes | Cluster username (secret: `username`). Use an account with filesystem, directory-quota, and user-quota permissions. |
+| `WEKA_PASSWORD` | Yes | Cluster password. |
+| `WEKA_ORGANIZATION` | No | Organization for login and `tenant_id` (default `Root`). |
+| `WEKA_FILESYSTEM` | Yes | Filesystem for tenant quota (matches StorageClass `filesystemName`). Volume directory quotas use the filesystem named by their `weka/v2` handle. |
+| `WEKA_STORAGE_PATH` | No | Directory path prefix for scoped tenant-quota aggregation. |
+| `WEKA_INSECURE_SKIP_VERIFY` | No | `1` / `true` to disable TLS cert verification (dev/test only). |
+
+¹ Either `WEKA_ENDPOINTS` or `WEKA_ENDPOINT` must be provided.
+
+### Mapping from a cluster secret
+
+| Secret key | Env var |
+| ---------- | ------- |
+| `endpoints` | `WEKA_ENDPOINTS` |
+| `scheme` | `WEKA_SCHEME` |
+| `username` | `WEKA_USERNAME` |
+| `password` | `WEKA_PASSWORD` |
+| `organization` | `WEKA_ORGANIZATION` |
+
+## Network locality requirement
+
+The shim makes direct HTTPS calls to WEKA backend hosts on port 14000.
+Unlike K8s checks — which go through `kubectl` — the storage shim must run
+from a host that can reach those endpoints (typically inside the cluster
+VPC). If probes time out from your laptop, use `isvctl deploy run` to
+execute the suite on a cluster node.
+
+## Running against a cluster
+
+From the repo root (on a machine that can reach the WEKA API):
+
+```bash
+export WEKA_ENDPOINTS="weka-1.example.com:14000,weka-2.example.com:14000"
+export WEKA_USERNAME=storage-csi-user
+export WEKA_PASSWORD='...'
+export WEKA_ORGANIZATION=Root
+export WEKA_FILESYSTEM=test_fs
+export WEKA_INSECURE_SKIP_VERIFY=1   # if using cluster-internal TLS
+
+# Sanity probe:
+uv run python .cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py \
+  --manifest isvctl/configs/providers/weka/config/storage-provider-manifest.yaml
+
+# Full check (unreleased -> gate env var required):
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/weka/config/storage.yaml
+```
+
+To also verify the directory-quota lifecycle **and** enforcement against the
+live cluster your kubectl points at (provisions a PVC, mounts it, and writes
+data), run the K8s config with the shared-fs StorageClass set:
+
+```bash
+export K8S_CSI_SHARED_FS_SC=weka-rwx
+ISVTEST_INCLUDE_UNRELEASED=1 \
+  uv run isvctl test run \
+    -f isvctl/configs/providers/weka/config/storage-k8s.yaml \
+    -- -v -s -k "StorageDirectoryQuotaEnforcement"
+```
+
+`volume-provisioning[weka-shared-fs]` reports **skipped (passed)** when
+`create_volume` is not implemented and `list_volumes` returns ≥1
+CSI-provisioned filesystem volume — that is expected, not a failure.
+
+If `list_volumes` returns 0 volumes, create a PVC against
+your WEKA RWX StorageClass first:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: weka-probe-pvc
+  namespace: default
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: weka-rwx
+  resources:
+    requests:
+      storage: 5Gi
+EOF
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| All subtests time out | WEKA API not reachable from this host | Run via `isvctl deploy run` from a cluster node |
+| `AuthenticationError` | Wrong creds or org | Verify with `POST /api/v2/login` from a client pod |
+| `hard_limit_bytes=0` | Wrong filesystem name | Check `WEKA_FILESYSTEM` matches `filesystemName` on the StorageClass |
+| `observed 0 ... via list_volumes` | No filesystems visible to the organization | Create a PVC against your WEKA RWX StorageClass |
+| `Skipping unreleased validation` | Gate env unset | Set `ISVTEST_INCLUDE_UNRELEASED=1` |
+
+## See also
+
+- [`isvtest/src/isvtest/core/storage_provider/`](../../../../../../isvtest/src/isvtest/core/storage_provider/) — `StorageApi` ABC
+- [`isvctl/configs/providers/vast/scripts/storage/vast/`](../../../vast/scripts/storage/vast/) — VAST reference (directory-quota CSI pattern)
+- [WEKA REST API](https://docs.weka.io/getting-started-with-weka/weka-rest-api-and-equivalent-cli-commands)

--- a/isvctl/configs/providers/weka/scripts/storage/README.md
+++ b/isvctl/configs/providers/weka/scripts/storage/README.md
@@ -9,6 +9,12 @@ Storage Provider Shim for WEKA. Drives
 [`StorageProviderApiCheck`](../../../../../../isvtest/src/isvtest/validations/storage_provider.py)
 against a live WEKA cluster via the REST API (`/api/v2`).
 
+This implementation is a working reference example for exercising the storage
+provider contract against representative WEKA environments. It is not an
+officially supported integration or a compatibility guarantee; validate the
+behavior against your WEKA release, topology, CSI driver, API permissions, and
+quota model before relying on the results.
+
 ## How it works
 
 The manifest at [`../../config/storage-provider-manifest.yaml`](../../config/storage-provider-manifest.yaml)

--- a/isvctl/configs/providers/weka/scripts/storage/weka/api.py
+++ b/isvctl/configs/providers/weka/scripts/storage/weka/api.py
@@ -795,7 +795,11 @@ class WekaApi(Implementation):
             )
             page = envelope.get("data")
             if page is None:
-                page = envelope.get("quotas") or envelope.get("results") or envelope
+                page = envelope.get("quotas") or envelope.get("results")
+                if page is None:
+                    raise StorageApiError(
+                        f"unexpected /fileSystems/{fs_uid}/quota response shape: keys={sorted(envelope)}"
+                    )
             if isinstance(page, dict):
                 page = [page]
             if not isinstance(page, list):
@@ -803,7 +807,7 @@ class WekaApi(Implementation):
             all_quotas.extend(page)
 
             next_token = envelope.get("next_token")
-            if not next_token:
+            if not next_token or (params is not None and str(next_token) == params.get("next_token")):
                 break
             params = {"next_token": str(next_token)}
 

--- a/isvctl/configs/providers/weka/scripts/storage/weka/api.py
+++ b/isvctl/configs/providers/weka/scripts/storage/weka/api.py
@@ -1,0 +1,1043 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WEKA ``StorageProvider`` shim.
+
+Calls the WEKA cluster REST API (``/api/v2``). The shim subclasses
+``Implementation`` and is served through ``new_implementation()``: it implements
+only the surfaces it backs, and the SDK *detects* which are supported. Which
+surfaces are *supported* is also declared in the sibling
+``config/storage-provider-manifest.yaml`` (the contract); the validation suite
+probes each declared-supported surface at runtime and fails if it raises
+``NotSupportedError``.
+
+* ``health_check`` — authenticated GET ``/fileSystems`` (validates credentials).
+* ``list_tenants`` / ``get_tenant`` — the single configured organization.
+* ``get_tenant_quota`` / ``list_tenant_quotas`` — filesystem ``total_budget`` /
+  ``used_total`` for ``WEKA_FILESYSTEM``, or directory-quota aggregation when
+  ``WEKA_STORAGE_PATH`` is set.
+* ``list_volumes`` / ``get_volume`` — one ``Volume`` per WEKA filesystem,
+  using the CSI handle ``weka/v2/<filesystem>``. Volume lifecycle is owned by
+  the driver; ``create_volume`` / ``delete_volume`` are left to the base method
+  (which raises ``NotSupportedError``) and the manifest declares them ``none``.
+* ``{list,get,set,delete}_directory_quota`` — directory-tree quotas via the
+  documented REST API (``resolvePath`` + ``PUT`` / ``PATCH`` / ``DELETE`` on
+  ``/fileSystems/<uid>/quota/<inode>``). ``id_assignment`` is ``backend`` (WEKA
+  mints the ``quota_id``), so ``set`` requires a volume-relative ``path``.
+  Creating a quota on a *non-empty* directory over REST needs a Data Services
+  container on the backend; without one WEKA restricts ``PUT`` to empty
+  directories (``PATCH`` / ``DELETE`` on an existing quota are unaffected). The
+  shim surfaces that backend rule verbatim.
+* ``{list,get,set,delete}_user_quota`` — per-UID quotas via
+  ``/fileSystems/<uid>/quota/user``, the REST surface WEKA introduced in
+  **v5.1.26**. Arguments travel as query values rather than a JSON body, and
+  ``GET`` paginates via ``next_token``. Older clusters answer the route with a
+  404 naming the route, which the shim reports as ``NotSupportedError`` (a
+  capability gap) rather than ``NotFoundError`` (a missing quota).
+
+WEKA addresses one UID per call and has no filesystem-wide default-user slot, so
+``defaultUserSlot`` is advertised ``false`` and a request with ``user=None`` is
+refused with ``NotSupportedError``. A hard limit of ``0`` means unlimited on the
+backend and is surfaced as an absent limit, not a zero-byte allowance. User
+quotas are accepted only for filesystem-backed (``weka/v2``) volumes: WEKA scopes
+them to a whole filesystem, so applying one to a directory-backed volume would
+also hit every other PVC sharing that filesystem.
+
+Two backend prerequisites apply before the limits take effect: filesystems
+created before WEKA 5.1.20 need a one-time ``weka fs quota enable-users`` (which
+requires a Data Services container), and enabling user quotas on an existing
+filesystem starts a background ``QUOTA_COLORING`` pass that stamps existing files
+with their UID — quotas are not enforced on pre-existing data until it finishes.
+
+Tenant scoping
+--------------
+``tenant_id`` maps to the WEKA organization name (``WEKA_ORGANIZATION``,
+default ``Root``). On clusters without multi-tenancy this is the sole
+isolation boundary exposed to the shim. To validate multiple tenants, declare
+one provider entry per organization in the manifest.
+
+Environment variables
+---------------------
+WEKA_ENDPOINTS             Comma-separated ``host:port`` list (preferred;
+                          matches the CSI secret ``endpoints`` field).
+WEKA_ENDPOINT              Single ``host:port`` fallback when
+                          ``WEKA_ENDPOINTS`` is unset.
+WEKA_SCHEME                URL scheme (default ``https``).
+WEKA_USERNAME              Required. Cluster username. All surfaces work with
+                          an account with quota-management permissions.
+WEKA_PASSWORD              Required. Cluster password.
+WEKA_ORGANIZATION          Optional. Organization / tenant name for login
+                          (default ``Root``).
+WEKA_FILESYSTEM            Required. Filesystem used for tenant quota
+                          (matches StorageClass ``filesystemName``, e.g.
+                          ``test_fs``). Volume directory quotas use the
+                          filesystem named by their ``weka/v2`` handle.
+WEKA_STORAGE_PATH          Optional. Directory path prefix within the
+                          filesystem for tenant-quota aggregation.
+WEKA_INSECURE_SKIP_VERIFY  Optional. ``1`` / ``true`` to disable TLS
+                          certificate verification (dev/test only).
+
+See ``scripts/storage/README.md`` (sibling directory).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import ssl
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    AuthenticationError,
+    ConflictError,
+    CsiSpec,
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DirectoryQuota,
+    GetTenantQuotaRequest,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    Implementation,
+    ImplementationCapabilities,
+    ListDirectoryQuotasRequest,
+    ListDirectoryQuotasResponse,
+    ListTenantQuotasRequest,
+    ListTenantQuotasResponse,
+    ListTenantsRequest,
+    ListTenantsResponse,
+    ListUserQuotasRequest,
+    ListUserQuotasResponse,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    NotFoundError,
+    NotSupportedError,
+    ProviderProperties,
+    QuotaLimits,
+    QuotaUsage,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    StorageApiError,
+    StorageProvider,
+    Tenant,
+    TenantQuota,
+    UserQuota,
+    ValidationError,
+    VersionMetadata,
+    Volume,
+    VolumeState,
+    new_implementation,
+)
+
+# Maximum pages for the paginated /fileSystems/<uid>/quota response (defensive
+# cap mirroring the VAST shim).
+_MAX_PAGES = 1000
+
+# HTTP status codes that indicate authentication / authorisation failures.
+_AUTH_STATUS_CODES: frozenset[int] = frozenset({401, 403})
+
+# Map WEKA filesystem ``status`` -> shim VolumeState (``weka/v2`` volumes).
+_FS_STATE_MAP: dict[str, VolumeState] = {
+    "ready": "available",
+    "creating": "creating",
+    "removing": "deleting",
+}
+
+# CSI volume handle for a filesystem-per-PVC volume: ``weka/v2/<filesystem>``.
+_FS_HANDLE_PREFIX = "weka/v2/"
+
+# WEKA emits directory-quota ids as ``DIR:0x…:0``; a volume named by one is
+# directory-backed and shares its filesystem with other PVCs.
+_DIR_V1_ID_PREFIX = "DIR:"
+
+# First WEKA release carrying /fileSystems/<uid>/quota/user. Named in the error
+# so an operator on an older cluster sees the upgrade path.
+_MIN_USER_QUOTA_RELEASE = "5.1.26"
+
+
+def _fs_name_from_volume_id(volume_id: str) -> str:
+    """Return the filesystem name from a ``weka/v2`` handle or bare name."""
+    if not volume_id:
+        return ""
+    if volume_id.startswith(_FS_HANDLE_PREFIX):
+        return volume_id[len(_FS_HANDLE_PREFIX) :].strip("/")
+    return "" if "/" in volume_id else volume_id
+
+
+def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
+    """Build the TLS context for provider API calls."""
+    ctx = ssl.create_default_context()
+    if insecure:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+class WekaApi(Implementation):
+    """``StorageProvider`` over the WEKA cluster REST API.
+
+    Single-tenant per instance: the shim is scoped to one WEKA organization +
+    one filesystem (optionally narrowed to a ``storage_path`` prefix). To
+    validate multiple tenants or filesystems, declare separate provider entries
+    in the manifest.
+    """
+
+    def __init__(
+        self,
+        *,
+        endpoints: str | None = None,
+        endpoint: str | None = None,
+        scheme: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        organization: str | None = None,
+        filesystem: str | None = None,
+        storage_path: str | None = None,
+        insecure_skip_verify: bool | None = None,
+    ) -> None:
+        """Initialize the object with its configured dependencies."""
+        raw_endpoints = endpoints or os.environ.get("WEKA_ENDPOINTS", "")
+        if not raw_endpoints:
+            raw_endpoints = endpoint or os.environ.get("WEKA_ENDPOINT", "")
+        if not raw_endpoints:
+            raise StorageApiError("WEKA_ENDPOINTS or WEKA_ENDPOINT must be set for the WEKA shim")
+        self._endpoint_hosts = [h.strip() for h in raw_endpoints.split(",") if h.strip()]
+        self._scheme = (scheme or os.environ.get("WEKA_SCHEME", "https")).rstrip(":/")
+
+        self._username = username or os.environ.get("WEKA_USERNAME", "")
+        self._password = password or os.environ.get("WEKA_PASSWORD", "")
+        if not self._username or not self._password:
+            raise StorageApiError("WEKA_USERNAME and WEKA_PASSWORD must be set for the WEKA shim")
+
+        self._organization = organization if organization is not None else os.environ.get("WEKA_ORGANIZATION", "Root")
+
+        self._filesystem = filesystem or os.environ.get("WEKA_FILESYSTEM", "")
+        if not self._filesystem:
+            raise StorageApiError("WEKA_FILESYSTEM must be set (env var or constructor arg) for the WEKA shim")
+
+        raw_path = storage_path if storage_path is not None else os.environ.get("WEKA_STORAGE_PATH", "")
+        self._storage_path = ("/" + raw_path.strip("/")) if raw_path else ""
+
+        if insecure_skip_verify is not None:
+            skip = insecure_skip_verify
+        else:
+            val = os.environ.get("WEKA_INSECURE_SKIP_VERIFY", "")
+            skip = val.lower() in ("1", "true", "yes")
+        self._ssl_ctx = _build_ssl_context(skip)
+
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._token_expires_at: float = 0.0
+        self._active_base_url: str | None = None
+
+        # Identity + capability core (mirrors ProviderProperties). provider
+        # version is "0.1.0" (the shim's own version, semver) and MUST stay in
+        # sync with the manifest's provider.version. The backend version is an
+        # opaque vendor passthrough ("unknown" - the live cluster build is not
+        # surfaced by the REST API today).
+        core = ProviderProperties(
+            provider_namespace="weka.io",
+            provider_id="shared-fs",
+            provider_metadata=VersionMetadata(
+                vendor_name="NVIDIA",
+                name="WEKA shared filesystem",
+                version="0.1.0",
+            ),
+            sdk_version=API_VERSION,
+            storage_type="file",
+            storage_protocols=["wekafs"],
+            backend_metadata=VersionMetadata(
+                vendor_name="WekaIO",
+                vendor_docs="https://docs.weka.io/weka-filesystems-and-object-stores/quota-management",
+                name="WEKA",
+                version="unknown",
+            ),
+            attributes={
+                "filesystem": self._filesystem,
+                "storage_path": self._storage_path,
+            },
+        )
+        self._core = core
+
+    # ------------------------------------------------------------------
+    # StorageProvider: discovery / tenant / volume
+    # ------------------------------------------------------------------
+
+    def health_check(self) -> None:
+        """Authenticated GET ``/fileSystems`` — validates credentials."""
+        self._request("GET", "/api/v2/fileSystems")
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        """Return overall storage utilization for the configured organization.
+
+        With ``WEKA_STORAGE_PATH`` unset, the target filesystem's
+        ``total_budget`` / ``used_total`` is the tenant ceiling. When set, the
+        ceiling and usage are aggregated from the directory quotas rooted at
+        that path (VAST-style: parent hard limit or sum of children).
+        """
+        resolved = self._resolve_tenant(req.tenant_id)
+        if self._storage_path:
+            return self._tenant_quota_from_directory_quotas(resolved)
+        return self._tenant_quota_from_filesystem(resolved)
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        """Return one ``weka/v2`` volume per filesystem in the organization."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        wanted_ids = set(req.ids) if req.ids else None
+        filters = list(req.tag_filters)
+
+        result: list[Volume] = []
+        for fs in self._filesystems():
+            vol = self._filesystem_to_volume(fs, tenant_id=resolved)
+            if wanted_ids is not None and vol.id not in wanted_ids:
+                continue
+            if filters:
+                # WEKA filesystems have no tag concept; tag filters never match.
+                continue
+            result.append(vol)
+        return ListVolumesResponse(volumes=tuple(result))
+
+    def get_volume(self, req: GetVolumeRequest) -> Volume:
+        """Return a filesystem volume by ``weka/v2`` handle or bare name."""
+        resolved = self._resolve_tenant(req.tenant_id)
+        fs = self._filesystem_for_volume(req.volume_id)
+        if fs is None:
+            raise NotFoundError(f"volume {req.volume_id!r} not found")
+        return self._filesystem_to_volume(fs, tenant_id=resolved)
+
+    # Volume lifecycle (create_volume / delete_volume) is intentionally NOT
+    # implemented: the WEKA CSI driver (csi.weka.io) owns it. The methods fall
+    # back to the base raise (NotSupportedError) and the manifest declares
+    # volume.create / volume.delete ``none``.
+
+    def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+        """Refine the composed capabilities with WEKA's semantic facts."""
+        # WEKA quotas are byte-only (no inode enforcement); directory-quota ids
+        # are backend-minted (``quota_id``), so ``set`` needs a path; and the
+        # shim is scoped to a single organization.
+        caps.quota().set_inodes(False)
+        caps.quota().directory().set_id_assignment("backend")
+        # WEKA's user quota API addresses one uid per call, with no
+        # filesystem-wide default-user slot.
+        caps.quota().user().set_default_user_slot(False)
+        caps.tenant().set_multi_tenant(False)
+
+    # ------------------------------------------------------------------
+    # StorageProvider: tenant enumeration
+    # ------------------------------------------------------------------
+
+    def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+        """Return the single organization this shim is scoped to."""
+        tenant = Tenant(id=self._organization, name=self._organization or "Root")
+        if not req.ids or self._organization in req.ids:
+            return ListTenantsResponse(tenants=(tenant,))
+        return ListTenantsResponse(tenants=())
+
+    def list_tenant_quotas(self, req: ListTenantQuotasRequest) -> ListTenantQuotasResponse:
+        """Return the sole organization's quota as a one-element list."""
+        quota = self.get_tenant_quota(GetTenantQuotaRequest(tenant_id=req.tenant_id))
+        return ListTenantQuotasResponse(tenant_quotas=(quota,))
+
+    # ------------------------------------------------------------------
+    # StorageProvider: directory quotas (documented REST API)
+    # ------------------------------------------------------------------
+
+    def list_directory_quotas(self, req: ListDirectoryQuotasRequest) -> ListDirectoryQuotasResponse:
+        """Return directory quotas below the volume's filesystem root."""
+        tenant_id = self._resolve_tenant(req.tenant_id)
+        fs_uid = self._filesystem_uid_for_volume(req.volume_id)
+        out: list[DirectoryQuota] = []
+        for q in self._list_directory_quotas(fs_uid=fs_uid):
+            q_path = _norm_path(q.get("path") or "")
+            if not q_path:
+                continue
+            out.append(self._directory_quota(q, tenant_id, req.volume_id, q_path.lstrip("/")))
+        return ListDirectoryQuotasResponse(directory_quotas=tuple(out))
+
+    def set_directory_quota(self, req: SetDirectoryQuotaRequest) -> DirectoryQuota:
+        """Create or update a directory-tree quota under the volume."""
+        quota = req.quota
+        if quota.path is None:
+            raise ValidationError("directory quota path is required (id_assignment=backend)")
+        tenant_id = self._resolve_tenant(quota.tenant_id)
+        fs_uid = self._filesystem_uid_for_volume(quota.volume_id)
+        abs_path = _norm_path(quota.path)
+        if not abs_path:
+            # Root path is the CSI capacity quota on the volume itself.
+            raise ValidationError(f"directory quota path must name a subdirectory of the volume, got {quota.path!r}")
+        hard = _hard_bytes(quota.hard)
+
+        existing = self._find_directory_quota_by_path(fs_uid, abs_path)
+        if existing is not None:
+            stored = self._patch_directory_quota(fs_uid, _quota_inode_id(existing), hard)
+        else:
+            inode = self._resolve_inode(fs_uid, abs_path)
+            stored = self._put_directory_quota(fs_uid, inode, hard)
+        if not stored.get("path"):
+            stored["path"] = abs_path
+        return self._directory_quota(
+            stored, tenant_id, quota.volume_id, _norm_path(stored.get("path") or "").lstrip("/")
+        )
+
+    def delete_directory_quota(self, req: DeleteDirectoryQuotaRequest) -> None:
+        """Remove a directory-tree quota (idempotent — missing is a no-op)."""
+        if req.path is None and req.id is None:
+            raise ValidationError("delete_directory_quota requires at least one of path or id")
+        if req.path is not None and not _norm_path(req.path):
+            raise ValidationError("directory quota path must name a subdirectory of the volume")
+        self._resolve_tenant(req.tenant_id)
+        fs_uid = self._filesystem_uid_for_volume(req.volume_id)
+
+        target: dict[str, Any] | None = None
+        if req.path is not None:
+            target = self._find_directory_quota_by_path(fs_uid, _norm_path(req.path))
+        else:
+            for q in self._list_directory_quotas(fs_uid=fs_uid):
+                if _quota_id(q) != req.id:
+                    continue
+                if not _norm_path(q.get("path") or ""):
+                    continue
+                target = q
+                break
+        if target is None:
+            return
+        if req.path is not None and req.id is not None and _quota_id(target) != req.id:
+            raise ConflictError(
+                f"directory quota key mismatch: path resolved to id {_quota_id(target)!r}, requested id {req.id!r}"
+            )
+        self._delete_directory_quota(fs_uid, _quota_inode_id(target))
+
+    # ------------------------------------------------------------------
+    # StorageProvider: user quotas (WEKA 5.1.26+ REST API)
+    # ------------------------------------------------------------------
+
+    def list_user_quotas(self, req: ListUserQuotasRequest) -> ListUserQuotasResponse:
+        """Enumerate the per-UID quotas on the volume's filesystem."""
+        tenant_id = self._resolve_tenant(req.tenant_id)
+        fs_uid = self._filesystem_uid_for_user_quota(req.volume_id)
+        rows = self._list_user_quota_rows(fs_uid)
+        return ListUserQuotasResponse(
+            user_quotas=tuple(self._user_quota(row, tenant_id, req.volume_id) for row in rows)
+        )
+
+    def get_user_quota(self, req: GetUserQuotaRequest) -> UserQuota:
+        """Look up one UID's quota on the volume's filesystem."""
+        if req.user is None:
+            raise _default_user_slot_unsupported()
+        tenant_id = self._resolve_tenant(req.tenant_id)
+        fs_uid = self._filesystem_uid_for_user_quota(req.volume_id)
+        uid = _parse_user_uid(req.user)
+        # WEKA exposes no per-uid read; the list endpoint is the only source.
+        for row in self._list_user_quota_rows(fs_uid):
+            if _row_uid(row) == uid:
+                return self._user_quota(row, tenant_id, req.volume_id)
+        raise NotFoundError(f"user quota for uid {uid} not found on volume {req.volume_id!r}")
+
+    def set_user_quota(self, req: SetUserQuotaRequest) -> UserQuota:
+        """Upsert one UID's hard byte limit on the volume's filesystem."""
+        quota = req.quota
+        if quota.user is None:
+            raise _default_user_slot_unsupported()
+        resolved = self._resolve_tenant(quota.tenant_id)
+        fs_uid = self._filesystem_uid_for_user_quota(quota.volume_id)
+        uid = _parse_user_uid(quota.user)
+        # Both limits are sent unconditionally: WEKA reads 0 as unlimited, so an
+        # explicit zero is how a limit gets cleared.
+        self._user_quota_request(
+            "POST",
+            fs_uid,
+            params={
+                "user_id": str(uid),
+                "hard_limit_bytes": str(max(_hard_bytes(quota.hard), 0)),
+                "soft_limit_bytes": "0",
+            },
+        )
+        return self.get_user_quota(GetUserQuotaRequest(tenant_id=resolved, volume_id=quota.volume_id, user=quota.user))
+
+    def delete_user_quota(self, req: DeleteUserQuotaRequest) -> None:
+        """Remove one UID's quota (no-op if already absent)."""
+        if req.user is None:
+            raise _default_user_slot_unsupported()
+        self._resolve_tenant(req.tenant_id)
+        fs_uid = self._filesystem_uid_for_user_quota(req.volume_id)
+        uid = _parse_user_uid(req.user)
+        try:
+            self._user_quota_request("DELETE", fs_uid, params={"user_id": str(uid)})
+        except NotFoundError:
+            return
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_tenant(self, tenant_id: str | None) -> str:
+        """Resolve and validate the request tenant for this shim."""
+        resolved = tenant_id if tenant_id is not None else self._organization
+        if not resolved:
+            raise StorageApiError("tenant_id is required (no default organization configured)")
+        if tenant_id is not None and tenant_id != self._organization:
+            raise NotFoundError(
+                f"tenant_id={tenant_id!r} does not match this shim's configured organization "
+                f"{self._organization!r}; declare a separate provider entry per tenant"
+            )
+        return resolved
+
+    def _base_urls(self) -> list[str]:
+        """Return candidate WEKA API base URLs."""
+        return [f"{self._scheme}://{host.rstrip('/')}" for host in self._endpoint_hosts]
+
+    def _ensure_token(self) -> None:
+        """Ensure a usable access token is available."""
+        if self._access_token and time.monotonic() < self._token_expires_at - 30:
+            return
+        if self._refresh_token:
+            try:
+                self._refresh_access_token()
+                return
+            except AuthenticationError:
+                pass
+        self._login()
+
+    def _login(self) -> None:
+        """Authenticate to WEKA and store returned tokens."""
+        body: dict[str, str] = {
+            "username": self._username,
+            "password": self._password,
+        }
+        if self._organization:
+            body["org"] = self._organization
+
+        last_error: Exception | None = None
+        for base_url in self._base_urls():
+            try:
+                payload = self._raw_request(
+                    "POST",
+                    "/api/v2/login",
+                    body=body,
+                    base_url=base_url,
+                    auth=False,
+                )
+                data = self._unwrap(payload)
+                self._store_tokens(data, base_url=base_url)
+                return
+            except AuthenticationError:
+                raise
+            except StorageApiError as exc:
+                last_error = exc
+        raise StorageApiError(f"WEKA login failed against all endpoints: {last_error}") from last_error
+
+    def _refresh_access_token(self) -> None:
+        """Refresh the WEKA access token using the refresh token."""
+        if not self._refresh_token or not self._active_base_url:
+            raise AuthenticationError("no refresh token available")
+        payload = self._raw_request(
+            "POST",
+            "/api/v2/login/refresh",
+            body={"refresh_token": self._refresh_token},
+            base_url=self._active_base_url,
+            auth=False,
+        )
+        data = self._unwrap(payload)
+        self._store_tokens(data, base_url=self._active_base_url)
+
+    def _store_tokens(self, payload: Any, *, base_url: str) -> None:
+        """Store WEKA authentication tokens and expiry metadata."""
+        if not isinstance(payload, dict):
+            raise StorageApiError(f"unexpected login response type: {type(payload)!r}")
+        access = payload.get("access_token")
+        if not access:
+            raise StorageApiError("login response missing access_token")
+        self._access_token = str(access)
+        refresh = payload.get("refresh_token")
+        self._refresh_token = str(refresh) if refresh else None
+        expires_in = int(payload.get("expires_in") or 300)
+        self._token_expires_at = time.monotonic() + expires_in
+        self._active_base_url = base_url
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> Any:
+        """Send an authenticated provider API request."""
+        envelope = self._request_envelope(method, path, body=body, params=params)
+        return self._unwrap(envelope)
+
+    def _request_envelope(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> Any:
+        """Send a WEKA request and return the response envelope."""
+        self._ensure_token()
+        assert self._active_base_url is not None
+        try:
+            payload = self._raw_request(
+                method,
+                path,
+                body=body,
+                params=params,
+                base_url=self._active_base_url,
+                auth=True,
+            )
+        except AuthenticationError:
+            self._access_token = None
+            self._ensure_token()
+            payload = self._raw_request(
+                method,
+                path,
+                body=body,
+                params=params,
+                base_url=self._active_base_url,
+                auth=True,
+            )
+        if isinstance(payload, dict):
+            return payload
+        return {"data": payload}
+
+    def _raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+        base_url: str,
+        auth: bool,
+    ) -> Any:
+        """Perform one raw HTTP request to the provider API."""
+        query = urllib.parse.urlencode(params) if params else ""
+        url = base_url + path + (f"?{query}" if query else "")
+        data = json.dumps(body).encode() if body is not None else None
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        if auth:
+            if not self._access_token:
+                raise AuthenticationError("missing access token")
+            headers["Authorization"] = f"Bearer {self._access_token}"
+
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, context=self._ssl_ctx, timeout=30) as resp:
+                raw = resp.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as exc:
+            if exc.code in _AUTH_STATUS_CODES:
+                raise AuthenticationError(f"WEKA {method} {path}: HTTP {exc.code} {exc.reason}") from exc
+            body_text = ""
+            try:
+                body_text = exc.read().decode(errors="replace").strip()
+            except Exception:
+                pass
+            if exc.code == 404 and _is_unknown_route(body_text):
+                raise NotSupportedError(
+                    f"WEKA {method} {path}: route not implemented on this cluster release: {body_text}"
+                ) from exc
+            if exc.code == 404:
+                raise NotFoundError(f"WEKA {method} {path}: HTTP 404 {exc.reason}") from exc
+            raise StorageApiError(f"WEKA {method} {path}: HTTP {exc.code}: {body_text or exc.reason}") from exc
+        except urllib.error.URLError as exc:
+            raise StorageApiError(f"WEKA {method} {path}: {exc.reason}") from exc
+
+    @staticmethod
+    def _unwrap(payload: Any) -> Any:
+        """Return the data payload from a provider response envelope."""
+        if isinstance(payload, dict) and "data" in payload:
+            return payload["data"]
+        return payload
+
+    def _filesystems(self) -> list[dict[str, Any]]:
+        """Return filesystem rows from the WEKA API."""
+        filesystems = self._request("GET", "/api/v2/fileSystems")
+        if not isinstance(filesystems, list):
+            raise StorageApiError(f"unexpected /fileSystems response type: {type(filesystems)!r}")
+        return filesystems
+
+    def _get_filesystem(self) -> dict[str, Any]:
+        """Return the configured WEKA filesystem row."""
+        for fs in self._filesystems():
+            if str(fs.get("name") or "") == self._filesystem:
+                return fs
+        raise StorageApiError(f"filesystem {self._filesystem!r} not found on WEKA cluster")
+
+    def _filesystem_for_volume(self, volume_id: str) -> dict[str, Any] | None:
+        """The filesystem a ``weka/v2`` volume id names, if the cluster has one."""
+        name = _fs_name_from_volume_id(volume_id)
+        if not name:
+            return None
+        for fs in self._filesystems():
+            if str(fs.get("name") or "") == name:
+                return fs
+        return None
+
+    def _filesystem_uid_for_volume(self, volume_id: str) -> str:
+        """Return the filesystem uid for a ``weka/v2`` volume."""
+        fs = self._filesystem_for_volume(volume_id)
+        if fs is None:
+            raise NotFoundError(f"volume {volume_id!r} not found")
+        uid = str(fs.get("uid") or "")
+        if not uid:
+            raise StorageApiError(f"filesystem {fs.get('name')!r} missing uid")
+        return uid
+
+    def _filesystem_to_volume(self, fs: dict[str, Any], *, tenant_id: str) -> Volume:
+        """Map a WEKA filesystem to the ``Volume`` a ``weka/v2`` PVC exposes."""
+        name = str(fs.get("name") or "")
+        handle = _FS_HANDLE_PREFIX + name
+        total = int(fs.get("total_budget") or fs.get("ssd_budget") or 0)
+        used = int(fs.get("used_total") or 0)
+        state: VolumeState = _FS_STATE_MAP.get(str(fs.get("status") or "").lower(), "failed")
+
+        return Volume(
+            tenant_id=tenant_id,
+            # CSI handle (not WEKA uid) so get_volume / quota calls round-trip.
+            id=handle,
+            size_bytes=total,
+            created_at=datetime.now(UTC),
+            type="file",
+            state=state,
+            name=name,
+            csi=CsiSpec(driver="csi.weka.io", volume_handle=handle, fs_type="wekafs"),
+            used_bytes=used,
+            available_bytes=max(0, total - used),
+            attributes={
+                "path": "",
+                "filesystem": name,
+                "uid": str(fs.get("uid") or ""),
+            },
+        )
+
+    def _tenant_quota_from_filesystem(self, tenant_id: str) -> TenantQuota:
+        """Build tenant quota from the configured filesystem."""
+        fs = self._get_filesystem()
+        hard_limit_bytes = int(fs.get("total_budget") or fs.get("ssd_budget") or 0)
+        used_bytes = int(fs.get("used_total") or 0)
+        name = str(fs.get("name") or self._filesystem)
+        return TenantQuota(
+            tenant_id=tenant_id,
+            hard_limit_bytes=hard_limit_bytes,
+            used_bytes=used_bytes,
+            name=name,
+        )
+
+    def _tenant_quota_from_directory_quotas(self, tenant_id: str) -> TenantQuota:
+        """Build tenant quota from directory quota rows."""
+        quotas = self._list_directory_quotas(include_root=True)
+        storage_path = self._storage_path.rstrip("/")
+
+        parent: dict[str, Any] | None = None
+        children: list[dict[str, Any]] = []
+        for q in quotas:
+            path_norm = (q.get("path") or "").rstrip("/")
+            if path_norm == storage_path:
+                parent = q
+            elif path_norm.startswith(storage_path + "/"):
+                children.append(q)
+
+        if parent is not None:
+            hard_limit_bytes = int(parent.get("hard_limit_bytes") or 0)
+            name = str(parent.get("path") or storage_path)
+        else:
+            hard_limit_bytes = sum(int(q.get("hard_limit_bytes") or 0) for q in children)
+            name = f"WEKA {storage_path}"
+
+        used_bytes = sum(int(q.get("total_bytes") or 0) for q in children)
+        return TenantQuota(
+            tenant_id=tenant_id,
+            hard_limit_bytes=hard_limit_bytes,
+            used_bytes=used_bytes,
+            name=name,
+        )
+
+    def _list_directory_quotas(self, *, fs_uid: str | None = None, include_root: bool = False) -> list[dict[str, Any]]:
+        """Paginated directory quotas for ``fs_uid`` (default: ``WEKA_FILESYSTEM``).
+
+        When ``fs_uid`` is omitted, apply ``WEKA_STORAGE_PATH`` filtering.
+        Callers that pass ``fs_uid`` already scope by the volume root.
+        """
+        scoped_to_volume = fs_uid is not None
+        if fs_uid is None:
+            fs_uid = self._filesystem_uid()
+
+        all_quotas: list[dict[str, Any]] = []
+        params: dict[str, str] | None = None
+        for _ in range(_MAX_PAGES):
+            envelope = self._request_envelope(
+                "GET",
+                f"/api/v2/fileSystems/{fs_uid}/quota",
+                params=params,
+            )
+            page = envelope.get("data")
+            if page is None:
+                page = envelope.get("quotas") or envelope.get("results") or envelope
+            if isinstance(page, dict):
+                page = [page]
+            if not isinstance(page, list):
+                break
+            all_quotas.extend(page)
+
+            next_token = envelope.get("next_token")
+            if not next_token:
+                break
+            params = {"next_token": str(next_token)}
+
+        if scoped_to_volume:
+            return all_quotas
+        return self._filter_quotas(all_quotas, include_root=include_root)
+
+    def _filter_quotas(self, quotas: list[dict[str, Any]], *, include_root: bool) -> list[dict[str, Any]]:
+        """Filter quota rows to the configured storage path."""
+        if not self._storage_path:
+            return quotas
+
+        storage_path = self._storage_path.rstrip("/")
+        filtered: list[dict[str, Any]] = []
+        for q in quotas:
+            path_norm = (q.get("path") or "").rstrip("/")
+            if path_norm == storage_path and include_root:
+                filtered.append(q)
+            elif path_norm.startswith(storage_path + "/"):
+                filtered.append(q)
+        return filtered
+
+    def _directory_quota(self, q: dict[str, Any], tenant_id: str, volume_id: str, rel_path: str) -> DirectoryQuota:
+        """Convert a WEKA quota row to a DirectoryQuota."""
+        hard = int(q.get("hard_limit_bytes") or 0)
+        return DirectoryQuota(
+            tenant_id=tenant_id,
+            volume_id=volume_id,
+            path=rel_path,
+            id=_quota_id(q),
+            hard=QuotaLimits(bytes=hard if hard > 0 else None),
+            usage=QuotaUsage(bytes=int(q.get("total_bytes") or 0)),
+        )
+
+    # --- directory-quota REST helpers -----------------------------------
+
+    def _filesystem_uid(self) -> str:
+        """Return the configured filesystem UID."""
+        fs = self._get_filesystem()
+        uid = str(fs.get("uid") or "")
+        if not uid:
+            raise StorageApiError(f"filesystem {self._filesystem!r} missing uid")
+        return uid
+
+    def _resolve_inode(self, fs_uid: str, quota_path: str) -> str:
+        """Resolve an absolute filesystem path to its inode id (for a new quota)."""
+        data = self._request(
+            "GET",
+            f"/api/v2/fileSystems/{urllib.parse.quote(fs_uid)}/resolvePath",
+            params={"path": _norm_path(quota_path)},
+        )
+        inode = str(data.get("inode_id") or "") if isinstance(data, dict) else ""
+        if not inode:
+            raise NotFoundError(f"path {quota_path!r} not found on WEKA filesystem")
+        return inode
+
+    def _find_directory_quota_by_path(self, fs_uid: str, abs_path: str) -> dict[str, Any] | None:
+        """Find a directory quota row by absolute path."""
+        want = _norm_path(abs_path)
+        for q in self._list_directory_quotas(fs_uid=fs_uid):
+            if _norm_path(q.get("path") or "") == want:
+                return q
+        return None
+
+    def _quota_path(self, fs_uid: str, inode: str) -> str:
+        """Build the WEKA directory quota endpoint path."""
+        return f"/api/v2/fileSystems/{urllib.parse.quote(fs_uid)}/quota/{urllib.parse.quote(inode)}"
+
+    def _put_directory_quota(self, fs_uid: str, inode: str, hard: int) -> dict[str, Any]:
+        """Create a WEKA directory quota for an inode."""
+        # PUT creates the quota; WEKA requires the full limit tuple even when
+        # only a hard limit is configured (0 keeps soft/grace unlimited).
+        data = self._request(
+            "PUT",
+            self._quota_path(fs_uid, inode),
+            body={"hard_limit_bytes": hard, "soft_limit_bytes": 0, "grace_seconds": 0},
+        )
+        return data if isinstance(data, dict) else {}
+
+    def _patch_directory_quota(self, fs_uid: str, inode: str, hard: int) -> dict[str, Any]:
+        """Update a WEKA directory quota for an inode."""
+        data = self._request(
+            "PATCH",
+            self._quota_path(fs_uid, inode),
+            body={"hard_limit_bytes": hard},
+        )
+        return data if isinstance(data, dict) else {}
+
+    def _delete_directory_quota(self, fs_uid: str, inode: str) -> None:
+        """Delete a WEKA directory quota for an inode."""
+        self._request("DELETE", self._quota_path(fs_uid, inode))
+
+    # --- user-quota REST helpers ----------------------------------------
+
+    def _filesystem_uid_for_user_quota(self, volume_id: str) -> str:
+        """The filesystem uid a user quota may be written to.
+
+        WEKA scopes user quotas to a whole filesystem, so a directory-backed
+        volume is refused: its quota would also bind every other PVC sharing
+        that filesystem.
+        """
+        if volume_id.strip().startswith(_DIR_V1_ID_PREFIX):
+            raise NotSupportedError(
+                "WEKA user quotas require a filesystem-backed (weka/v2) volume, one filesystem per PVC; "
+                f"refusing directory-backed volume {volume_id!r}"
+            )
+        return self._filesystem_uid_for_volume(volume_id)
+
+    def _user_quota_request(self, method: str, fs_uid: str, *, params: dict[str, str] | None = None) -> Any:
+        """Send a WEKA user quota request with release mapping."""
+        with _user_quota_route():
+            return self._request(method, _user_quota_path(fs_uid), params=params)
+
+    def _list_user_quota_rows(self, fs_uid: str) -> list[dict[str, Any]]:
+        """Every user-quota row on ``fs_uid``, following ``next_token``."""
+        rows: list[dict[str, Any]] = []
+        params: dict[str, str] | None = None
+        for _ in range(_MAX_PAGES):
+            with _user_quota_route():
+                envelope = self._request_envelope("GET", _user_quota_path(fs_uid), params=params)
+            page = envelope.get("data")
+            if isinstance(page, dict):
+                page = [page]
+            if not isinstance(page, list):
+                break
+            rows.extend(row for row in page if isinstance(row, dict))
+
+            next_token = envelope.get("next_token")
+            # next_token is a number in the body but must go back as a query
+            # value; the final page omits it.
+            if not next_token or (params is not None and str(next_token) == params.get("next_token")):
+                break
+            params = {"next_token": str(next_token)}
+        return rows
+
+    def _user_quota(self, row: dict[str, Any], tenant_id: str, volume_id: str) -> UserQuota:
+        """Convert a WEKA user quota row to a UserQuota."""
+        # WEKA reports 0 as unlimited rather than as a zero-byte allowance.
+        hard = int(row.get("hard_limit_bytes") or 0)
+        return UserQuota(
+            tenant_id=tenant_id,
+            volume_id=volume_id,
+            user=str(_row_uid(row)),
+            hard=QuotaLimits(bytes=hard if hard > 0 else None),
+            usage=QuotaUsage(bytes=int(row.get("total_bytes") or 0)),
+        )
+
+
+# ----------------------------------------------------------------------
+# Module-level path / id / quota helpers
+# ----------------------------------------------------------------------
+
+
+def _norm_path(p: str) -> str:
+    """Normalize to a leading-slash absolute path (``""`` for empty / root)."""
+    raw = (p or "").strip("/")
+    return "/" + raw if raw else ""
+
+
+def _quota_id(q: dict[str, Any]) -> str:
+    """Return the stable quota identifier from a backend row."""
+    qid = str(q.get("quota_id") or "").strip()
+    if qid:
+        return qid
+    return str(q.get("inode_id") or "").strip()
+
+
+def _quota_inode_id(q: dict[str, Any]) -> str:
+    """The decimal inode id WEKA quota endpoints key on (falls back to quota_id)."""
+    inode = str(q.get("inode_id") or "").strip()
+    if inode:
+        return inode
+    return _quota_id(q)
+
+
+def _hard_bytes(limits: QuotaLimits | None) -> int:
+    """Return the hard byte limit, or zero for unlimited."""
+    if limits is None or limits.bytes is None:
+        return 0
+    return int(limits.bytes)
+
+
+def _parse_user_uid(user: str) -> int:
+    """WEKA's ``user_id`` is numeric; usernames have no REST equivalent."""
+    try:
+        return int(user.strip())
+    except ValueError:
+        raise ValidationError(f"WEKA user subject must be a numeric uid, got {user!r}") from None
+
+
+def _row_uid(row: dict[str, Any]) -> int:
+    """Return the numeric UID from a WEKA quota row."""
+    return int(row.get("uid_or_gid") or 0)
+
+
+def _user_quota_path(fs_uid: str) -> str:
+    """Build the WEKA user quota endpoint path."""
+    return f"/api/v2/fileSystems/{urllib.parse.quote(fs_uid)}/quota/user"
+
+
+@contextlib.contextmanager
+def _user_quota_route() -> Iterator[None]:
+    """Name the release that carries these endpoints when the route is absent."""
+    try:
+        yield
+    except NotSupportedError as exc:
+        raise NotSupportedError(f"WEKA user quotas require WEKA {_MIN_USER_QUOTA_RELEASE} or later: {exc}") from exc
+
+
+def _default_user_slot_unsupported() -> NotSupportedError:
+    """Build the default-user-slot unsupported error."""
+    return NotSupportedError(
+        "WEKA user quotas address a specific uid; the default-user slot (user=None) has no WEKA equivalent"
+    )
+
+
+def _is_unknown_route(message: str) -> bool:
+    """Whether a 404 body names a missing *route* rather than a missing object.
+
+    WEKA answers a route it does not implement with 404 and a body like
+    ``{"message":"Route GET - /api/v2/… does not exist"}``, whereas a missing
+    object reads ``{"message":"uid: '…' not found"}``. An absent API surface is
+    a capability gap, so the two must not collapse together.
+    """
+    return '"Route ' in message and "does not exist" in message
+
+
+def build_api() -> StorageProvider:
+    """Entry point isvtest calls. Single hook the provider commits to.
+
+    Composes ``WekaApi`` into a served ``StorageProvider`` via
+    ``new_implementation``: capabilities are detected from the overridden
+    methods. WEKA resolves its own default tenant internally, so no
+    ``default_tenant`` wrapping is applied here.
+    """
+    impl = WekaApi()
+    return new_implementation(core=impl._core, impl=impl)

--- a/isvctl/configs/suites/storage.yaml
+++ b/isvctl/configs/suites/storage.yaml
@@ -363,6 +363,36 @@ tests:
           bind_timeout_s: 120
           expand_timeout_s: 180
           namespace_prefix: "isvtest-csi-expand"
+        StorageProviderApiCheck:
+          test_id: "N/A"
+          labels: ["kubernetes", "storage", "storage_provider_api"]
+          requires: [kubernetes]
+          # Drives StorageProvider API contract conformity. The manifest enumerates
+          # one or more backend providers; this check imports each provider's shim
+          # Python file in-process and runs health_check / create+delete_volume /
+          # get_tenant_quota against it.
+          # manifest_path is empty by default so the check is skipped
+          # cleanly on providers that haven't onboarded the shim yet. Set
+          # steps.setup.storage.manifest_path (or override this key in a
+          # provider config) to the path of the mounted ConfigMap file (K8s) or to the on-disk manifest (bare-metal).
+          manifest_path: "{{ steps.setup.storage.manifest_path | default('', true) }}"
+          volume_size_bytes: 1073741824 # 1 GiB
+        StorageDirectoryQuotaEnforcementCheck:
+          test_id: "N/A"
+          labels: ["kubernetes", "storage", "storage_provider_api", "slow"]
+          requires: [kubernetes]
+          # Real directory-quota lifecycle + enforcement (vs. the bogus-id probes
+          # in StorageProviderApiCheck). Provisions an RWX PVC on the shared-fs
+          # StorageClass, mounts it, then drives set/get/update/list/delete over
+          # the shim and writes data through the mount to prove the hard limit is
+          # enforced. Skipped cleanly when no provider declares
+          # quota.directory.set, no shared-fs StorageClass is configured, or no
+          # cluster is reachable. storage_class falls back to K8S_CSI_SHARED_FS_SC.
+          manifest_path: "{{ steps.setup.storage.manifest_path | default('', true) }}"
+          storage_class: "{{ steps.setup_cluster.csi.shared_fs_storage_class | default('', true) }}"
+          pvc_size: "5Gi"
+          create_hard_bytes: 1073741824 # 1 GiB
+          enforcement_hard_bytes: 67108864 # 64 MiB
         K8sNodeKernelModulesCheck:
           test_id: "HSS11-04"
           labels: ["kubernetes", "storage"]

--- a/isvctl/configs/suites/storage.yaml
+++ b/isvctl/configs/suites/storage.yaml
@@ -251,6 +251,40 @@ tests:
           requires: [vm, bare_metal]
           step: multipath
 
+    storage_provider_api:
+      checks:
+        StorageProviderApiCheck:
+          test_id: "N/A"
+          labels: ["storage", "storage_provider_api"]
+          requires: []
+          # Drives StorageProvider API contract conformity. The manifest enumerates
+          # one or more backend providers; this check imports each provider's shim
+          # Python file in-process and runs health_check / create+delete_volume /
+          # get_tenant_quota against it. It does not require Kubernetes; K8s
+          # provider configs may still point manifest_path at a mounted ConfigMap.
+          # manifest_path is empty by default so the check is skipped cleanly on
+          # providers that haven't onboarded the shim yet.
+          manifest_path: "{{ steps.setup.storage.manifest_path | default('', true) }}"
+          volume_size_bytes: 1073741824 # 1 GiB
+        StorageDirectoryQuotaEnforcementCheck:
+          test_id: "N/A"
+          labels: ["storage", "storage_provider_api", "slow"]
+          requires: []
+          # Real directory-quota lifecycle + enforcement (vs. the sentinel-id probes
+          # in StorageProviderApiCheck). Uses the Kubernetes PVC/pod path for
+          # CSI-owned volume lifecycle when a cluster is reachable; otherwise,
+          # providers that declare native volume.create/delete are exercised via
+          # create_volume(), Volume.mount, local writes, and delete_volume().
+          # Skipped cleanly when no provider declares full directory-quota CRUD,
+          # no Kubernetes/CSI or native acquisition path is available, or a
+          # native volume returns no mount instructions.
+          manifest_path: "{{ steps.setup.storage.manifest_path | default('', true) }}"
+          storage_class: "{{ steps.setup_cluster.csi.shared_fs_storage_class | default('', true) }}"
+          pvc_size: "5Gi"
+          volume_size_bytes: 1073741824 # 1 GiB
+          create_hard_bytes: 1073741824 # 1 GiB
+          enforcement_hard_bytes: 67108864 # 64 MiB
+
     # Kubernetes storage checks probe the current cluster, so they bind to no
     # step: a `step:` here would skip them whenever no provider supplies that
     # fixture. StorageClass names come from steps.setup_cluster.csi on a provider
@@ -363,36 +397,6 @@ tests:
           bind_timeout_s: 120
           expand_timeout_s: 180
           namespace_prefix: "isvtest-csi-expand"
-        StorageProviderApiCheck:
-          test_id: "N/A"
-          labels: ["kubernetes", "storage", "storage_provider_api"]
-          requires: [kubernetes]
-          # Drives StorageProvider API contract conformity. The manifest enumerates
-          # one or more backend providers; this check imports each provider's shim
-          # Python file in-process and runs health_check / create+delete_volume /
-          # get_tenant_quota against it.
-          # manifest_path is empty by default so the check is skipped
-          # cleanly on providers that haven't onboarded the shim yet. Set
-          # steps.setup.storage.manifest_path (or override this key in a
-          # provider config) to the path of the mounted ConfigMap file (K8s) or to the on-disk manifest (bare-metal).
-          manifest_path: "{{ steps.setup.storage.manifest_path | default('', true) }}"
-          volume_size_bytes: 1073741824 # 1 GiB
-        StorageDirectoryQuotaEnforcementCheck:
-          test_id: "N/A"
-          labels: ["kubernetes", "storage", "storage_provider_api", "slow"]
-          requires: [kubernetes]
-          # Real directory-quota lifecycle + enforcement (vs. the bogus-id probes
-          # in StorageProviderApiCheck). Provisions an RWX PVC on the shared-fs
-          # StorageClass, mounts it, then drives set/get/update/list/delete over
-          # the shim and writes data through the mount to prove the hard limit is
-          # enforced. Skipped cleanly when no provider declares
-          # quota.directory.set, no shared-fs StorageClass is configured, or no
-          # cluster is reachable. storage_class falls back to K8S_CSI_SHARED_FS_SC.
-          manifest_path: "{{ steps.setup.storage.manifest_path | default('', true) }}"
-          storage_class: "{{ steps.setup_cluster.csi.shared_fs_storage_class | default('', true) }}"
-          pvc_size: "5Gi"
-          create_hard_bytes: 1073741824 # 1 GiB
-          enforcement_hard_bytes: 67108864 # 64 MiB
         K8sNodeKernelModulesCheck:
           test_id: "HSS11-04"
           labels: ["kubernetes", "storage"]

--- a/isvctl/schemas/storage-provider-manifest.schema.json
+++ b/isvctl/schemas/storage-provider-manifest.schema.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/NVIDIA/ISV-NCP-Validation-Suite/schemas/storage-provider-manifest.schema.json",
+  "title": "Storage Provider Manifest",
+  "description": "Manifest describing a provider's storage shims. The same YAML is consumed on disk (bare-metal) and inside a ConfigMap (K8s). It feeds StorageProviderApiCheck (shim contract) only; the CSI / NFS / POSIX filesystem checks get their StorageClass names and protocol expectations from their own config (suite/provider YAML or K8S_CSI_* env vars). The schema is informational and is NOT enforced at runtime by isvtest (the loader does targeted validation only). v1alpha2 mirrors the upstream StorageProvider package manifest: package-level namespace / vendor / default_capabilities, a per-provider provider block (name / description / type / protocols / version), and a hierarchical capabilities block using native | default | none. v1alpha1 remains valid as the original shim-only shape.",
+  "type": "object",
+  "required": ["schema_version", "providers"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "description": "Manifest schema version. v1alpha1 is the original shim-only shape; v1alpha2 adds the package-manifest-mirroring identity (namespace / vendor / provider / backend) and capability (native|default|none) model.",
+      "type": "string",
+      "enum": ["v1alpha1", "v1alpha2"]
+    },
+    "namespace": {
+      "description": "Package DNS namespace you control (the package manifest namespace). With each provider's id it forms the registration key <namespace>/<id>. Maps to ProviderProperties.provider_namespace.",
+      "type": "string"
+    },
+    "vendor": {
+      "description": "Package-level vendor metadata (the package manifest vendor), inherited by every provider that does not override it.",
+      "$ref": "#/$defs/Vendor"
+    },
+    "defaultCapabilities": {
+      "description": "Package-wide capability policy (the package manifest defaultCapabilities). A provider's capabilities block overrides these; a `default:` fallback here applies to any capability neither block declares. This is the canonical camelCase key mirroring the upstream package manifest.",
+      "$ref": "#/$defs/Capabilities"
+    },
+    "default_capabilities": {
+      "description": "DEPRECATED snake_case alias of `defaultCapabilities`, accepted for backward compatibility. Prefer `defaultCapabilities`.",
+      "$ref": "#/$defs/Capabilities"
+    },
+    "providers": {
+      "description": "One entry per storage provider exposed by this cluster / IaaS handover.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/Provider" }
+    }
+  },
+  "$defs": {
+    "Provider": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "description": "DNS-label provider id (the package manifest provider map key). With the package namespace it forms the registration key <namespace>/<id>. Maps to ProviderProperties.provider_id. Defaults the subtest tag name when `name` is omitted.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Stable provider tag (used as the per-provider tag in StorageProviderApiCheck subtest IDs). When omitted, the loader derives it from id / provider.id.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "Storage type. Accepts 'file' and 'block'. When omitted, the loader derives it from provider.type then identity.storage_type.",
+          "type": "string",
+          "enum": ["file", "block"]
+        },
+        "tenant_id": {
+          "description": "Default backend tenant for this provider. Round-trips on Volume.tenant_id / TenantQuota.tenant_id. Quote AWS account IDs to keep YAML from stripping leading zeros.",
+          "type": ["string", "integer", "null"]
+        },
+        "namespace": {
+          "description": "Optional per-provider override of the package namespace (registration domain).",
+          "type": "string"
+        },
+        "sdk_version": {
+          "description": "StorageProvider SPI/contract version the shim speaks. Maps to ProviderProperties.sdk_version.",
+          "type": "string"
+        },
+        "provider": { "$ref": "#/$defs/ProviderIdentity" },
+        "backend": { "$ref": "#/$defs/BackendIdentity" },
+        "vendor": { "$ref": "#/$defs/Vendor" },
+        "identity": { "$ref": "#/$defs/Identity" },
+        "shim": { "$ref": "#/$defs/Shim" },
+        "capabilities": { "$ref": "#/$defs/Capabilities" },
+        "capability_qualifiers": { "$ref": "#/$defs/CapabilityQualifiers" },
+        "tiers": {
+          "description": "Optional, informational list of vendor tiers this provider exposes.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "attributes": {
+          "description": "Opaque vendor metadata (region, account email, etc.). Values are string-coerced by the loader. Maps to ProviderProperties.attributes (L3, advisory only).",
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "ProviderIdentity": {
+      "description": "The StorageProvider implementor identity (the package manifest providers.<id>.provider). Maps to the static facet of ProviderProperties + provider_metadata.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "id": { "description": "DNS-label provider id (alternative to the entry-level id).", "type": "string" },
+        "namespace": { "description": "DNS namespace (alternative to entry/package namespace).", "type": "string" },
+        "name": { "description": "Human-facing offering name, e.g. 'AWS FSx Lustre'.", "type": "string" },
+        "description": { "description": "Optional brief, human-facing description.", "type": "string" },
+        "type": {
+          "description": "Storage category. Accepts 'file'/'block' (and the uppercase FILE/BLOCK proto forms).",
+          "type": "string",
+          "enum": ["file", "block", "FILE", "BLOCK"]
+        },
+        "protocols": {
+          "description": "Wire protocols served. file -> 'lustre' | 'nfsv4' | 'nfsv3' | 'smb'; block -> 'nvme' | 'iscsi' | 'nvme-of' | 'fc'. Maps to ProviderProperties.storage_protocols.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "version": {
+          "description": "Implementor semver, e.g. '0.1.0'. Maps to provider_metadata.version.",
+          "type": "string"
+        }
+      }
+    },
+    "BackendIdentity": {
+      "description": "Optional identity of the storage system fronted (distinct from the implementor). Maps to ProviderProperties.backend_metadata; version is an opaque vendor passthrough.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "vendorName": { "description": "Canonical camelCase key.", "type": "string" },
+        "vendorDocs": { "description": "Canonical camelCase key.", "type": "string" },
+        "vendor_name": { "description": "DEPRECATED snake_case alias of vendorName.", "type": "string" },
+        "vendor_docs": { "description": "DEPRECATED snake_case alias of vendorDocs.", "type": "string" },
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "Vendor": {
+      "description": "Vendor metadata (the package manifest vendor). Maps to ProviderProperties.provider_metadata vendor fields. The camelCase keys (vendorName / vendorDocs) mirror the upstream package manifest; the snake_case forms are accepted for backward compatibility.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "vendorName": { "description": "Org display name, e.g. 'NVIDIA', 'VAST Data'. Canonical camelCase key.", "type": "string" },
+        "vendorDocs": { "description": "URL to the vendor's API / product docs. Canonical camelCase key.", "type": "string" },
+        "vendor_name": { "description": "DEPRECATED snake_case alias of vendorName.", "type": "string" },
+        "vendor_docs": { "description": "DEPRECATED snake_case alias of vendorDocs.", "type": "string" }
+      }
+    },
+    "Identity": {
+      "description": "DEPRECATED legacy v1alpha2 identity block, retained as a fallback source. Prefer the top-level namespace/vendor and per-provider provider/backend blocks (package-manifest shape). provider.domain is read as the namespace; storage_protocol (scalar) is read as a single-element protocols list.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "domain": { "type": "string" },
+            "namespace": { "type": "string" },
+            "id": { "type": "string" },
+            "version": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        },
+        "backend": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "storage_type": {
+          "type": "string",
+          "enum": ["file", "block", "FILE", "BLOCK"]
+        },
+        "storage_protocol": { "type": "string" },
+        "storage_protocols": { "type": "array", "items": { "type": "string" } },
+        "sdk_version": { "type": "string" }
+      }
+    },
+    "Shim": {
+      "description": "Management-API shim for this provider. Omit entirely for CSI-only providers; isvtest skips the StorageProviderApiCheck shim subtests for them and runs the CSI-level checks only.",
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": {
+          "description": "Transport. 'python' drives the in-process Python file. 'rest' is a future provider-hosted endpoint - declared in the manifest but skipped by the in-process loader.",
+          "type": "string",
+          "enum": ["python", "rest"]
+        },
+        "module": {
+          "description": "shim.kind=python only. Key inside the shim ConfigMap (K8s) or relative path on disk (bare-metal). Resolved against the manifest's parent directory.",
+          "type": "string",
+          "minLength": 1
+        },
+        "endpoint": {
+          "description": "shim.kind=rest only. URL of the provider-hosted canonical REST API.",
+          "type": "string",
+          "format": "uri"
+        },
+        "configmap": {
+          "description": "K8s only; provider-chosen ConfigMap name holding the shim file (+ optional config.yaml). Informational - the manifest references it by name.",
+          "type": "string"
+        },
+        "credentials_secret": {
+          "description": "K8s only; provider-chosen Secret name mounted into the shim sidecar. Informational.",
+          "type": "string"
+        }
+      }
+    },
+    "Capabilities": {
+      "description": "Hierarchical capability declaration mirroring the package manifest. Each node is a state (native | default | none) or a subgroup of finer nodes. A group state cascades to its descendants; a more-specific node overrides it. native/default mean the surface is serviceable (StorageProviderApiCheck expects it advertised supported); none opts out. The loader lowers this tree to a cap_id -> supported? map (tenant.list, volume.create, quota.directory.set, quota.user.get, ...). An optional `default:` key sets the fallback for any leaf neither this block nor default_capabilities declares.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": { "$ref": "#/$defs/CapabilityState" },
+        "tenantManagement": {
+          "description": "tenant.* surfaces. State or { list, get, getQuota, listQuotas }.",
+          "$ref": "#/$defs/CapabilityNode"
+        },
+        "volumeManagement": {
+          "description": "volume.* surfaces. State or { list, get, create, delete }.",
+          "$ref": "#/$defs/CapabilityNode"
+        },
+        "quotaManagement": {
+          "description": "quota.* surfaces. State or { directory: {...}, user: {...} } where each subgroup is a state or { list, get, set, delete }.",
+          "$ref": "#/$defs/CapabilityNode"
+        }
+      }
+    },
+    "CapabilityState": {
+      "description": "Build-manifest capability state. native = backend-native implementation; default = served by the SDK default (composable getters); none = not offered.",
+      "type": "string",
+      "enum": ["native", "default", "none"]
+    },
+    "CapabilityNode": {
+      "description": "A capability group node: either a single state that cascades to all descendants, or a mapping of finer nodes (each itself a state or subgroup).",
+      "oneOf": [
+        { "$ref": "#/$defs/CapabilityState" },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              { "$ref": "#/$defs/CapabilityState" },
+              { "type": "object", "additionalProperties": { "$ref": "#/$defs/CapabilityState" } }
+            ]
+          }
+        }
+      ]
+    },
+    "CapabilityQualifiers": {
+      "description": "Optional L2 semantic facts (ProviderProperties capability qualifiers), keyed by capability id or dotted group prefix (e.g. 'quota.directory'). Values are string maps such as { idAssignment: backend } / { inodes: 'false' } / { defaultUserSlot: 'true' }. Cross-checked behaviourally by the suite where relevant.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      }
+    }
+  }
+}

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -128,8 +128,9 @@ def _resolve_capability_context(config: RunConfig, capability: str | None, suite
     One rule for every entry path: a plain suite with no ``--capability`` runs
     its core checks. "Unfiltered" corresponds to no real ISV situation - nobody
     runs on vm and kubernetes at once - so a plain suite always has a context.
-    Platform suites declare no ``requires:``, so they are left alone and reject
-    an explicit capability context.
+    Platform suites run under their declared capability and reject an explicit
+    capability context. This still matters when a provider config imports a
+    plain suite whose checks carry ``requires:`` metadata.
     """
     if config.tests and config.tests.capability:
         if capability is not None:
@@ -137,7 +138,7 @@ def _resolve_capability_context(config: RunConfig, capability: str | None, suite
                 f"--capability cannot be used with platform suite {suite_label!r}; "
                 f"it already runs under capability {config.tests.capability!r}."
             )
-        return None
+        return config.tests.capability
 
     if capability is None:
         print_progress(f"No capability selected; running {suite_label!r} core checks.")
@@ -154,9 +155,8 @@ def _reported_capability(config: RunConfig, capability_context: str | None) -> s
 
     Two client-side spellings have to be translated before they leave the process.
     ``CORE_REQUIREMENT_CONTEXT`` is this module's word for "no capability", which
-    the service records as NULL. A platform suite is left with no explicit context
-    because the capability it declares *is* the one it runs under, so report that
-    rather than losing the axis for every platform-suite run.
+    the service records as NULL. A platform suite reports its declaration rather
+    than the resolved filter context so the run cannot be mislabeled.
     """
     if config.tests and config.tests.capability:
         return config.tests.capability
@@ -520,8 +520,8 @@ def run(
 
     # Resolve the requirement context here rather than per entry path, so the
     # same config behaves identically whether it was reached via --suite, -f,
-    # or --label discovery. Platform suites carry no `requires:`, so they keep
-    # the unfiltered context (filtering there would be a no-op anyway).
+    # or --label discovery. Platform suites use their declared capability, which
+    # lets imported plain-suite checks filter on their `requires:` metadata.
     suite_name = suite_label or resolve_suite_name(config_files, CONFIGS_ROOT)
     try:
         capability_context = _resolve_capability_context(

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -395,7 +395,7 @@ class ValidationConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_suite_shape(self) -> "ValidationConfig":
-        """Reject legacy axes and requirements on platform suite checks."""
+        """Reject legacy axes and validate check requirement declarations."""
         if self.model_extra and "module" in self.model_extra:
             raise ValueError("tests.module is no longer supported; plain suites have no axis key")
         # Extras are allowed, so an unmigrated `tests.platform:` would be ignored
@@ -405,18 +405,15 @@ class ValidationConfig(BaseModel):
         if self.capability is not None and self.capability not in DECLARABLE_CAPABILITIES:
             raise ValueError(f"tests.capability must be one of: {', '.join(sorted(DECLARABLE_CAPABILITIES))}")
         entries = parse_validations(self.validations)
-        if self.capability and any("requires" in entry.params_template for entry in entries):
-            raise ValueError("requires is not allowed in platform suites")
         if any("platforms" in entry.params_template for entry in entries):
             raise ValueError("per-check platforms is no longer supported; use requires in plain suites")
-        if not self.capability:
-            for entry in entries:
-                raw_requires = entry.params_template.get("requires")
-                if raw_requires is None:
-                    continue
-                message = requires_error(raw_requires)
-                if message:
-                    raise ValueError(message)
+        for entry in entries:
+            raw_requires = entry.params_template.get("requires")
+            if raw_requires is None:
+                continue
+            message = requires_error(raw_requires)
+            if message:
+                raise ValueError(message)
         return self
 
 

--- a/isvctl/tests/test_capability_step_gating.py
+++ b/isvctl/tests/test_capability_step_gating.py
@@ -47,8 +47,8 @@ def _plain_suite_configs() -> list[tuple[str, Path]]:
         provider = config_dir.parent.name
         for path in sorted(config_dir.glob("*.yaml")):
             config = RunConfig.model_validate(merge_yaml_files([str(path)]))
-            # Platform suites carry no `requires:` on their checks, so nothing
-            # is ever gated inside them.
+            # Platform suites use their declared capability context; this test
+            # exercises only plain suites, whose context varies by parameter.
             if config.tests and config.tests.capability:
                 continue
             configs.append((provider, path))

--- a/isvctl/tests/test_provider_scaffold_cli.py
+++ b/isvctl/tests/test_provider_scaffold_cli.py
@@ -33,6 +33,17 @@ from isvctl.main import app as main_app
 
 runner = CliRunner()
 
+# Storage provider manifests live alongside run-configs in a provider's config/
+# directory but are not RunConfigs (no commands/tests) and carry no path
+# references, so the run-config assertions below skip them.
+_MANIFEST_GLOB = "storage-provider-manifest*.yaml"
+
+
+def _generated_run_configs(config_dir: Path) -> list[Path]:
+    """Return generated run-config YAMLs, excluding storage provider manifests."""
+    manifests = set(config_dir.glob(_MANIFEST_GLOB))
+    return sorted(p for p in config_dir.glob("*.yaml") if p not in manifests)
+
 
 def test_provider_help_renders() -> None:
     """Test provider command help."""
@@ -324,7 +335,7 @@ def test_output_dir_scaffold_imports_load_for_every_config(tmp_path: Path) -> No
     result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
 
     assert result.exit_code == 0
-    config_files = sorted((target / "config").glob("*.yaml"))
+    config_files = _generated_run_configs(target / "config")
     assert config_files, "no generated config files"
     for config_path in config_files:
         config_text = config_path.read_text(encoding="utf-8")
@@ -442,20 +453,23 @@ def test_every_generated_config_relative_path_resolves(tmp_path: Path) -> None:
     result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
     assert result.exit_code == 0
 
-    config_files = sorted((target / "config").glob("*.yaml"))
+    config_files = _generated_run_configs(target / "config")
     assert config_files, "no generated config files"
 
+    # Not every config carries a provider-local ``../`` reference: storage
+    # configs reference only built-in files (the shared step script, the suite),
+    # which the scaffolder rewrites to checkout-root-relative paths. The
+    # invariant is that any ``../`` reference that *is* present resolves, and
+    # that the scaffold as a whole still uses relative references somewhere.
     total_refs = 0
     for yaml_path in config_files:
         content = yaml_path.read_text(encoding="utf-8")
-        refs = RELATIVE_PATH_RE.findall(content)
-        assert refs, f"{yaml_path} has no relative references; template change?"
-        for ref in refs:
+        for ref in RELATIVE_PATH_RE.findall(content):
             resolved = (yaml_path.parent / ref).resolve()
             assert resolved.is_file(), f"{yaml_path} references missing file: {ref} -> {resolved}"
             total_refs += 1
 
-    assert total_refs >= len(config_files), "expected at least one reference per config file"
+    assert total_refs > 0, "expected at least one relative reference across generated configs"
 
 
 def test_meta_file_is_written_and_records_provider_name(tmp_path: Path) -> None:

--- a/isvctl/tests/test_reporting.py
+++ b/isvctl/tests/test_reporting.py
@@ -216,13 +216,9 @@ class TestReportedCapability:
         assert _reported_capability(config, CORE_REQUIREMENT_CONTEXT) is None
 
     def test_platform_suite_reports_its_own_platform(self) -> None:
-        """A platform suite gets no explicit context because its platform is one.
-
-        Passing the resolved context straight through would record NULL for
-        every platform-suite run and lose the axis entirely.
-        """
+        """A platform suite records its declaration as the run capability."""
         config = self._config("vm")
-        assert _reported_capability(config, None) == "vm"
+        assert _reported_capability(config, "vm") == "vm"
 
     def test_plain_suite_reports_explicit_capability(self) -> None:
         """A plain suite reports its explicit capability context."""

--- a/isvctl/tests/test_suite_resolution.py
+++ b/isvctl/tests/test_suite_resolution.py
@@ -64,12 +64,11 @@ def test_capability_uses_catalog_vocabulary(tmp_path: Path) -> None:
         parse_capability("kubernetes,vm", tmp_path)
 
 
-def test_platform_suites_reject_requires_and_unknown_platforms() -> None:
-    """Platform placement is its obligation; it cannot declare check requirements."""
+def test_platform_suites_accept_imported_requires_and_reject_unknown_platforms() -> None:
+    """Provider platform configs may import plain-suite checks carrying requirements."""
     validation = {"sample": {"checks": {"PlainCheck": {"requires": []}}}}
 
-    with pytest.raises(ValidationError, match="requires is not allowed in platform suites"):
-        RunConfig.model_validate({"tests": {"capability": "kubernetes", "validations": validation}})
+    RunConfig.model_validate({"tests": {"capability": "kubernetes", "validations": validation}})
     with pytest.raises(ValidationError, match=r"tests\.capability must be one of"):
         RunConfig.model_validate({"tests": {"capability": "compute", "validations": {}}})
     with pytest.raises(ValidationError, match=r"tests\.capability must be one of"):

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -471,11 +471,11 @@ tests:
         assert "[SKIP] VmCheck" in output
 
 
-def test_platform_suite_keeps_the_unfiltered_context(
+def test_platform_suite_uses_declared_capability_context(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Platform suites declare no requires, so the core default must not apply."""
+    """Platform suites filter imported requirement metadata using their declaration."""
     configs_root = tmp_path / "configs"
     suites = configs_root / "suites"
     suites.mkdir(parents=True)
@@ -489,6 +489,10 @@ tests:
         PlatformCheck:
           test_id: "N/A"
           labels: ["vm"]
+        K8sImportedCheck:
+          test_id: "N/A"
+          labels: ["kubernetes"]
+          requires: [kubernetes]
 """,
         encoding="utf-8",
     )
@@ -501,8 +505,9 @@ tests:
     )
 
     assert result.exit_code == 0, result.output
-    assert "Capability: not filtered" in result.stdout
+    assert "Capability: vm" in result.stdout
     assert "[RUN]  PlatformCheck" in result.stdout
+    assert "[SKIP] K8sImportedCheck: requires kubernetes (context: vm)" in result.stdout
 
 
 def test_platform_suite_rejects_explicit_capability(

--- a/isvtest/pyproject.toml
+++ b/isvtest/pyproject.toml
@@ -50,5 +50,5 @@ ignore = ["E501", "RUF005"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
-testpaths = ["tests", "src/isvtest/tests"]
+testpaths = ["tests", "src/isvtest/tests", "src/isvtest/core/storage_provider/tests"]
 addopts = "-v --junitxml=junit.xml"

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -22,6 +22,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -54,6 +55,64 @@ TERMINAL_WAITING_REASONS: frozenset[str] = frozenset(
 # attempt before kubelet transitions to ImagePullBackOff; callers should fail
 # only if they persist across consecutive polls.
 TRANSIENT_WAITING_REASONS: frozenset[str] = frozenset({"ErrImagePull"})
+
+# Projected ServiceAccount mount. kubectl has no in-cluster config fallback
+# (unlike client-go), so a pod needs a kubeconfig even when token/CA are here.
+_INCLUSTER_SA_DIR = Path("/var/run/secrets/kubernetes.io/serviceaccount")
+
+
+@functools.lru_cache(maxsize=1)
+def ensure_incluster_kubeconfig() -> str | None:
+    """Write a kubeconfig from the pod ServiceAccount when none exists.
+
+    Returns the path, or ``None`` if a kubeconfig already exists or this is not
+    an in-cluster process. Uses ``tokenFile`` / CA paths (not embedded secrets)
+    so kubelet token rotation is picked up on the next kubectl call. Cached
+    once per process; sets ``KUBECONFIG``.
+    """
+    if os.environ.get("KUBECONFIG") or Path(os.path.expanduser("~/.kube/config")).exists():
+        return None
+
+    host = os.environ.get("KUBERNETES_SERVICE_HOST")
+    token_file = _INCLUSTER_SA_DIR / "token"
+    ca_file = _INCLUSTER_SA_DIR / "ca.crt"
+    if not host or not token_file.exists() or not ca_file.exists():
+        return None
+    port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+    if ":" in host:
+        host = f"[{host}]"  # IPv6 URL host needs brackets
+
+    context: dict[str, str] = {"cluster": "in-cluster", "user": "in-cluster"}
+    namespace_file = _INCLUSTER_SA_DIR / "namespace"
+    try:
+        context["namespace"] = namespace_file.read_text().strip()
+    except OSError:
+        pass
+
+    kubeconfig = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [
+            {
+                "name": "in-cluster",
+                "cluster": {"server": f"https://{host}:{port}", "certificate-authority": str(ca_file)},
+            }
+        ],
+        "users": [{"name": "in-cluster", "user": {"tokenFile": str(token_file)}}],
+        "contexts": [{"name": "in-cluster", "context": context}],
+        "current-context": "in-cluster",
+    }
+
+    path = Path(tempfile.gettempdir()) / f"isvtest-incluster-kubeconfig-{os.getuid()}.yaml"
+    try:
+        path.write_text(yaml.safe_dump(kubeconfig, sort_keys=False))
+    except OSError as exc:
+        logger.warning("Could not write in-cluster kubeconfig to %s: %s", path, exc)
+        return None
+
+    os.environ["KUBECONFIG"] = str(path)
+    logger.info("No kubeconfig found; generated one from the pod ServiceAccount at %s", path)
+    return str(path)
 
 
 @functools.lru_cache(maxsize=1)
@@ -164,6 +223,8 @@ def get_kubectl_command() -> list[str]:
         ValueError: If ``KUBECTL`` contains malformed shell syntax
             (e.g. unterminated quotes).
     """
+    ensure_incluster_kubeconfig()
+
     raw = os.environ.get("KUBECTL")
     if raw is not None:
         trimmed = raw.strip()
@@ -489,11 +550,15 @@ def run_kubectl(
 def is_k8s_available() -> bool:
     """Check if Kubernetes cluster is accessible.
 
+    Uses ``kubectl get --raw /version`` (any authenticated caller) rather than
+    ``cluster-info`` (needs ``kube-system`` list rights), so namespace-scoped
+    ServiceAccounts still report the cluster as reachable.
+
     Returns:
         True if kubectl can connect to a cluster, False otherwise.
     """
     try:
-        result = run_kubectl(["cluster-info"], timeout=10)
+        result = run_kubectl(["get", "--raw", "/version"], timeout=10)
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return False

--- a/isvtest/src/isvtest/core/storage.py
+++ b/isvtest/src/isvtest/core/storage.py
@@ -1,0 +1,620 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider manifest parsing + registry for the storage shim.
+
+The manifest mirrors the upstream StorageProvider package manifest in how it
+declares storage-api values and capabilities:
+
+* package-level ``namespace`` + ``vendor`` (the registration domain and vendor
+  metadata) and an optional package-wide ``default_capabilities`` policy;
+* per-provider ``provider: {name, description, type, protocols, version}`` and
+  optional ``backend`` metadata (the static facet of ``ProviderProperties``);
+* a hierarchical ``capabilities:`` block using ``native`` | ``default`` | ``none``
+  with group cascade and most-specific-wins resolution (lowered here into a flat
+  ``cap_id -> expected-supported`` map the contract check asserts against);
+* optional L2 ``capability_qualifiers`` (semantic facts like ``idAssignment``).
+
+The same YAML file is consumed on disk (bare-metal mode) and inside a ConfigMap
+(K8s); there is no K8s API call in the parser itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from isvtest.core.storage_provider import (
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_TENANT_GET,
+    CAP_TENANT_GET_QUOTA,
+    CAP_TENANT_LIST,
+    CAP_TENANT_LIST_QUOTAS,
+    CAP_USER_QUOTA_DELETE,
+    CAP_USER_QUOTA_GET,
+    CAP_USER_QUOTA_LIST,
+    CAP_USER_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_DELETE,
+    CAP_VOLUME_GET,
+    CAP_VOLUME_LIST,
+    CAPABILITY_IDS,
+    ShimLoadError,
+    StorageProvider,
+    VolumeType,
+    build_api_from_path,
+)
+
+_logger = logging.getLogger(__name__)
+
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("v1alpha1", "v1alpha2")
+ShimKind = Literal["python", "rest"]
+
+# Build-manifest capability states. ``native`` and
+# ``default`` both yield a serviceable (``supported``) surface; ``none`` opts out.
+_CAPABILITY_STATES: tuple[str, ...] = ("native", "default", "none")
+
+# camelCase manifest capability tree -> dotted capability-id leaves. Mirrors the
+# package manifest grouping (tenantManagement / volumeManagement / quotaManagement
+# with directory + user quota subgroups). Leaf values are the registry ids the
+# contract check asserts against; nested dicts are groups.
+_CAPABILITY_TREE: dict[str, Any] = {
+    "tenantManagement": {
+        "list": CAP_TENANT_LIST,
+        "get": CAP_TENANT_GET,
+        "getQuota": CAP_TENANT_GET_QUOTA,
+        "listQuotas": CAP_TENANT_LIST_QUOTAS,
+    },
+    "volumeManagement": {
+        "list": CAP_VOLUME_LIST,
+        "get": CAP_VOLUME_GET,
+        "create": CAP_VOLUME_CREATE,
+        "delete": CAP_VOLUME_DELETE,
+    },
+    "quotaManagement": {
+        "directory": {
+            "list": CAP_DIRECTORY_QUOTA_LIST,
+            "get": CAP_DIRECTORY_QUOTA_GET,
+            "set": CAP_DIRECTORY_QUOTA_SET,
+            "delete": CAP_DIRECTORY_QUOTA_DELETE,
+        },
+        "user": {
+            "list": CAP_USER_QUOTA_LIST,
+            "get": CAP_USER_QUOTA_GET,
+            "set": CAP_USER_QUOTA_SET,
+            "delete": CAP_USER_QUOTA_DELETE,
+        },
+    },
+}
+
+
+class ManifestError(Exception):
+    """The provider manifest is missing, malformed, or violates the schema."""
+
+
+@dataclass(frozen=True)
+class Provider:
+    """Manifest entry + the live ``StorageProvider`` client (when a shim is loaded).
+
+    The identity fields mirror the static facet of ``ProviderProperties``:
+    ``provider_namespace`` + ``provider_id`` form the registration key
+    ``<namespace>/<id>``; ``storage_protocols`` is the wire-protocol list;
+    ``provider_version`` is the implementor semver. ``expected_capabilities``
+    is the lowered ``cap_id -> supported?`` map and ``capability_qualifiers`` the
+    optional L2 semantic facts; both are cross-checked against the running shim.
+    """
+
+    name: str
+    volume_type: VolumeType
+    tenant_id: str | None = None
+    provider_namespace: str | None = None
+    provider_id: str | None = None
+    provider_version: str | None = None
+    storage_protocols: tuple[str, ...] = ()
+    vendor: Mapping[str, Any] = field(default_factory=dict)
+    backend: Mapping[str, Any] = field(default_factory=dict)
+    sdk_version: str | None = None
+    expected_capabilities: Mapping[str, bool] = field(default_factory=dict)
+    capability_qualifiers: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
+    attributes: Mapping[str, str] = field(default_factory=dict)
+    # K8s StorageClass names from an instance config's ``storageClasses`` (empty
+    # unless a two-layer instance ``config.yaml`` supplied them).
+    storage_classes: tuple[str, ...] = ()
+    shim_kind: ShimKind | None = None
+    api: StorageProvider | None = None
+
+    @property
+    def has_shim(self) -> bool:
+        return self.api is not None
+
+
+def load_provider_registry(config: Mapping[str, Any]) -> list[Provider]:
+    """Parse the manifest pointed at by ``config["manifest_path"]`` and load each shim.
+
+    Returns one ``Provider`` per manifest entry. Providers with a
+    ``shim.kind: python`` block have ``api`` populated; CSI-only providers and
+    ``shim.kind: rest`` entries return with ``api=None``.
+
+    Returns an empty list when ``manifest_path`` is unset / empty so the check
+    can skip cleanly on providers that haven't onboarded the shim yet. Raises
+    ``ManifestError`` on any other malformed input.
+    """
+    manifest_path = str(config.get("manifest_path") or "").strip()
+    if not manifest_path:
+        return []
+
+    path = Path(manifest_path).expanduser()
+    if not path.is_file():
+        raise ManifestError(f"manifest file not found: {path}")
+
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"failed to parse manifest {path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ManifestError(f"manifest {path} must be a YAML mapping at the top level")
+
+    schema_version = raw.get("schema_version")
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        raise ManifestError(
+            f"manifest {path}: schema_version={schema_version!r} not supported "
+            f"(expected one of {list(SUPPORTED_SCHEMA_VERSIONS)})"
+        )
+
+    providers_raw = raw.get("providers")
+    if not isinstance(providers_raw, list):
+        raise ManifestError(f"manifest {path}: providers must be a list (got {type(providers_raw).__name__})")
+
+    # Package-level identity / policy (mirrors the package manifest). All optional.
+    # The camelCase key (``defaultCapabilities``) mirrors the upstream package
+    # manifest; the snake_case ``default_capabilities`` is accepted as a
+    # backward-compatible fallback for pre-existing manifests.
+    package_namespace = raw.get("namespace")
+    package_vendor = _coerce_mapping(raw.get("vendor"), field_name="vendor")
+    default_caps_key = "defaultCapabilities" if "defaultCapabilities" in raw else "default_capabilities"
+    package_default_caps = _coerce_mapping(raw.get(default_caps_key), field_name=default_caps_key)
+
+    manifest_dir = path.parent
+    providers: list[Provider] = []
+    seen_names: set[str] = set()
+    for index, entry in enumerate(providers_raw):
+        if not isinstance(entry, dict):
+            raise ManifestError(f"manifest {path}: providers[{index}] must be a mapping")
+        provider = _build_provider(
+            entry,
+            index=index,
+            manifest_dir=manifest_dir,
+            package_namespace=package_namespace,
+            package_vendor=package_vendor,
+            package_default_caps=package_default_caps,
+        )
+        if provider.name in seen_names:
+            raise ManifestError(f"manifest {path}: duplicate provider name {provider.name!r}")
+        seen_names.add(provider.name)
+        providers.append(provider)
+
+    # Optional second layer: an nv-storage-style per-instance config that
+    # overrides defaultTenant / storageClasses / capabilities on top of the
+    # manifest (the first layer). Consume-only: the shim still reads its own
+    # backend config/credentials at build_api() time, so backend.config and
+    # secrets are not imported here.
+    instance = _load_instance_config(config, path)
+    if instance is not None:
+        providers = [_apply_instance_config(p, instance) for p in providers]
+    return providers
+
+
+def _build_provider(
+    entry: Mapping[str, Any],
+    *,
+    index: int,
+    manifest_dir: Path,
+    package_namespace: Any,
+    package_vendor: Mapping[str, Any],
+    package_default_caps: Mapping[str, Any],
+) -> Provider:
+    # `provider:` block mirrors the package manifest providers.<id>.provider. The
+    # legacy v1alpha2 `identity` block is still accepted as a fallback source.
+    provider_block = _coerce_mapping(entry.get("provider"), field_name=f"providers[{index}].provider")
+    identity = _coerce_mapping(entry.get("identity"), field_name=f"providers[{index}].identity")
+    identity_provider = _coerce_mapping(identity.get("provider"), field_name=f"providers[{index}].identity.provider")
+
+    # ``name`` falls back to ``id`` then identity.provider.id.
+    name = entry.get("name")
+    if not isinstance(name, str) or not name:
+        candidate = entry.get("id") or identity_provider.get("id")
+        name = candidate if isinstance(candidate, str) and candidate else None
+    if not name:
+        raise ManifestError(
+            f"providers[{index}]: name (or id / identity.provider.id) is required and must be a non-empty string"
+        )
+
+    # ``type`` falls back to provider.type then identity.storage_type; accept the
+    # uppercase FILE/BLOCK proto forms.
+    raw_type = entry.get("type")
+    if raw_type is None:
+        raw_type = provider_block.get("type")
+    if raw_type is None:
+        raw_type = identity.get("storage_type")
+    if isinstance(raw_type, str):
+        raw_type = raw_type.lower()
+    if raw_type not in ("file", "block"):
+        raise ManifestError(
+            f"providers[{index}] ({name!r}): type must be 'file' or 'block' "
+            f"(set providers[].type, provider.type, or identity.storage_type; got {raw_type!r})"
+        )
+
+    tenant_id_raw = entry.get("tenant_id")
+    if tenant_id_raw is not None and not isinstance(tenant_id_raw, str | int):
+        raise ManifestError(f"providers[{index}] ({name!r}): tenant_id must be a string or int")
+    tenant_id = str(tenant_id_raw) if tenant_id_raw is not None else None
+
+    # Identity scalars (mirror ProviderProperties). namespace / id / version /
+    # protocols are sourced from the provider block first, then identity, then
+    # the package namespace.
+    provider_namespace = (
+        entry.get("namespace")
+        or provider_block.get("namespace")
+        or identity_provider.get("namespace")
+        or identity_provider.get("domain")  # legacy field name
+        or package_namespace
+    )
+    provider_id = entry.get("id") or provider_block.get("id") or identity_provider.get("id") or name
+    provider_version = provider_block.get("version") or identity_provider.get("version")
+    storage_protocols = _coerce_protocols(
+        entry.get("protocols")
+        or provider_block.get("protocols")
+        or identity.get("storage_protocols")
+        or identity.get("storage_protocol"),
+        field_name=f"providers[{index}] ({name!r}).protocols",
+    )
+    sdk_version = entry.get("sdk_version") or identity.get("sdk_version")
+
+    vendor = _coerce_mapping(entry.get("vendor"), field_name=f"providers[{index}] ({name!r}).vendor") or dict(
+        package_vendor
+    )
+    # Fold the human-facing provider name / description into the vendor metadata
+    # bag so consumers see the full VersionMetadata-shaped values.
+    for key in ("name", "description"):
+        if provider_block.get(key) is not None and key not in vendor:
+            vendor[key] = provider_block[key]
+    backend = _coerce_mapping(
+        entry.get("backend") or identity.get("backend"),
+        field_name=f"providers[{index}] ({name!r}).backend",
+    )
+
+    expected_capabilities = _resolve_capabilities(
+        _coerce_mapping(
+            entry.get("capabilities"),
+            field_name=f"providers[{index}] ({name!r}).capabilities",
+        ),
+        package_default_caps,
+        field_name=f"providers[{index}] ({name!r}).capabilities",
+    )
+    capability_qualifiers = _coerce_qualifiers(
+        entry.get("capability_qualifiers"),
+        field_name=f"providers[{index}] ({name!r}).capability_qualifiers",
+    )
+    attributes = _coerce_string_mapping(entry.get("attributes"), field_name=f"providers[{index}] ({name!r}).attributes")
+
+    shim_kind, api = _load_shim(entry.get("shim"), name=name, manifest_dir=manifest_dir, attributes=attributes)
+
+    return Provider(
+        name=name,
+        volume_type=raw_type,
+        tenant_id=tenant_id,
+        provider_namespace=str(provider_namespace) if provider_namespace else None,
+        provider_id=str(provider_id) if provider_id else None,
+        provider_version=str(provider_version) if provider_version is not None else None,
+        storage_protocols=storage_protocols,
+        vendor=vendor,
+        backend=backend,
+        sdk_version=str(sdk_version) if sdk_version else None,
+        expected_capabilities=expected_capabilities,
+        capability_qualifiers=capability_qualifiers,
+        attributes=attributes,
+        shim_kind=shim_kind,
+        api=api,
+    )
+
+
+def _load_shim(
+    shim_entry: Any,
+    *,
+    name: str,
+    manifest_dir: Path,
+    attributes: Mapping[str, str],
+) -> tuple[ShimKind | None, StorageProvider | None]:
+    if shim_entry is None:
+        return None, None
+    if not isinstance(shim_entry, dict):
+        raise ManifestError(f"provider {name!r}: shim must be a mapping")
+
+    kind = shim_entry.get("kind")
+    if kind not in ("python", "rest"):
+        raise ManifestError(f"provider {name!r}: shim.kind must be 'python' or 'rest' (got {kind!r})")
+
+    if kind == "rest":
+        _logger.info(
+            "provider %r declares shim.kind=rest; Phase 1a in-process Python loader skips REST endpoints",
+            name,
+        )
+        return "rest", None
+
+    module = shim_entry.get("module")
+    if not isinstance(module, str) or not module:
+        raise ManifestError(f"provider {name!r}: shim.module is required for shim.kind=python")
+    shim_path = (manifest_dir / module).resolve()
+    try:
+        api = build_api_from_path(shim_path, attributes=attributes)
+    except ShimLoadError as exc:
+        raise ManifestError(f"provider {name!r}: failed to load shim {shim_path}: {exc}") from exc
+    return "python", api
+
+
+def _coerce_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ManifestError(f"{field_name}: must be a mapping")
+    return dict(value)
+
+
+def _coerce_protocols(value: Any, *, field_name: str) -> tuple[str, ...]:
+    """Coerce the wire-protocol declaration to a tuple of strings.
+
+    Accepts a list (the new ``protocols`` shape) or a single scalar (the legacy
+    ``storage_protocol`` shape).
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list):
+        return tuple(str(v) for v in value)
+    raise ManifestError(f"{field_name}: must be a string or list of strings")
+
+
+def _resolve_capabilities(
+    provider_caps: Mapping[str, Any],
+    package_caps: Mapping[str, Any],
+    *,
+    field_name: str,
+) -> dict[str, bool]:
+    """Lower the hierarchical capabilities block to ``cap_id -> supported?``.
+
+    Mirrors the package manifest resolution: most-specific wins, the provider block
+    overrides the package ``default_capabilities``, and an absent capability with
+    no ``default:`` fallback resolves to ``none`` (not supported). ``native`` /
+    ``default`` map to ``True`` (serviceable); ``none`` maps to ``False``.
+
+    Returns only the capabilities the manifest actually declares (explicitly or
+    via a ``default:`` fallback) so the contract check leaves undeclared
+    surfaces unchecked.
+    """
+    _validate_capability_block(provider_caps, field_name=field_name)
+    _validate_capability_block(package_caps, field_name="default_capabilities")
+    has_default = "default" in provider_caps or "default" in package_caps
+
+    resolved: dict[str, bool] = {}
+    for cap_id, path in _capability_leaves():
+        state = _lookup_capability(provider_caps, path)
+        if state is None:
+            state = _lookup_capability(package_caps, path)
+        explicit = state is not None
+        if state is None:
+            state = _default_state(provider_caps, package_caps)
+        if state is None:
+            continue  # undeclared and no default -> leave unchecked
+        # Only record a capability the manifest meaningfully declares: an
+        # explicit leaf/group state, or a `default:` fallback.
+        if not explicit and not has_default:
+            continue
+        resolved[cap_id] = state != "none"
+    return resolved
+
+
+def _capability_leaves(tree: Any = None, prefix: tuple[str, ...] = ()) -> list[tuple[str, tuple[str, ...]]]:
+    """Flatten ``_CAPABILITY_TREE`` to ``(cap_id, manifest_path)`` leaf pairs."""
+    if tree is None:
+        tree = _CAPABILITY_TREE
+    leaves: list[tuple[str, tuple[str, ...]]] = []
+    for key, value in tree.items():
+        if isinstance(value, dict):
+            leaves.extend(_capability_leaves(value, (*prefix, key)))
+        else:
+            leaves.append((value, (*prefix, key)))
+    return leaves
+
+
+def _lookup_capability(caps: Mapping[str, Any], path: tuple[str, ...]) -> str | None:
+    """Return the deepest scalar state along ``path`` in ``caps`` (most specific)."""
+    node: Any = caps
+    found: str | None = None
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            break
+        node = node[key]
+        if isinstance(node, str):
+            found = node
+    return found
+
+
+def _default_state(provider_caps: Mapping[str, Any], package_caps: Mapping[str, Any]) -> str | None:
+    for caps in (provider_caps, package_caps):
+        value = caps.get("default")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _validate_capability_block(caps: Mapping[str, Any], *, field_name: str, _path: str = "") -> None:
+    """Reject capability values that are not native/default/none (or a subgroup)."""
+    for key, value in caps.items():
+        where = f"{field_name}.{_path}{key}" if _path else f"{field_name}.{key}"
+        if isinstance(value, dict):
+            _validate_capability_block(value, field_name=field_name, _path=f"{_path}{key}.")
+        elif value not in _CAPABILITY_STATES:
+            raise ManifestError(f"{where}: capability state must be one of {list(_CAPABILITY_STATES)} (got {value!r})")
+
+
+def _coerce_qualifiers(value: Any, *, field_name: str) -> dict[str, dict[str, str]]:
+    """Coerce the optional capability_qualifiers block (id/group -> {key: value})."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ManifestError(f"{field_name}: must be a mapping of capability id/group to qualifiers")
+    out: dict[str, dict[str, str]] = {}
+    for cap_key, quals in value.items():
+        if not isinstance(quals, dict):
+            raise ManifestError(f"{field_name}.{cap_key}: must be a mapping of qualifier keys to values")
+        out[str(cap_key)] = {str(k): str(v) for k, v in quals.items()}
+    return out
+
+
+def _coerce_string_mapping(value: Any, *, field_name: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ManifestError(f"{field_name}: must be a mapping of string values")
+    return {str(k): str(v) for k, v in value.items()}
+
+
+# --- optional second layer: per-instance config (nv-storage two-layer model) --
+
+
+def _load_instance_config(config: Mapping[str, Any], manifest_path: Path) -> Mapping[str, Any] | None:
+    """Load the optional per-instance ``config.yaml`` ``instance:`` section.
+
+    Sourced from the ``instance_config_path`` config key, else auto-discovered as
+    a sibling ``config.yaml`` next to the manifest. Returns the ``instance``
+    mapping, or ``None`` when no instance config is present. Raises
+    ``ManifestError`` on a malformed file.
+    """
+    explicit = str(config.get("instance_config_path") or "").strip()
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.is_file():
+            raise ManifestError(f"instance config file not found: {path}")
+    else:
+        path = manifest_path.parent / "config.yaml"
+        if not path.is_file():
+            return None
+
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"failed to parse instance config {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ManifestError(f"instance config {path} must be a YAML mapping at the top level")
+    return _coerce_mapping(raw.get("instance"), field_name="instance")
+
+
+def _apply_instance_config(provider: Provider, instance: Mapping[str, Any]) -> Provider:
+    """Overlay an instance config's provider overrides onto a manifest ``Provider``.
+
+    Applies ``defaultTenant`` (the tenant cross-check target), ``storageClasses``,
+    and ``capabilities`` (id/group -> enabled/disabled) on top of the manifest's
+    resolved ``expected_capabilities``.
+    """
+    inst_provider = _coerce_mapping(instance.get("provider"), field_name="instance.provider")
+
+    default_tenant = inst_provider.get("defaultTenant")
+    if default_tenant is not None and not isinstance(default_tenant, str):
+        raise ManifestError("instance.provider.defaultTenant: must be a string")
+
+    storage_classes = _coerce_protocols(
+        inst_provider.get("storageClasses"), field_name="instance.provider.storageClasses"
+    )
+
+    overrides = _parse_instance_capability_overrides(
+        _coerce_mapping(inst_provider.get("capabilities"), field_name="instance.provider.capabilities")
+    )
+    expected = dict(provider.expected_capabilities)
+    for cap_id in CAPABILITY_IDS:
+        override = _resolve_capability_override(overrides, cap_id)
+        if override is not None:
+            expected[cap_id] = override
+
+    return replace(
+        provider,
+        tenant_id=default_tenant if default_tenant else provider.tenant_id,
+        storage_classes=storage_classes or provider.storage_classes,
+        expected_capabilities=expected,
+    )
+
+
+def _parse_instance_capability_overrides(raw: Mapping[str, Any]) -> dict[str, bool]:
+    """Map an instance ``capabilities:`` block (id|group -> enabled/disabled).
+
+    Keys are capability ids or dotted group prefixes (e.g. ``"volume.create"``,
+    ``"quota"``); values are ``enabled`` / ``disabled`` (or a YAML bool). An
+    unknown key or non-bool value is a ``ManifestError`` (catches typos).
+    """
+    overrides: dict[str, bool] = {}
+    for key, value in raw.items():
+        key = str(key)
+        if key not in _CAPABILITY_OVERRIDE_KEYS:
+            raise ManifestError(f"instance.provider.capabilities: unknown capability key {key!r}")
+        overrides[key] = _coerce_override_value(key, value)
+    return overrides
+
+
+def _coerce_override_value(key: str, value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        norm = value.strip().lower()
+        if norm == "enabled":
+            return True
+        if norm == "disabled":
+            return False
+    raise ManifestError(f"instance.provider.capabilities.{key}: must be 'enabled' or 'disabled' (got {value!r})")
+
+
+def _resolve_capability_override(overrides: Mapping[str, bool], cap_id: str) -> bool | None:
+    """Most-specific override for ``cap_id`` (exact id, then group prefixes)."""
+    key = cap_id
+    while True:
+        if key in overrides:
+            return overrides[key]
+        dot = key.rfind(".")
+        if dot < 0:
+            return None
+        key = key[:dot]
+
+
+def _capability_override_key_set() -> frozenset[str]:
+    """Every accepted override key: each capability id and its group prefixes."""
+    keys: set[str] = set()
+    for cap_id in CAPABILITY_IDS:
+        key = cap_id
+        keys.add(key)
+        while (dot := key.rfind(".")) >= 0:
+            key = key[:dot]
+            keys.add(key)
+    return frozenset(keys)
+
+
+_CAPABILITY_OVERRIDE_KEYS = _capability_override_key_set()

--- a/isvtest/src/isvtest/core/storage.py
+++ b/isvtest/src/isvtest/core/storage.py
@@ -69,6 +69,7 @@ _logger = logging.getLogger(__name__)
 
 SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("v1alpha1", "v1alpha2")
 ShimKind = Literal["python", "rest"]
+CapabilityDeclaration = Literal["native", "default", "none"]
 
 # Build-manifest capability states. ``native`` and
 # ``default`` both yield a serviceable (``supported``) surface; ``none`` opts out.
@@ -135,6 +136,7 @@ class Provider:
     backend: Mapping[str, Any] = field(default_factory=dict)
     sdk_version: str | None = None
     expected_capabilities: Mapping[str, bool] = field(default_factory=dict)
+    capability_states: Mapping[str, CapabilityDeclaration] = field(default_factory=dict)
     capability_qualifiers: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
     attributes: Mapping[str, str] = field(default_factory=dict)
     # K8s StorageClass names from an instance config's ``storageClasses`` (empty
@@ -304,7 +306,7 @@ def _build_provider(
         field_name=f"providers[{index}] ({name!r}).backend",
     )
 
-    expected_capabilities = _resolve_capabilities(
+    capability_states = _resolve_capability_states(
         _coerce_mapping(
             entry.get("capabilities"),
             field_name=f"providers[{index}] ({name!r}).capabilities",
@@ -312,6 +314,7 @@ def _build_provider(
         package_default_caps,
         field_name=f"providers[{index}] ({name!r}).capabilities",
     )
+    expected_capabilities = {cap_id: state != "none" for cap_id, state in capability_states.items()}
     capability_qualifiers = _coerce_qualifiers(
         entry.get("capability_qualifiers"),
         field_name=f"providers[{index}] ({name!r}).capability_qualifiers",
@@ -332,6 +335,7 @@ def _build_provider(
         backend=backend,
         sdk_version=str(sdk_version) if sdk_version else None,
         expected_capabilities=expected_capabilities,
+        capability_states=capability_states,
         capability_qualifiers=capability_qualifiers,
         attributes=attributes,
         shim_kind=shim_kind,
@@ -402,22 +406,33 @@ def _resolve_capabilities(
     *,
     field_name: str,
 ) -> dict[str, bool]:
-    """Lower the hierarchical capabilities block to ``cap_id -> supported?``.
+    """Lower the hierarchical capabilities block to ``cap_id -> supported?``."""
+    return {
+        cap_id: state != "none"
+        for cap_id, state in _resolve_capability_states(provider_caps, package_caps, field_name=field_name).items()
+    }
+
+
+def _resolve_capability_states(
+    provider_caps: Mapping[str, Any],
+    package_caps: Mapping[str, Any],
+    *,
+    field_name: str,
+) -> dict[str, CapabilityDeclaration]:
+    """Lower the hierarchical capabilities block to ``cap_id -> native/default/none``.
 
     Mirrors the package manifest resolution: most-specific wins, the provider block
     overrides the package ``default_capabilities``, and an absent capability with
-    no ``default:`` fallback resolves to ``none`` (not supported). ``native`` /
-    ``default`` map to ``True`` (serviceable); ``none`` maps to ``False``.
-
-    Returns only the capabilities the manifest actually declares (explicitly or
-    via a ``default:`` fallback) so the contract check leaves undeclared
-    surfaces unchecked.
+    no ``default:`` fallback is left undeclared. The boolean
+    ``expected_capabilities`` view is derived from this state map for legacy
+    contract checks, while validations that need to distinguish backend-native
+    behavior can inspect this richer declaration.
     """
     _validate_capability_block(provider_caps, field_name=field_name)
     _validate_capability_block(package_caps, field_name="default_capabilities")
     has_default = "default" in provider_caps or "default" in package_caps
 
-    resolved: dict[str, bool] = {}
+    resolved: dict[str, CapabilityDeclaration] = {}
     for cap_id, path in _capability_leaves():
         state = _lookup_capability(provider_caps, path)
         if state is None:
@@ -431,7 +446,7 @@ def _resolve_capabilities(
         # explicit leaf/group state, or a `default:` fallback.
         if not explicit and not has_default:
             continue
-        resolved[cap_id] = state != "none"
+        resolved[cap_id] = state
     return resolved
 
 
@@ -552,16 +567,22 @@ def _apply_instance_config(provider: Provider, instance: Mapping[str, Any]) -> P
         _coerce_mapping(inst_provider.get("capabilities"), field_name="instance.provider.capabilities")
     )
     expected = dict(provider.expected_capabilities)
+    states = dict(provider.capability_states)
     for cap_id in CAPABILITY_IDS:
         override = _resolve_capability_override(overrides, cap_id)
         if override is not None:
             expected[cap_id] = override
+            if override:
+                states[cap_id] = states.get(cap_id, "native") if states.get(cap_id) != "none" else "native"
+            else:
+                states[cap_id] = "none"
 
     return replace(
         provider,
         tenant_id=default_tenant if default_tenant else provider.tenant_id,
         storage_classes=storage_classes or provider.storage_classes,
         expected_capabilities=expected,
+        capability_states=states,
     )
 
 

--- a/isvtest/src/isvtest/core/storage_provider/README.md
+++ b/isvtest/src/isvtest/core/storage_provider/README.md
@@ -1,0 +1,93 @@
+# storage_provider
+
+Python contract between [`isvtest`](../../../../) acceptance tests and
+provider-implemented storage backends. Each provider authors one Python file per
+storage backend that subclasses `Implementation`; `isvtest` imports the file,
+calls `build_api()`, and drives the storage acceptance tests against the
+provider's real backend — no Kubernetes, sidecar, or REST endpoint required.
+
+|                              |                                                                                                       |
+| ---                          | ---                                                                                                   |
+| **Source**                   | [`api.py`](./api.py) (contract) · [`mock.py`](./mock.py) (reference impl) · [`loader.py`](./loader.py) (shim discovery) |
+| **Contract reference**       | Per-method input/output, error conditions, and capability/qualifier semantics live as docstrings in [`api.py`](./api.py) |
+| **Manifest schema**          | [`isvctl/schemas/storage-provider-manifest.schema.json`](../../../../../isvctl/schemas/storage-provider-manifest.schema.json) |                     |
+
+## Quickstart
+
+Providers author one Python file per backend:
+
+```python
+# api.py — the file you ship per backend
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    Implementation,
+    ProviderProperties,
+    StorageProvider,
+    VersionMetadata,
+    new_implementation,
+)
+
+# Static identity declaration. Which optional surfaces are *supported* is
+# detected from the methods you override below (and cross-checked against the
+# provider manifest, the contract).
+_CORE = ProviderProperties(
+    provider_namespace="my-backend.example.com",
+    provider_id="my-backend",
+    provider_metadata=VersionMetadata(
+        vendor_name="<your org>",
+        name="My Backend",
+        version="1.0.0",
+    ),
+    sdk_version=API_VERSION,
+    storage_type="file",
+    storage_protocols=["nfsv4"],
+)
+
+
+class MyStorageApi(Implementation):
+    def health_check(self) -> None: ...
+    def get_tenant_quota(self, req): ...
+    def list_volumes(self, req): ...
+    # ... see api.py for the full surface (every method takes a request object).
+    # To opt OUT of a surface, simply do not define its method.
+
+
+def build_api() -> StorageProvider:
+    return new_implementation(core=_CORE, impl=MyStorageApi(), default_tenant="...")
+```
+
+`isvtest` discovers `MyStorageApi` via a provider manifest YAML (the blank
+template and a fully-populated example ship under
+`isvctl/configs/providers/my-isv/config/`; the field-by-field reference is
+[`storage-provider-manifest.schema.json`](../../../../../isvctl/schemas/storage-provider-manifest.schema.json))
+and drives the acceptance tests against it.
+
+## What ships
+
+| Path                                | What it does                                                                                                                       |
+| ---                                 | ---                                                                                                                                |
+| [`api.py`](./api.py)                | `StorageProvider` ABC + `Implementation` / `new_implementation()`, frozen-dataclass DTOs (`Volume`, `Tenant`, `DirectoryQuota`, `UserQuota`, `ProviderProperties`, …), error taxonomy |
+| [`mock.py`](./mock.py)              | In-memory `MockStorageApi` reference implementation used by the unit tests                                                         |
+| [`loader.py`](./loader.py)          | Loads a provider-authored shim module from disk (bare-metal) or ConfigMap (managed K8s)                                            |
+
+## Tests
+
+Unit tests for the contract package itself live alongside the source in
+[`tests/`](./tests/) — pure tests of the ABC surface, the in-memory mock,
+and the loader. Providers are not required to run them, but may consult them
+as living documentation of the contract.
+
+```bash
+uv run pytest isvtest/src/isvtest/core/storage_provider/tests/test_api.py
+uv run pytest isvtest/src/isvtest/core/storage_provider/tests/test_mock.py
+uv run pytest isvtest/src/isvtest/core/storage_provider/tests/test_loader.py
+```
+
+Tests for the isvtest-internal manifest registry (`isvtest.core.storage`)
+and the validation that drives the acceptance tests
+(`StorageProviderApiCheck`) live with the rest of the framework tests
+under `isvtest/tests/`.
+
+## License
+
+Apache-2.0. See the repository [`LICENSE`](../../../../../LICENSE) file.

--- a/isvtest/src/isvtest/core/storage_provider/README.md
+++ b/isvtest/src/isvtest/core/storage_provider/README.md
@@ -10,7 +10,7 @@ provider's real backend — no Kubernetes, sidecar, or REST endpoint required.
 | ---                          | ---                                                                                                   |
 | **Source**                   | [`api.py`](./api.py) (contract) · [`mock.py`](./mock.py) (reference impl) · [`loader.py`](./loader.py) (shim discovery) |
 | **Contract reference**       | Per-method input/output, error conditions, and capability/qualifier semantics live as docstrings in [`api.py`](./api.py) |
-| **Manifest schema**          | [`isvctl/schemas/storage-provider-manifest.schema.json`](../../../../../isvctl/schemas/storage-provider-manifest.schema.json) |                     |
+| **Manifest schema**          | [`isvctl/schemas/storage-provider-manifest.schema.json`](../../../../../isvctl/schemas/storage-provider-manifest.schema.json) |
 
 ## Quickstart
 

--- a/isvtest/src/isvtest/core/storage_provider/__init__.py
+++ b/isvtest/src/isvtest/core/storage_provider/__init__.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Storage provider shim.
+
+Python ABC + error taxonomy + value types that providers subclass once per
+backend storage provider. The surface covers backend identity and capability
+discovery (``properties``), authenticated health checks, tenant + volume
+enumeration, and directory- and user-quota CRUD.
+
+A shim subclasses ``Implementation``, overriding only the surfaces it backs; the
+SDK *detects* which surfaces are supported and gates the rest. Support is also
+declared in the provider manifest (the contract) and verified at runtime: the
+validation suite probes every declared-``supported`` surface and fails if the
+shim raises ``NotSupportedError`` / ``NotImplementedError``. Detection and the
+manifest must agree. ``properties().capabilities()`` reports the composed states
++ L2 qualifiers per surface.
+
+For orientation, quickstart, and source links see ``README.md``
+co-located with this package. The per-method contract (inputs, outputs,
+error conditions, capability/qualifier semantics) lives as docstrings on
+the classes and methods in ``api.py``; the provider manifest schema is
+``isvctl/schemas/storage-provider-manifest.schema.json``.
+
+One authoring model (mirrors nv-storage): override only the served surfaces on an
+``Implementation`` and compose it with ``new_implementation()``::
+
+    # api.py - the file the provider ships per backend
+    from isvtest.core.storage_provider import (
+        Implementation, ProviderProperties, StorageProvider, new_implementation,
+    )
+
+    class MyStorageApi(Implementation):
+        def health_check(self) -> None: ...
+        def get_tenant_quota(self, req): ...
+        def list_volumes(self, req): ...
+
+    def build_api() -> StorageProvider:  # the one entry point the loader calls
+        return new_implementation(core=_CORE, impl=MyStorageApi(), default_tenant="...")
+"""
+
+from isvtest.core.storage_provider.api import (
+    API_VERSION,
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_GROUP_DIRECTORY_QUOTA,
+    CAP_GROUP_QUOTA,
+    CAP_GROUP_TENANT,
+    CAP_GROUP_USER_QUOTA,
+    CAP_GROUP_VOLUME,
+    CAP_TENANT_GET,
+    CAP_TENANT_GET_QUOTA,
+    CAP_TENANT_LIST,
+    CAP_TENANT_LIST_QUOTAS,
+    CAP_USER_QUOTA_DELETE,
+    CAP_USER_QUOTA_GET,
+    CAP_USER_QUOTA_LIST,
+    CAP_USER_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_DELETE,
+    CAP_VOLUME_GET,
+    CAP_VOLUME_LIST,
+    CAPABILITY_IDS,
+    DEFAULT_INSTANCE_ID,
+    QUAL_ACCOUNTING,
+    QUAL_BYTE_GRANULARITY,
+    QUAL_DEFAULT_USER_SLOT,
+    QUAL_ID_ASSIGNMENT,
+    QUAL_INODES,
+    QUAL_MULTI_PATH_BINDING,
+    QUAL_MULTI_TENANT,
+    QUAL_TIERED,
+    AuthenticationError,
+    Capability,
+    CapabilityState,
+    ConflictError,
+    CreateVolumeRequest,
+    CsiSpec,
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DeleteVolumeRequest,
+    DirectoryQuota,
+    GetDirectoryQuotaRequest,
+    GetTenantQuotaRequest,
+    GetTenantRequest,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    IDAssignment,
+    Implementation,
+    ListDirectoryQuotasRequest,
+    ListDirectoryQuotasResponse,
+    ListTenantQuotasRequest,
+    ListTenantQuotasResponse,
+    ListTenantsRequest,
+    ListTenantsResponse,
+    ListUserQuotasRequest,
+    ListUserQuotasResponse,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    MountSpec,
+    NotFoundError,
+    NotSupportedError,
+    ProviderProperties,
+    QuotaAccounting,
+    QuotaExceededError,
+    QuotaLimits,
+    QuotaUsage,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    StorageApiError,
+    StorageProvider,
+    TagFilter,
+    Tenant,
+    TenantQuota,
+    UnavailableError,
+    UserQuota,
+    ValidationError,
+    VersionMetadata,
+    Volume,
+    VolumeState,
+    VolumeType,
+    instance_or_default,
+    new_implementation,
+    with_default_tenant,
+)
+from isvtest.core.storage_provider.capabilities import (
+    Capabilities,
+    ImplementationCapabilities,
+)
+from isvtest.core.storage_provider.loader import (
+    ShimLoadError,
+    build_api_from_path,
+)
+from isvtest.core.storage_provider.mock import MockStorageApi
+
+__all__ = [
+    "API_VERSION",
+    "CAPABILITY_IDS",
+    "CAP_DIRECTORY_QUOTA_DELETE",
+    "CAP_DIRECTORY_QUOTA_GET",
+    "CAP_DIRECTORY_QUOTA_LIST",
+    "CAP_DIRECTORY_QUOTA_SET",
+    "CAP_GROUP_DIRECTORY_QUOTA",
+    "CAP_GROUP_QUOTA",
+    "CAP_GROUP_TENANT",
+    "CAP_GROUP_USER_QUOTA",
+    "CAP_GROUP_VOLUME",
+    "CAP_TENANT_GET",
+    "CAP_TENANT_GET_QUOTA",
+    "CAP_TENANT_LIST",
+    "CAP_TENANT_LIST_QUOTAS",
+    "CAP_USER_QUOTA_DELETE",
+    "CAP_USER_QUOTA_GET",
+    "CAP_USER_QUOTA_LIST",
+    "CAP_USER_QUOTA_SET",
+    "CAP_VOLUME_CREATE",
+    "CAP_VOLUME_DELETE",
+    "CAP_VOLUME_GET",
+    "CAP_VOLUME_LIST",
+    "DEFAULT_INSTANCE_ID",
+    "QUAL_ACCOUNTING",
+    "QUAL_BYTE_GRANULARITY",
+    "QUAL_DEFAULT_USER_SLOT",
+    "QUAL_ID_ASSIGNMENT",
+    "QUAL_INODES",
+    "QUAL_MULTI_PATH_BINDING",
+    "QUAL_MULTI_TENANT",
+    "QUAL_TIERED",
+    "AuthenticationError",
+    "Capabilities",
+    "Capability",
+    "CapabilityState",
+    "ConflictError",
+    "CreateVolumeRequest",
+    "CsiSpec",
+    "DeleteDirectoryQuotaRequest",
+    "DeleteUserQuotaRequest",
+    "DeleteVolumeRequest",
+    "DirectoryQuota",
+    "GetDirectoryQuotaRequest",
+    "GetTenantQuotaRequest",
+    "GetTenantRequest",
+    "GetUserQuotaRequest",
+    "GetVolumeRequest",
+    "IDAssignment",
+    "Implementation",
+    "ImplementationCapabilities",
+    "ListDirectoryQuotasRequest",
+    "ListDirectoryQuotasResponse",
+    "ListTenantQuotasRequest",
+    "ListTenantQuotasResponse",
+    "ListTenantsRequest",
+    "ListTenantsResponse",
+    "ListUserQuotasRequest",
+    "ListUserQuotasResponse",
+    "ListVolumesRequest",
+    "ListVolumesResponse",
+    "MockStorageApi",
+    "MountSpec",
+    "NotFoundError",
+    "NotSupportedError",
+    "ProviderProperties",
+    "QuotaAccounting",
+    "QuotaExceededError",
+    "QuotaLimits",
+    "QuotaUsage",
+    "SetDirectoryQuotaRequest",
+    "SetUserQuotaRequest",
+    "ShimLoadError",
+    "StorageApiError",
+    "StorageProvider",
+    "TagFilter",
+    "Tenant",
+    "TenantQuota",
+    "UnavailableError",
+    "UserQuota",
+    "ValidationError",
+    "VersionMetadata",
+    "Volume",
+    "VolumeState",
+    "VolumeType",
+    "build_api_from_path",
+    "instance_or_default",
+    "new_implementation",
+    "with_default_tenant",
+]

--- a/isvtest/src/isvtest/core/storage_provider/api.py
+++ b/isvtest/src/isvtest/core/storage_provider/api.py
@@ -1,0 +1,1362 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``StorageProvider`` ABC, value types, and error taxonomy.
+
+Mirrors nv-storage's ``spi/storageprovider`` contract. Defines the abstract
+``StorageProvider`` interface for provider-implemented storage shims: every
+tenant/volume/quota method takes a request object and returns either the domain
+type, a response object, or ``None``.
+
+Providers author a shim with a single model: subclass ``Implementation``,
+override only the surfaces the backend serves, and hand it to
+``new_implementation()``. The SDK *detects* which surfaces are supported from
+the overridden method set, folds in config overrides and the
+``capability_qualifiers`` hook, advertises the merged states on
+``properties().capabilities()``, and gates the rest.
+
+``properties().capabilities()`` returns the typed, navigable capability tree
+(state + L2 qualifiers per surface); consumers read it there rather than
+touching the SDK-internal ``_capability_list``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from typing import Literal
+
+VolumeType = Literal["block", "file"]
+VolumeState = Literal["creating", "available", "failed", "deleting"]
+
+#: Merged "effective" state of one capability on a provider endpoint - the value
+#: a caller routes on. Only ``"supported"`` is routable; the others are distinct,
+#: actionable diagnostics. ``None`` is unspecified and treated as not-supported
+#: (fail safe). Mirrors nv-storage's ``CapabilityState``.
+CapabilityState = Literal["supported", "disabled", "unavailable", "unimplemented"]
+
+API_VERSION = "v1alpha1"
+
+#: The ``instance_id`` an impl gets when it declares none - the third
+#: registration-key / UDS-path segment for a single-instance provider.
+DEFAULT_INSTANCE_ID = "default"
+
+
+def instance_or_default(instance_id: str) -> str:
+    """Resolve an empty ``instance_id`` to ``DEFAULT_INSTANCE_ID``.
+
+    The one place the "" -> "default" rule lives, shared by the SDK base class
+    (which echoes the resolved value on ``properties()``) and the transport
+    identity layer (registration key, UDS path, identity validation).
+    """
+    return instance_id or DEFAULT_INSTANCE_ID
+
+
+@dataclass(frozen=True)
+class Tenant:
+    """A backend tenant - the shim's view of an isolation boundary on the backend.
+
+    AWS account, VAST tenant, NetApp SVM, Azure subscription, etc. The
+    minimum a backend MUST report is ``id``; ``name`` and ``attributes``
+    are best-effort metadata.
+    """
+
+    id: str
+    name: str | None = None
+    attributes: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TenantQuota:
+    """Tenant-level storage utilization.
+
+    A backend that partitions quota by tier (the ``tiered`` qualifier on
+    ``tenant.listQuotas``) reports one ``TenantQuota`` per tier, each with
+    ``tier`` set; an untiered backend reports a single entry with ``tier`` None.
+    """
+
+    tenant_id: str
+    hard_limit_bytes: int
+    used_bytes: int
+    name: str
+    # Tier this quota accounts for (e.g. a Lustre deployment type like
+    # "PERSISTENT_2"). None on the aggregate quota from get_tenant_quota and on
+    # untiered backends; set on each per-tier entry from list_tenant_quotas.
+    tier: str | None = None
+    # Backend-stable identifier this quota is looked up by, distinct from
+    # tenant_id (a backend-specific quota code). Empty when the backend has no
+    # stable per-quota id.
+    id: str = ""
+
+
+@dataclass(frozen=True)
+class QuotaLimits:
+    """Hard caps for a quota subject.
+
+    Per-dimension: ``None`` = unlimited / unset on that dimension; positive
+    int = capped at that value. Backends that do not enforce a dimension
+    (per the quota capability's ``QUAL_INODES`` qualifier etc.) silently ignore
+    the field; callers pre-check the qualifier if they need to surface a
+    diagnostic.
+    """
+
+    bytes: int | None = None
+    inodes: int | None = None
+
+
+@dataclass(frozen=True)
+class QuotaUsage:
+    """Observed usage for a quota subject, as reported by the backend.
+
+    Per-dimension: ``None`` = backend does not report usage on that
+    dimension (e.g. inode counters disabled, or the backend has no such
+    concept). ``usage`` is ignored on ``set_*`` input; the backend's
+    actual values are echoed on return.
+    """
+
+    bytes: int | None = None
+    inodes: int | None = None
+
+
+@dataclass(frozen=True)
+class VersionMetadata:
+    """Descriptive metadata about a party and its offering - human-facing.
+
+    Reused for the StorageProvider implementor
+    (``ProviderProperties.provider_metadata``), the storage backend it fronts
+    (``ProviderProperties.backend_metadata``), and the gateway itself.
+
+    Machine identity is NOT here: the registration/addressing key is carried as
+    first-class ``provider_namespace`` + ``provider_id`` scalars on
+    ``ProviderProperties``, so the DNS-label / key constraints apply there, not
+    to this bag.
+
+    ``version`` is context-dependent: for an implementor (provider/gateway) it
+    MUST be semver (``"1.2.3"``); for a backend it is the backing system's
+    version passed through as-is (opaque, e.g. ``"2.15"``) and is not
+    constrained.
+    """
+
+    vendor_name: str = ""  # org display name, e.g. "NVIDIA", "VAST Data"
+    vendor_docs: str = ""  # URL to the vendor's API / product docs (optional)
+    name: str = ""  # product / offering display name, e.g. "AWS FSx Lustre"
+    version: str = ""  # offering version; implementor -> semver, backend -> opaque passthrough
+    description: str = ""  # optional brief, human-facing description
+
+
+# Qualifier-value type aliases - the documented values of the corresponding
+# capability qualifiers (L2). An absent qualifier means the permissive default.
+IDAssignment = Literal["caller", "backend"]
+QuotaAccounting = Literal["nested", "partitioned"]
+
+# Qualifier keys are the SDK-owned vocabulary for ``Capability.qualifiers`` (L2):
+# registry-governed semantic facts a caller may need to behave correctly. A
+# provider attaches them via the ``capability_qualifiers()`` hook
+# (``Implementation``); keys absent from a capability carry their permissive
+# default. Values are the documented strings noted below.
+QUAL_ID_ASSIGNMENT = "idAssignment"  # who mints the quota id; value: an IDAssignment ("caller"|"backend")
+QUAL_BYTE_GRANULARITY = "byteGranularity"  # min byte alignment as a decimal int; absent = byte-exact
+QUAL_MULTI_PATH_BINDING = "multiPathBinding"  # "true": one quota id governs multiple paths (Lustre)
+QUAL_ACCOUNTING = "accounting"  # nested-subject accounting; value: a QuotaAccounting ("nested"|"partitioned")
+QUAL_INODES = "inodes"  # "true"|"false": backend honors inode (file-count) limits on this surface
+QUAL_DEFAULT_USER_SLOT = "defaultUserSlot"  # "true"|"false": user-quota surface supports the fs-wide default-user slot
+QUAL_MULTI_TENANT = "multiTenant"  # "true"|"false": backend manages multiple tenants (vs. a single fixed tenant)
+QUAL_TIERED = "tiered"  # "true"|"false": backend partitions tenant quota by tier (list_tenant_quotas returns one per tier; get_tenant_quota honors req.tier)
+
+# Capability group prefixes - the dotted ancestors of the leaf ids below. They
+# are valid qualifier keys: a group key fans out to every leaf beneath it.
+CAP_GROUP_TENANT = "tenant"
+CAP_GROUP_VOLUME = "volume"
+CAP_GROUP_QUOTA = "quota"
+CAP_GROUP_DIRECTORY_QUOTA = f"{CAP_GROUP_QUOTA}.directory"
+CAP_GROUP_USER_QUOTA = f"{CAP_GROUP_QUOTA}.user"
+
+# Capability registry ids - the SDK-owned identifiers carried as ``Capability.id``
+# and the keys a capability claim (manifest) or qualifier may target (by id, or a
+# dotted group prefix of one).
+CAP_TENANT_LIST = f"{CAP_GROUP_TENANT}.list"
+CAP_TENANT_GET = f"{CAP_GROUP_TENANT}.get"
+CAP_TENANT_GET_QUOTA = f"{CAP_GROUP_TENANT}.getQuota"
+CAP_TENANT_LIST_QUOTAS = f"{CAP_GROUP_TENANT}.listQuotas"
+CAP_VOLUME_LIST = f"{CAP_GROUP_VOLUME}.list"
+CAP_VOLUME_GET = f"{CAP_GROUP_VOLUME}.get"
+CAP_VOLUME_CREATE = f"{CAP_GROUP_VOLUME}.create"
+CAP_VOLUME_DELETE = f"{CAP_GROUP_VOLUME}.delete"
+CAP_DIRECTORY_QUOTA_LIST = f"{CAP_GROUP_DIRECTORY_QUOTA}.list"
+CAP_DIRECTORY_QUOTA_GET = f"{CAP_GROUP_DIRECTORY_QUOTA}.get"
+CAP_DIRECTORY_QUOTA_SET = f"{CAP_GROUP_DIRECTORY_QUOTA}.set"
+CAP_DIRECTORY_QUOTA_DELETE = f"{CAP_GROUP_DIRECTORY_QUOTA}.delete"
+CAP_USER_QUOTA_LIST = f"{CAP_GROUP_USER_QUOTA}.list"
+CAP_USER_QUOTA_GET = f"{CAP_GROUP_USER_QUOTA}.get"
+CAP_USER_QUOTA_SET = f"{CAP_GROUP_USER_QUOTA}.set"
+CAP_USER_QUOTA_DELETE = f"{CAP_GROUP_USER_QUOTA}.delete"
+
+#: The complete set of capability ids the SDK knows about - the registry the
+#: manifest declares against and the validation suite probes.
+CAPABILITY_IDS: tuple[str, ...] = (
+    CAP_TENANT_LIST,
+    CAP_TENANT_GET,
+    CAP_TENANT_GET_QUOTA,
+    CAP_TENANT_LIST_QUOTAS,
+    CAP_VOLUME_LIST,
+    CAP_VOLUME_GET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_DELETE,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_USER_QUOTA_LIST,
+    CAP_USER_QUOTA_GET,
+    CAP_USER_QUOTA_SET,
+    CAP_USER_QUOTA_DELETE,
+)
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One API surface's merged effective state and L2 qualifiers on this endpoint.
+
+    ``id`` is a value from the SDK-owned capability registry (e.g.
+    ``"quota.user.set"``). ``state`` is the merged effective ``CapabilityState``
+    a caller routes on; ``qualifiers`` are registry-governed semantic facts (L2).
+    Purely advisory attributes live on ``ProviderProperties.attributes`` (L3),
+    never here.
+    """
+
+    id: str
+    state: CapabilityState | None = None
+    qualifiers: Mapping[str, str] = field(default_factory=dict)
+
+
+def _resolve_qualifiers(qmap: Mapping[str, Mapping[str, str]], cap_id: str) -> dict[str, str]:
+    """Qualifiers for ``cap_id``, merging group prefixes then the leaf's own entry.
+
+    Least-specific first so the leaf wins on conflicting keys: ``"quota"`` then
+    ``"quota.user"`` then ``"quota.user.set"``. A pure read convenience that lets
+    a provider declare a fact once for a whole group.
+    """
+    keys = [cap_id]
+    key = cap_id
+    while (dot := key.rfind(".")) >= 0:
+        key = key[:dot]
+        keys.append(key)
+    merged: dict[str, str] = {}
+    for key in reversed(keys):
+        merged.update(qmap.get(key, {}))
+    return merged
+
+
+@dataclass(frozen=True)
+class ProviderProperties:
+    """Static declaration of a provider's identity, capabilities, and semantics.
+
+    Returned by ``StorageProvider.properties()`` and immutable for the lifetime
+    of a shim instance. Callers branch on ``capabilities()`` rather than catching
+    ``NotSupportedError`` after the fact; validation suites assert advertised
+    behavior against the running shim.
+
+    ``provider_namespace`` + ``provider_id`` are required; ``instance_id`` is
+    OPTIONAL and defaults to ``"default"``. ``backend_metadata`` is OPTIONAL
+    (``None`` = undeclared).
+
+    ``capabilities()`` is the single model for inspecting optional API surfaces:
+    navigate the typed tree and read merged ``CapabilityState`` and L2 qualifiers.
+    The flat ``_capability_list`` behind it is SDK-internal wire input, set only
+    by trusted builders (``new_implementation()``); consumers use ``capabilities()``.
+    """
+
+    provider_namespace: str
+    provider_id: str
+    provider_metadata: VersionMetadata
+    sdk_version: str
+    storage_type: Literal["file", "block"]
+    storage_protocols: list[str]
+
+    instance_id: str = ""
+    backend_metadata: VersionMetadata | None = None
+    kubernetes_storage_classes: list[str] = field(default_factory=list)
+
+    # SDK-internal construction/wire input: merged effective state per surface.
+    # Set only by ``new_implementation()``; consumers read via ``capabilities()``.
+    _capability_list: list[Capability] = field(default_factory=list)
+
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    def capabilities(self) -> Capabilities:
+        """The advertised capabilities as a typed, navigable tree.
+
+        The single capability accessor: walk to a group or a leaf and read its
+        ``state`` / ``is_supported`` or its typed qualifiers, instead of
+        string-keying a flat list. Rebuilt from the advertised list each call
+        (retain the result if you read it repeatedly). The returned tree also
+        exposes ``effective_list()`` / ``raw_list()`` flat views.
+        """
+        return _new_capabilities(self._capability_list)
+
+
+@dataclass(frozen=True)
+class DirectoryQuota:
+    """Per-directory-tree quota record on a volume.
+
+    Identity keys vary by backend (see the directory-quota capability's
+    ``QUAL_ID_ASSIGNMENT`` qualifier): ``path`` is the primary key on
+    ``"backend"`` backends (VAST), ``id`` is the primary key on ``"caller"``
+    backends (Lustre, where the caller mints the project id). Returned DTOs MUST
+    populate ``id`` regardless of assignment mode.
+    """
+
+    tenant_id: str
+    volume_id: str
+    path: str | None = None  # volume-relative; REQUIRED when id_assignment="backend"; OPTIONAL on "caller"
+    id: str | None = None  # backend-native id; REQUIRED input on "caller"; MUST be populated on return
+    hard: QuotaLimits | None = None  # None = managed entity with no caps declared on any dimension
+    usage: QuotaUsage = field(default_factory=QuotaUsage)
+    attributes: Mapping[str, str] = field(
+        default_factory=dict
+    )  # provider-defined opaque metadata; round-trip as received
+
+
+@dataclass(frozen=True)
+class UserQuota:
+    """Per-user quota record on a volume.
+
+    ``user=None`` addresses the volume's default-user slot (one per volume,
+    gated by the user-quota capability's ``QUAL_DEFAULT_USER_SLOT`` qualifier). A
+    non-None ``user`` identifies an override; the backend infers the
+    identifier kind from format (numeric -> uid, non-numeric -> username).
+    """
+
+    tenant_id: str
+    volume_id: str
+    user: str | None  # None = default-user slot (singleton per volume); str = per-user override
+    hard: QuotaLimits | None = None  # None = managed entity with no caps declared on any dimension
+    usage: QuotaUsage = field(default_factory=QuotaUsage)
+    attributes: Mapping[str, str] = field(
+        default_factory=dict
+    )  # provider-defined opaque metadata; round-trip as received
+
+
+@dataclass(frozen=True)
+class MountSpec:
+    """Linux ``mount(8)``-shaped access info for bare-metal / VM consumers.
+
+    Fields map directly to ``mount -t <fs_type> -o <options> <source>
+    <target>`` so a caller composes the command (or an ``/etc/fstab``
+    line) without any vendor-specific logic.
+    """
+
+    fs_type: str
+    source: str
+    options: str | None = None
+
+
+@dataclass(frozen=True)
+class CsiSpec:
+    """``spec.csi`` payload for a statically-provisioned PV.
+
+    Fields map 1:1 to ``CSIPersistentVolumeSource``; the operator can
+    build a PV manifest from this without consulting the CSI driver.
+    """
+
+    driver: str
+    volume_handle: str
+    fs_type: str | None = None
+    volume_attributes: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Volume:
+    """A provisioned volume in a backend tenant.
+
+    The only universally-meaningful identifier is ``id``. ``mount`` /
+    ``csi`` carry access info shapes most backends report; everything
+    vendor-specific lands in ``attributes``. Usage metrics are optional
+    (``None`` means "not reported").
+    """
+
+    tenant_id: str
+    id: str
+    size_bytes: int
+    created_at: datetime
+    type: VolumeType
+    state: VolumeState
+
+    name: str | None = None
+    mount: MountSpec | None = None
+    csi: CsiSpec | None = None
+    tier: str | None = None
+    tags: Mapping[str, str] = field(default_factory=dict)
+    attributes: Mapping[str, str] = field(default_factory=dict)
+
+    used_bytes: int | None = None
+    available_bytes: int | None = None
+    used_inodes: int | None = None
+    available_inodes: int | None = None
+
+
+@dataclass(frozen=True)
+class TagFilter:
+    """Predicate over volume tags, used by ``list_volumes``.
+
+    Matches a volume when ``tag[key]`` exists and (if ``values`` is
+    non-empty) its value is one of ``values``. ``values=()`` is an
+    existence check on ``key``. Multiple ``TagFilter``s in one call are
+    AND'd together.
+    """
+
+    key: str
+    values: tuple[str, ...] = ()
+
+
+# ===== request / response objects =====
+#
+# Every tenant/volume/quota method takes a XxxRequest and, mirroring the wire,
+# returns either the domain type (single-entity getters), a XxxResponse (list
+# calls, so they can grow pagination later), or None (deletes). A request object
+# keeps optional fields self-documenting at the call site and lets the contract
+# gain fields without churning signatures. ``tenant_id=None`` selects the
+# configured default tenant (resolved by the SDK base class, not per-impl).
+
+
+@dataclass(frozen=True)
+class ListTenantsRequest:
+    """Arguments to ``StorageProvider.list_tenants``."""
+
+    ids: tuple[str, ...] = ()  # restrict to matching ids; unknown ids silently omitted
+
+
+@dataclass(frozen=True)
+class ListTenantsResponse:
+    """Result of ``StorageProvider.list_tenants``."""
+
+    tenants: tuple[Tenant, ...] = ()
+
+
+@dataclass(frozen=True)
+class GetTenantRequest:
+    """Arguments to ``StorageProvider.get_tenant``."""
+
+    tenant_id: str | None = None  # None = default tenant
+
+
+@dataclass(frozen=True)
+class GetTenantQuotaRequest:
+    """Arguments to ``StorageProvider.get_tenant_quota``."""
+
+    tenant_id: str | None = None  # None = default tenant
+    # Optional tier filter. None = the aggregate across all tiers; set = that
+    # tier's quota. Backends that do not partition quota by tier ignore it and
+    # return the aggregate; use list_tenant_quotas to enumerate every tier.
+    tier: str | None = None
+    # Optional backend lookup key (TenantQuota.id). None = address by tier /
+    # aggregate. When set it takes precedence over tier (NOT_FOUND if the id is
+    # unknown); backends with no stable per-quota id ignore it.
+    id: str | None = None
+
+
+@dataclass(frozen=True)
+class ListTenantQuotasRequest:
+    """Arguments to ``StorageProvider.list_tenant_quotas``."""
+
+    tenant_id: str | None = None  # None = default tenant
+
+
+@dataclass(frozen=True)
+class ListTenantQuotasResponse:
+    """Result of ``StorageProvider.list_tenant_quotas`` - one ``TenantQuota`` per tier
+    on a tiered backend, or a single untiered entry."""
+
+    tenant_quotas: tuple[TenantQuota, ...] = ()
+
+
+@dataclass(frozen=True)
+class CreateVolumeRequest:
+    """Arguments to ``StorageProvider.create_volume``."""
+
+    size_bytes: int
+    volume_type: VolumeType
+    tenant_id: str | None = None  # None = default tenant
+    name: str | None = None
+    tier: str | None = None
+    tags: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class DeleteVolumeRequest:
+    """Arguments to ``StorageProvider.delete_volume``."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+
+
+@dataclass(frozen=True)
+class ListVolumesRequest:
+    """Arguments to ``StorageProvider.list_volumes``."""
+
+    tenant_id: str | None = None  # None = default tenant
+    ids: tuple[str, ...] = ()
+    tag_filters: tuple[TagFilter, ...] = ()
+
+
+@dataclass(frozen=True)
+class ListVolumesResponse:
+    """Result of ``StorageProvider.list_volumes``."""
+
+    volumes: tuple[Volume, ...] = ()
+
+
+@dataclass(frozen=True)
+class GetVolumeRequest:
+    """Arguments to ``StorageProvider.get_volume``."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+
+
+@dataclass(frozen=True)
+class ListDirectoryQuotasRequest:
+    """Arguments to ``StorageProvider.list_directory_quotas``."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+
+
+@dataclass(frozen=True)
+class ListDirectoryQuotasResponse:
+    """Result of ``StorageProvider.list_directory_quotas``."""
+
+    directory_quotas: tuple[DirectoryQuota, ...] = ()
+
+
+@dataclass(frozen=True)
+class GetDirectoryQuotaRequest:
+    """Arguments to ``StorageProvider.get_directory_quota`` (at least one of path/id)."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+    path: str | None = None
+    id: str | None = None
+
+
+@dataclass(frozen=True)
+class SetDirectoryQuotaRequest:
+    """Arguments to ``StorageProvider.set_directory_quota``."""
+
+    quota: DirectoryQuota
+
+
+@dataclass(frozen=True)
+class DeleteDirectoryQuotaRequest:
+    """Arguments to ``StorageProvider.delete_directory_quota`` (at least one of path/id)."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+    path: str | None = None
+    id: str | None = None
+
+
+@dataclass(frozen=True)
+class ListUserQuotasRequest:
+    """Arguments to ``StorageProvider.list_user_quotas``."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+
+
+@dataclass(frozen=True)
+class ListUserQuotasResponse:
+    """Result of ``StorageProvider.list_user_quotas``."""
+
+    user_quotas: tuple[UserQuota, ...] = ()
+
+
+@dataclass(frozen=True)
+class GetUserQuotaRequest:
+    """Arguments to ``StorageProvider.get_user_quota``."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+    user: str | None = None  # None = default-user slot
+
+
+@dataclass(frozen=True)
+class SetUserQuotaRequest:
+    """Arguments to ``StorageProvider.set_user_quota``."""
+
+    quota: UserQuota
+
+
+@dataclass(frozen=True)
+class DeleteUserQuotaRequest:
+    """Arguments to ``StorageProvider.delete_user_quota``."""
+
+    volume_id: str
+    tenant_id: str | None = None  # None = default tenant
+    user: str | None = None  # None = default-user slot
+
+
+class StorageApiError(Exception):
+    """Base for all shim errors."""
+
+
+class AuthenticationError(StorageApiError):
+    """Backend unreachable or credentials rejected."""
+
+
+class NotFoundError(StorageApiError):
+    """Lookup of an unknown volume / tenant."""
+
+
+class NotSupportedError(StorageApiError):
+    """Optional shim surface not offered by this backend.
+
+    Raised by the default ``create_volume`` / ``delete_volume`` on
+    managed-K8s providers whose CSI driver owns lifecycle, and by backends
+    that don't expose an optional argument value (e.g. a tier they don't
+    support).
+    """
+
+
+class QuotaExceededError(StorageApiError):
+    """``create_volume`` that would breach the tenant quota."""
+
+
+class ValidationError(StorageApiError):
+    """Shim-side input check failed before the call reached the backend.
+
+    Raised on e.g. ``DirectoryQuota.id`` being ``None`` when the directory-quota
+    capability advertises ``QUAL_ID_ASSIGNMENT == "caller"``, neither
+    ``path`` nor ``id`` supplied to ``get_directory_quota`` /
+    ``delete_directory_quota``, or malformed ``DirectoryQuota.path``.
+    """
+
+
+class ConflictError(StorageApiError):
+    """Backend write conflict or cross-key disagreement.
+
+    Raised when the backend reports a write conflict (concurrent
+    mutation), or when ``get_*`` / ``delete_*`` was called with both
+    ``path`` and ``id`` and the natural-key lookup returned a record
+    whose secondary key disagreed with the caller's input. Callers
+    SHOULD re-fetch via ``get_*`` and retry with fresh state; the shim
+    does NOT serialize concurrent writes.
+    """
+
+
+class UnavailableError(StorageApiError):
+    """A surface that is serviceable in principle but not from this endpoint
+    right now - a **transient** failure the caller SHOULD retry or route around.
+
+    Distinct from ``NotSupportedError`` (a permanent refusal). Maps to gRPC
+    ``UNAVAILABLE`` / HTTP 503.
+    """
+
+
+class StorageProvider(ABC):
+    """Provider-implemented contract for one or more backend storage tenants.
+
+    Implementations MUST be safe to call concurrently from multiple
+    threads (the future REST/gRPC server may dispatch in parallel). The
+    implementation is constructed once at process start via the
+    module-level ``build_api()`` factory; per-call credentials / auth
+    handling is internal to the implementation.
+
+    A shim implements the optional surfaces it backs. Surfaces it does not back
+    fall back to the base method (which raises ``NotSupportedError``), or the
+    shim MAY override them with an explicit stub that raises
+    ``NotSupportedError`` / ``NotImplementedError`` (e.g. to give a custom
+    message). Which surfaces are *supported* is declared in the provider manifest
+    (the contract); the validation suite verifies each declared-supported surface
+    by probing it at runtime, so a stub under a ``supported`` claim fails the
+    suite.
+
+    Every tenant-scoped method takes a request object whose ``tenant_id`` is
+    ``None`` by default. ``None`` selects the shim's configured default tenant
+    (typically read from an env var or ConfigMap at construction time, then
+    resolved by the impl - see the reference shims' ``_resolve_tenant`` helper).
+    Single-tenant providers configure the default and never set it on the request;
+    multi-tenant providers either configure no default and set ``tenant_id``
+    explicitly on every call, or set a default and override per call.
+
+    ``health_check`` is intentionally NOT tenant-scoped - it answers "can
+    the shim reach the backend at all". Per-tenant authorization
+    surfaces on the actual tenant-scoped calls.
+    """
+
+    @abstractmethod
+    def properties(self) -> ProviderProperties:
+        """Return this shim's identity, capability, and semantics declaration.
+
+        Required on every shim - no default. MUST return the same
+        ``ProviderProperties`` value on every call for a given shim
+        lifetime; capabilities are properties of the wrapped backend's
+        design and version, not its runtime state.
+
+        Callers branch on the advertised ``capabilities`` rather than catching
+        ``NotSupportedError`` after the fact; validation suites assert
+        advertised behavior against the running shim.
+        """
+
+    @abstractmethod
+    def health_check(self) -> None:
+        """Authenticated round-trip to the backend.
+
+        * Backend unreachable or credentials rejected -> raises ``AuthenticationError``.
+        * Returns ``None`` on success.
+        """
+
+    def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+        """Return every backend tenant the shim has access to (optional).
+
+        ``req.ids`` restricts the result to matching tenant IDs; unknown IDs
+        are silently omitted (not an error).
+
+        Implement to back ``tenant.list`` (and declare it ``native`` in the manifest).
+
+        * Not implemented by this backend -> raises ``NotSupportedError``.
+        """
+        raise NotSupportedError("list_tenants not implemented by this backend")
+
+    def get_tenant(self, req: GetTenantRequest) -> Tenant:
+        """Return one tenant by ID, or the configured default when ``req.tenant_id`` is None.
+
+        Default delegates to ``list_tenants`` (so ``tenant.get`` is available
+        whenever ``tenant.list`` is); backends with a native single-tenant
+        endpoint should override. When ``req.tenant_id`` is None the default impl
+        returns the sole tenant if the backend exposes exactly one, otherwise it
+        raises ``ValidationError`` (ambiguous) - a multi-tenant backend MUST
+        override to resolve its configured default.
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        * ``req.tenant_id`` None and the backend exposes >1 tenant -> raises ``ValidationError``.
+        * Backend does not support tenant enumeration -> raises ``NotSupportedError``.
+        """
+        tenants = self.list_tenants(
+            ListTenantsRequest(ids=(req.tenant_id,) if req.tenant_id is not None else ())
+        ).tenants
+        if req.tenant_id is None:
+            if len(tenants) == 1:
+                return tenants[0]
+            raise ValidationError(
+                "get_tenant requires an explicit tenant_id when the backend exposes "
+                f"{len(tenants)} tenants; override get_tenant to resolve the configured default"
+            )
+        for t in tenants:
+            if t.id == req.tenant_id:
+                return t
+        raise NotFoundError(f"tenant {req.tenant_id!r} not found")
+
+    @abstractmethod
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        """Return overall storage utilization for the named (or default) tenant.
+
+        Backends that partition quota by tier honor ``req.tier`` / ``req.id``;
+        untiered backends ignore them and return the aggregate.
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        """
+
+    def list_tenant_quotas(self, req: ListTenantQuotasRequest) -> ListTenantQuotasResponse:
+        """Enumerate the named (or default) tenant's quotas (optional).
+
+        Backends that partition quota by tier (advertised by the ``tiered``
+        qualifier on ``tenant.listQuotas``) return one ``TenantQuota`` per tier,
+        each with ``tier`` set; an untiered backend returns a single entry with
+        ``tier`` None (equivalent to ``get_tenant_quota``). Callers fall back to
+        ``get_tenant_quota`` when this is unimplemented.
+
+        Implement to back ``tenant.listQuotas`` (and declare it ``native`` in the manifest).
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        * Not implemented by this backend -> raises ``NotSupportedError``.
+        """
+        raise NotSupportedError("list_tenant_quotas not implemented by this backend")
+
+    def create_volume(self, req: CreateVolumeRequest) -> Volume:
+        """Provision a new volume in the named (or default) tenant (optional).
+
+        Providers whose managed-K8s CSI driver handles dynamic provisioning leave this
+        unimplemented (inherit this base raise, or override with a stub that
+        raises) and declare ``volume.create: none`` in the manifest.
+
+        The returned ``Volume`` MUST have ``id`` populated even when the
+        backend provisions asynchronously - callers poll ``get_volume``
+        until ``state == "available"``.
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        * Requested size would breach the tenant quota -> raises ``QuotaExceededError``.
+        * ``req.tier`` not supported by this backend -> raises ``NotSupportedError``.
+        * Not implemented by this backend -> raises ``NotSupportedError``.
+        """
+        raise NotSupportedError("create_volume not implemented by this backend")
+
+    def delete_volume(self, req: DeleteVolumeRequest) -> None:
+        """Tear down a volume previously returned by ``create_volume`` (optional).
+
+        Implementations that support ``create_volume`` MUST also support
+        ``delete_volume`` so callers can release resources they provisioned.
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        * ``req.volume_id`` already gone -> no-op, no error.
+        * Not implemented by this backend -> raises ``NotSupportedError``.
+        """
+        raise NotSupportedError("delete_volume not implemented by this backend")
+
+    @abstractmethod
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        """Return volumes in the named (or default) tenant, optionally filtered.
+
+        ``req.ids`` restricts the result to matching volume IDs; unknown IDs
+        are silently omitted (not an error). ``req.tag_filters`` is a
+        conjunction - every filter MUST match. A single call NEVER
+        spans tenants; backends MUST always scope to the selected tenant
+        regardless of filters.
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        """
+
+    def get_volume(self, req: GetVolumeRequest) -> Volume:
+        """Return the volume with ``req.volume_id`` from the named (or default) tenant.
+
+        Default delegates to ``list_volumes`` (so ``volume.get`` is always
+        available); backends with a native single-volume endpoint should
+        override.
+
+        * ``req.tenant_id`` not found -> raises ``NotFoundError``.
+        * ``req.volume_id`` not found -> raises ``NotFoundError``.
+        """
+        resp = self.list_volumes(ListVolumesRequest(tenant_id=req.tenant_id, ids=(req.volume_id,)))
+        for vol in resp.volumes:
+            if vol.id == req.volume_id:
+                return vol
+        raise NotFoundError(f"volume {req.volume_id!r} not found")
+
+    # ===== Directory quotas =====
+
+    def list_directory_quotas(self, req: ListDirectoryQuotasRequest) -> ListDirectoryQuotasResponse:
+        """Enumerate every directory-tree quota on ``req.volume_id``.
+
+        Each returned ``DirectoryQuota`` has ``id`` populated regardless
+        of the directory-quota capability's ``QUAL_ID_ASSIGNMENT`` qualifier.
+
+        Implement to back ``quota.directory.list`` (and declare it ``native`` in
+        the manifest). Backends that can set quotas but cannot enumerate them
+        (Lustre) leave this unimplemented and override ``get_directory_quota``
+        natively instead.
+
+        * Listing not supported (e.g. Lustre) -> raises ``NotSupportedError``.
+        * ``req.tenant_id`` / ``req.volume_id`` not found -> raises ``NotFoundError``.
+        """
+        raise NotSupportedError("list_directory_quotas not implemented by this backend")
+
+    def get_directory_quota(self, req: GetDirectoryQuotaRequest) -> DirectoryQuota:
+        """Lookup a directory-tree quota by ``path``, ``id``, or both.
+
+        At least one of ``req.path`` / ``req.id`` MUST be supplied. When both
+        are supplied, the lookup verifies they identify the same record.
+
+        Default delegates to ``list_directory_quotas`` (so ``quota.directory.get``
+        is available whenever ``quota.directory.list`` is); backends with a
+        native single-record endpoint (or no list surface) should override.
+
+        * Neither ``path`` nor ``id`` supplied -> raises ``ValidationError``.
+        * Surface not supported -> raises ``NotSupportedError``.
+        * No record matches -> raises ``NotFoundError``.
+        * Both keys supplied and disagree -> raises ``ConflictError``.
+        """
+        if req.path is None and req.id is None:
+            raise ValidationError("get_directory_quota requires at least one of `path` or `id`")
+        resp = self.list_directory_quotas(ListDirectoryQuotasRequest(tenant_id=req.tenant_id, volume_id=req.volume_id))
+        match = _match_directory_quota(resp.directory_quotas, path=req.path, id=req.id)
+        if match.full is not None:
+            return match.full
+        if match.partial is not None:
+            p = match.partial
+            raise ConflictError(
+                f"directory quota lookup mismatch: requested path={req.path!r}, "
+                f"id={req.id!r}; found path={p.path!r}, id={p.id!r}"
+            )
+        raise NotFoundError(
+            f"directory quota not found (volume_id={req.volume_id!r}, path={req.path!r}, id={req.id!r})"
+        )
+
+    def set_directory_quota(self, req: SetDirectoryQuotaRequest) -> DirectoryQuota:
+        """Upsert a directory-tree quota (``req.quota``).
+
+        ``quota.hard=None`` means "managed entity with no caps declared";
+        removal goes through ``delete_directory_quota``. Backends silently
+        ignore unsupported dimensions on ``quota.hard`` (callers pre-check the
+        directory-quota capability's ``QUAL_INODES`` qualifier etc.).
+
+        The returned DTO MUST have ``id`` populated and SHOULD reflect the
+        actual stored value. ``quota.usage`` on input is ignored.
+
+        Implement to back ``quota.directory.set`` (and declare it ``native`` in the manifest).
+
+        * Surface not supported -> raises ``NotSupportedError``.
+        * ``id_assignment="caller"`` and ``quota.id`` is None -> raises ``ValidationError``.
+        * Backend reports a write conflict -> raises ``ConflictError``.
+        * ``quota.tenant_id`` / ``quota.volume_id`` not found -> raises ``NotFoundError``.
+        """
+        raise NotSupportedError("set_directory_quota not implemented by this backend")
+
+    def delete_directory_quota(self, req: DeleteDirectoryQuotaRequest) -> None:
+        """Remove a directory-tree quota record.
+
+        Key resolution mirrors ``get_directory_quota``: at least one of
+        ``req.path`` / ``req.id`` is required; cross-checks raise
+        ``ConflictError`` when both are supplied and disagree. On backends
+        advertising ``QUAL_MULTI_PATH_BINDING == "true"`` (Lustre), removing by
+        ``id`` removes the record for ALL paths sharing that id.
+
+        Implement to back ``quota.directory.delete`` (and declare it ``native`` in the manifest).
+
+        * Neither ``path`` nor ``id`` supplied -> raises ``ValidationError``.
+        * Surface not supported -> raises ``NotSupportedError``.
+        * Record already absent -> no-op, no error.
+        * Both keys supplied and disagree -> raises ``ConflictError``.
+        """
+        raise NotSupportedError("delete_directory_quota not implemented by this backend")
+
+    # ===== User quotas =====
+
+    def list_user_quotas(self, req: ListUserQuotasRequest) -> ListUserQuotasResponse:
+        """Enumerate every user quota on ``req.volume_id``.
+
+        The default-user slot (``user=None``) is included when set, gated by the
+        user-quota capability's ``QUAL_DEFAULT_USER_SLOT`` qualifier.
+
+        Implement to back ``quota.user.list`` (and declare it ``native`` in the
+        manifest). Backends that can set user quotas but cannot enumerate them
+        (Lustre) leave this unimplemented and override ``get_user_quota``
+        natively instead.
+
+        * Listing not supported (e.g. Lustre) -> raises ``NotSupportedError``.
+        * ``req.tenant_id`` / ``req.volume_id`` not found -> raises ``NotFoundError``.
+        """
+        raise NotSupportedError("list_user_quotas not implemented by this backend")
+
+    def get_user_quota(self, req: GetUserQuotaRequest) -> UserQuota:
+        """Lookup the quota for ``req.user``.
+
+        ``req.user=None`` addresses the volume's default-user slot. A non-None
+        ``user`` matches the backend's stored identifier verbatim.
+
+        Default delegates to ``list_user_quotas`` (so ``quota.user.get`` is
+        available whenever ``quota.user.list`` is); backends with a native
+        single-record endpoint (or no list surface) should override.
+
+        * Surface not supported -> raises ``NotSupportedError``.
+        * No record matches -> raises ``NotFoundError``.
+        """
+        resp = self.list_user_quotas(ListUserQuotasRequest(tenant_id=req.tenant_id, volume_id=req.volume_id))
+        for q in resp.user_quotas:
+            if q.user == req.user:
+                return q
+        raise NotFoundError(f"user quota not found (volume_id={req.volume_id!r}, user={req.user!r})")
+
+    def set_user_quota(self, req: SetUserQuotaRequest) -> UserQuota:
+        """Upsert a per-user quota (``req.quota``).
+
+        ``quota.user=None`` targets the default-user slot. ``quota.hard=None``
+        means "managed entity with no caps declared"; removal goes through
+        ``delete_user_quota``. Unsupported dimensions on ``quota.hard`` are
+        silently ignored. ``quota.usage`` on input is ignored.
+
+        Implement to back ``quota.user.set`` (and declare it ``native`` in the manifest).
+
+        * Surface not supported -> raises ``NotSupportedError``.
+        * ``quota.user=None`` and ``QUAL_DEFAULT_USER_SLOT`` not advertised
+          -> raises ``NotSupportedError``.
+        * Backend reports a write conflict -> raises ``ConflictError``.
+        """
+        raise NotSupportedError("set_user_quota not implemented by this backend")
+
+    def delete_user_quota(self, req: DeleteUserQuotaRequest) -> None:
+        """Remove a user quota record.
+
+        ``req.user=None`` removes the default-user slot.
+
+        Implement to back ``quota.user.delete`` (and declare it ``native`` in the manifest).
+
+        * Surface not supported -> raises ``NotSupportedError``.
+        * Record already absent -> no-op, no error.
+        """
+        raise NotSupportedError("delete_user_quota not implemented by this backend")
+
+
+@dataclass(frozen=True)
+class _DirectoryQuotaMatch:
+    full: DirectoryQuota | None = None
+    partial: DirectoryQuota | None = None
+
+
+def _match_directory_quota(
+    quotas: tuple[DirectoryQuota, ...],
+    *,
+    path: str | None,
+    id: str | None,  # noqa: A002
+) -> _DirectoryQuotaMatch:
+    """Scan all quotas for a full (both keys agree) and/or partial (one key
+    matches while the other disagrees) match.
+
+    Order-independent: a full match always wins over a partial mismatch
+    regardless of where each sits in the list (the singular-lookup helper shared
+    by the default ``get_`` / ``delete_`` directory-quota impls).
+    """
+    full: DirectoryQuota | None = None
+    partial: DirectoryQuota | None = None
+    for q in quotas:
+        path_match = path is None or q.path == path
+        id_match = id is None or q.id == id
+        if path_match and id_match:
+            full = q
+            break
+        if path is not None and id is not None and (q.path == path or q.id == id):
+            partial = q
+    return _DirectoryQuotaMatch(full=full, partial=partial)
+
+
+# ===========================================================================
+# Implementation authoring model (mirrors nv-storage's new_implementation())
+# ===========================================================================
+#
+# An author subclasses ``Implementation`` (overriding only the surfaces the
+# backend actually serves) and hands it to ``new_implementation()``. The SDK then
+# *detects* which surfaces are served from the overridden method set, folds in
+# any config-driven enable/disable overrides and the ``capability_qualifiers``
+# hook's per-node qualifiers / runtime states, and composes a served
+# ``StorageProvider`` that advertises the resolved capabilities on ``properties()``
+# and *gates* every surface (a non-``supported`` surface raises rather than
+# reaching the impl).
+#
+# The bottom-of-module import breaks the api<->capabilities cycle: the capability
+# constants + ``Capability`` this module owns are defined above, so importing the
+# typed tree / composition helpers here is safe.
+from isvtest.core.storage_provider.capabilities import (  # noqa: E402
+    Capabilities,
+    ImplementationCapabilities,
+    _compose_capabilities,
+    _narrow_states,
+    _new_capabilities,
+)
+
+#: cap_id -> the impl method(s) whose presence backs it. A surface is *detected*
+#: as served when the impl overrides ANY listed method (the composite ``get_*``
+#: surfaces ride on their ``list_*`` sibling, matching the base delegation).
+_CAPABILITY_METHODS: dict[str, tuple[str, ...]] = {
+    CAP_TENANT_LIST: ("list_tenants",),
+    CAP_TENANT_GET: ("get_tenant", "list_tenants"),
+    CAP_TENANT_GET_QUOTA: ("get_tenant_quota",),
+    CAP_TENANT_LIST_QUOTAS: ("list_tenant_quotas",),
+    CAP_VOLUME_LIST: ("list_volumes",),
+    CAP_VOLUME_GET: ("get_volume", "list_volumes"),
+    CAP_VOLUME_CREATE: ("create_volume",),
+    CAP_VOLUME_DELETE: ("delete_volume",),
+    CAP_DIRECTORY_QUOTA_LIST: ("list_directory_quotas",),
+    CAP_DIRECTORY_QUOTA_GET: ("get_directory_quota", "list_directory_quotas"),
+    CAP_DIRECTORY_QUOTA_SET: ("set_directory_quota",),
+    CAP_DIRECTORY_QUOTA_DELETE: ("delete_directory_quota",),
+    CAP_USER_QUOTA_LIST: ("list_user_quotas",),
+    CAP_USER_QUOTA_GET: ("get_user_quota", "list_user_quotas"),
+    CAP_USER_QUOTA_SET: ("set_user_quota",),
+    CAP_USER_QUOTA_DELETE: ("delete_user_quota",),
+}
+
+
+class Implementation(StorageProvider):
+    """Author-facing base: override only the surfaces the backend serves.
+
+    An ``Implementation`` does NOT build its own ``properties()`` -
+    ``new_implementation()`` composes that (identity from the core, capabilities
+    from detection + config + the qualifier hook). Overriding ``properties()``
+    here is a programming error and raises.
+
+    ``health_check`` is the one required override (a shim must be able to answer
+    "can I reach the backend"). Every data-plane surface has a raising default;
+    override the ones the backend backs. The optional refinement hooks:
+
+    * ``capability_qualifiers(caps)`` - amend the typed ``ImplementationCapabilities``
+      view in place (per-surface L2 qualifiers, and runtime-availability
+      narrowing via ``set_state``). Default: no-op.
+    * ``backend_metadata()`` - the fronted system's metadata (default: ``None``).
+    """
+
+    def properties(self) -> ProviderProperties:  # pragma: no cover - guard
+        raise NotImplementedError(
+            "Implementation.properties() is composed by new_implementation(); do not call or override it"
+        )
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        raise NotSupportedError("get_tenant_quota not implemented by this backend")
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        raise NotSupportedError("list_volumes not implemented by this backend")
+
+    def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+        """Refine the composed capabilities in place (optional; default no-op)."""
+
+    def backend_metadata(self) -> VersionMetadata | None:
+        """Fronted system's metadata (default: undeclared)."""
+        return None
+
+
+def _implements(impl: StorageProvider, method: str) -> bool:
+    """Whether ``impl`` overrides ``method`` vs. the ``Implementation`` default."""
+    return getattr(type(impl), method, None) is not getattr(Implementation, method, None)
+
+
+def _detect_capabilities(impl: StorageProvider) -> list[Capability]:
+    """The declared capability list detected from ``impl``'s overridden methods.
+
+    Each registry surface is ``"supported"`` when the impl backs any of its
+    methods, else ``"unimplemented"``. Qualifiers are empty here - the qualifier
+    hook and config overrides layer on in ``new_implementation()``.
+    """
+    caps: list[Capability] = []
+    for cap_id in CAPABILITY_IDS:
+        served = any(_implements(impl, m) for m in _CAPABILITY_METHODS[cap_id])
+        caps.append(Capability(id=cap_id, state="supported" if served else "unimplemented"))
+    return caps
+
+
+def _gate_error(cap_id: str, state: CapabilityState | None) -> StorageApiError:
+    """The error a gated (non-``supported``) surface raises, by state."""
+    if state == "unavailable":
+        return UnavailableError(f"{cap_id} is currently unavailable")
+    if state == "disabled":
+        return NotSupportedError(f"{cap_id} is disabled by configuration")
+    return NotSupportedError(f"{cap_id} is not implemented by this backend")
+
+
+class _ServedProvider(StorageProvider):
+    """A composed ``StorageProvider``: advertises resolved capabilities and gates them.
+
+    Wraps an ``Implementation`` with the precomputed ``ProviderProperties`` and
+    per-id effective states. Each surface gate-checks its capability first (a
+    non-``supported`` state raises the matching error) then delegates to the
+    impl. Composite getters delegate to the impl, whose base delegation rides on
+    the impl's own ``list_*``.
+    """
+
+    def __init__(self, impl: StorageProvider, props: ProviderProperties, capabilities: list[Capability]) -> None:
+        self._impl = impl
+        self._props = props
+        self._states = {cap.id: cap.state for cap in capabilities}
+
+    def _gate(self, cap_id: str) -> None:
+        state = self._states.get(cap_id)
+        if state != "supported":
+            raise _gate_error(cap_id, state)
+
+    def properties(self) -> ProviderProperties:
+        return self._props
+
+    def health_check(self) -> None:
+        self._impl.health_check()
+
+    def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+        self._gate(CAP_TENANT_LIST)
+        return self._impl.list_tenants(req)
+
+    def get_tenant(self, req: GetTenantRequest) -> Tenant:
+        self._gate(CAP_TENANT_GET)
+        return self._impl.get_tenant(req)
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        self._gate(CAP_TENANT_GET_QUOTA)
+        return self._impl.get_tenant_quota(req)
+
+    def list_tenant_quotas(self, req: ListTenantQuotasRequest) -> ListTenantQuotasResponse:
+        self._gate(CAP_TENANT_LIST_QUOTAS)
+        return self._impl.list_tenant_quotas(req)
+
+    def create_volume(self, req: CreateVolumeRequest) -> Volume:
+        self._gate(CAP_VOLUME_CREATE)
+        return self._impl.create_volume(req)
+
+    def delete_volume(self, req: DeleteVolumeRequest) -> None:
+        self._gate(CAP_VOLUME_DELETE)
+        self._impl.delete_volume(req)
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        self._gate(CAP_VOLUME_LIST)
+        return self._impl.list_volumes(req)
+
+    def get_volume(self, req: GetVolumeRequest) -> Volume:
+        self._gate(CAP_VOLUME_GET)
+        return self._impl.get_volume(req)
+
+    def list_directory_quotas(self, req: ListDirectoryQuotasRequest) -> ListDirectoryQuotasResponse:
+        self._gate(CAP_DIRECTORY_QUOTA_LIST)
+        return self._impl.list_directory_quotas(req)
+
+    def get_directory_quota(self, req: GetDirectoryQuotaRequest) -> DirectoryQuota:
+        self._gate(CAP_DIRECTORY_QUOTA_GET)
+        return self._impl.get_directory_quota(req)
+
+    def set_directory_quota(self, req: SetDirectoryQuotaRequest) -> DirectoryQuota:
+        self._gate(CAP_DIRECTORY_QUOTA_SET)
+        return self._impl.set_directory_quota(req)
+
+    def delete_directory_quota(self, req: DeleteDirectoryQuotaRequest) -> None:
+        self._gate(CAP_DIRECTORY_QUOTA_DELETE)
+        self._impl.delete_directory_quota(req)
+
+    def list_user_quotas(self, req: ListUserQuotasRequest) -> ListUserQuotasResponse:
+        self._gate(CAP_USER_QUOTA_LIST)
+        return self._impl.list_user_quotas(req)
+
+    def get_user_quota(self, req: GetUserQuotaRequest) -> UserQuota:
+        self._gate(CAP_USER_QUOTA_GET)
+        return self._impl.get_user_quota(req)
+
+    def set_user_quota(self, req: SetUserQuotaRequest) -> UserQuota:
+        self._gate(CAP_USER_QUOTA_SET)
+        return self._impl.set_user_quota(req)
+
+    def delete_user_quota(self, req: DeleteUserQuotaRequest) -> None:
+        self._gate(CAP_USER_QUOTA_DELETE)
+        self._impl.delete_user_quota(req)
+
+
+def _with_default_tenant_req(req: object, default_tenant: str) -> object:
+    """Inject ``default_tenant`` where a request left the tenant unspecified.
+
+    Fills a top-level ``tenant_id`` that is ``None``, or a nested ``quota``'s
+    empty ``tenant_id`` (the set-quota requests carry tenant inside the record).
+    """
+    if hasattr(req, "tenant_id") and getattr(req, "tenant_id") is None:
+        return replace(req, tenant_id=default_tenant)  # type: ignore[type-var]
+    quota = getattr(req, "quota", None)
+    if quota is not None and getattr(quota, "tenant_id", None) in (None, ""):
+        return replace(req, quota=replace(quota, tenant_id=default_tenant))  # type: ignore[type-var]
+    return req
+
+
+class _DefaultTenantApi(StorageProvider):
+    """Wrap a ``StorageProvider`` to resolve unspecified tenants to a fixed default.
+
+    A single-tenant provider sets one default here so callers never pass
+    ``tenant_id``; a request that DOES name a tenant is untouched. ``list_tenants``
+    and ``health_check`` are not tenant-scoped and pass straight through.
+    """
+
+    def __init__(self, inner: StorageProvider, default_tenant: str) -> None:
+        self._inner = inner
+        self._default = default_tenant
+
+    def _wt(self, req: object) -> object:
+        return _with_default_tenant_req(req, self._default)
+
+    def properties(self) -> ProviderProperties:
+        return self._inner.properties()
+
+    def health_check(self) -> None:
+        self._inner.health_check()
+
+    def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+        return self._inner.list_tenants(req)
+
+    def get_tenant(self, req: GetTenantRequest) -> Tenant:
+        return self._inner.get_tenant(self._wt(req))  # type: ignore[arg-type]
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        return self._inner.get_tenant_quota(self._wt(req))  # type: ignore[arg-type]
+
+    def list_tenant_quotas(self, req: ListTenantQuotasRequest) -> ListTenantQuotasResponse:
+        return self._inner.list_tenant_quotas(self._wt(req))  # type: ignore[arg-type]
+
+    def create_volume(self, req: CreateVolumeRequest) -> Volume:
+        return self._inner.create_volume(self._wt(req))  # type: ignore[arg-type]
+
+    def delete_volume(self, req: DeleteVolumeRequest) -> None:
+        self._inner.delete_volume(self._wt(req))  # type: ignore[arg-type]
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        return self._inner.list_volumes(self._wt(req))  # type: ignore[arg-type]
+
+    def get_volume(self, req: GetVolumeRequest) -> Volume:
+        return self._inner.get_volume(self._wt(req))  # type: ignore[arg-type]
+
+    def list_directory_quotas(self, req: ListDirectoryQuotasRequest) -> ListDirectoryQuotasResponse:
+        return self._inner.list_directory_quotas(self._wt(req))  # type: ignore[arg-type]
+
+    def get_directory_quota(self, req: GetDirectoryQuotaRequest) -> DirectoryQuota:
+        return self._inner.get_directory_quota(self._wt(req))  # type: ignore[arg-type]
+
+    def set_directory_quota(self, req: SetDirectoryQuotaRequest) -> DirectoryQuota:
+        return self._inner.set_directory_quota(self._wt(req))  # type: ignore[arg-type]
+
+    def delete_directory_quota(self, req: DeleteDirectoryQuotaRequest) -> None:
+        self._inner.delete_directory_quota(self._wt(req))  # type: ignore[arg-type]
+
+    def list_user_quotas(self, req: ListUserQuotasRequest) -> ListUserQuotasResponse:
+        return self._inner.list_user_quotas(self._wt(req))  # type: ignore[arg-type]
+
+    def get_user_quota(self, req: GetUserQuotaRequest) -> UserQuota:
+        return self._inner.get_user_quota(self._wt(req))  # type: ignore[arg-type]
+
+    def set_user_quota(self, req: SetUserQuotaRequest) -> UserQuota:
+        return self._inner.set_user_quota(self._wt(req))  # type: ignore[arg-type]
+
+    def delete_user_quota(self, req: DeleteUserQuotaRequest) -> None:
+        self._inner.delete_user_quota(self._wt(req))  # type: ignore[arg-type]
+
+
+def with_default_tenant(api: StorageProvider, default_tenant: str) -> StorageProvider:
+    """Wrap ``api`` so unspecified tenants resolve to ``default_tenant``.
+
+    Returns ``api`` unchanged when ``default_tenant`` is empty (no default
+    configured - callers must name the tenant explicitly).
+    """
+    if not default_tenant:
+        return api
+    return _DefaultTenantApi(api, default_tenant)
+
+
+def new_implementation(
+    core: ProviderProperties,
+    impl: Implementation,
+    *,
+    configured_capability_overrides: Mapping[str, bool] | None = None,
+    default_tenant: str = "",
+) -> StorageProvider:
+    """Compose a served ``StorageProvider`` from an author's ``Implementation``.
+
+    Pipeline (all pure, computed once): detect served surfaces from ``impl`` ->
+    apply ``configured_capability_overrides`` (config enable/disable; cannot
+    resurrect an unimplemented surface) -> merge the ``capability_qualifiers``
+    hook's per-node qualifiers and narrow runtime states -> advertise the result
+    on ``properties()`` and gate every surface. Optionally wrap with
+    ``with_default_tenant``.
+    """
+    detected = _detect_capabilities(impl)
+    view = ImplementationCapabilities()
+    impl.capability_qualifiers(view)
+    quals, states = view._collected()
+    composed = _compose_capabilities(detected, configured_capability_overrides or {}, quals)
+    narrowed = _narrow_states(composed, states)
+    props = replace(
+        core,
+        instance_id=instance_or_default(core.instance_id),
+        _capability_list=narrowed,
+        backend_metadata=impl.backend_metadata(),
+    )
+    served = _ServedProvider(impl, props, narrowed)
+    return with_default_tenant(served, default_tenant)

--- a/isvtest/src/isvtest/core/storage_provider/capabilities.py
+++ b/isvtest/src/isvtest/core/storage_provider/capabilities.py
@@ -1,0 +1,758 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed capability tree + composition, mirroring nv-storage's ``capabilities.py``.
+
+Trimmed to the singular capability ids this suite models (no batch surfaces).
+The registry ids, qualifier vocabulary, and the ``Capability`` wire record live
+in :mod:`isvtest.core.storage_provider.api`; this module layers on:
+
+* ``_compose_capabilities`` / ``_narrow_states`` - the deploy-time / runtime
+  composition ``new_implementation()`` sits on;
+* the typed, navigable read tree a consumer walks (``Capabilities``) and the
+  write view an author refines in ``capability_qualifiers`` (``ImplementationCapabilities``).
+
+A semantic fact set on a group inherits to its leaves: the group views expose
+the inherited getters/setters, and the per-leaf views expose each leaf's
+*effective* (own + inherited) qualifiers, settable as a leaf override.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import cast
+
+from isvtest.core.storage_provider.api import (
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_GROUP_QUOTA,
+    CAP_GROUP_TENANT,
+    CAP_GROUP_VOLUME,
+    CAP_TENANT_GET,
+    CAP_TENANT_GET_QUOTA,
+    CAP_TENANT_LIST,
+    CAP_TENANT_LIST_QUOTAS,
+    CAP_USER_QUOTA_DELETE,
+    CAP_USER_QUOTA_GET,
+    CAP_USER_QUOTA_LIST,
+    CAP_USER_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_DELETE,
+    CAP_VOLUME_GET,
+    CAP_VOLUME_LIST,
+    CAPABILITY_IDS,
+    QUAL_ACCOUNTING,
+    QUAL_BYTE_GRANULARITY,
+    QUAL_DEFAULT_USER_SLOT,
+    QUAL_ID_ASSIGNMENT,
+    QUAL_INODES,
+    QUAL_MULTI_PATH_BINDING,
+    QUAL_MULTI_TENANT,
+    QUAL_TIERED,
+    Capability,
+    CapabilityState,
+    IDAssignment,
+    QuotaAccounting,
+    _resolve_qualifiers,
+)
+
+__all__ = [
+    "Capabilities",
+    "CapabilityNode",
+    "ImplementationCapabilities",
+    "ImplementationNode",
+]
+
+
+def _resolve_override(overrides: Mapping[str, bool], cap_id: str) -> bool | None:
+    """Most-specific config override for ``cap_id``: exact id, then group prefixes.
+
+    Walks ``"quota.user.set"`` -> ``"quota.user"`` -> ``"quota"`` and returns the
+    first match, so a leaf override beats the group it sits under. ``None`` = no
+    override touches this id.
+    """
+    key = cap_id
+    while True:
+        if key in overrides:
+            return overrides[key]
+        dot = key.rfind(".")
+        if dot < 0:
+            return None
+        key = key[:dot]
+
+
+def _compose_capabilities(
+    declared: list[Capability],
+    overrides: Mapping[str, bool],
+    qualifiers: Mapping[str, Mapping[str, str]],
+) -> list[Capability]:
+    """Resolve the ADVERTISED capability list from the declared core.
+
+    For each declared surface: a config override may flip ``supported`` <->
+    ``disabled`` (by id or group prefix) but can NOT resurrect a surface the code
+    left ``unimplemented``; qualifiers from the hook are merged on top of any the
+    surface already carries (hook wins). A pure function (no I/O).
+    """
+    result: list[Capability] = []
+    for cap in declared:
+        state = cap.state
+        override = _resolve_override(overrides, cap.id)
+        if override is False and state == "supported":
+            state = "disabled"
+        elif override is True and state == "disabled":
+            state = "supported"
+        if state == "unimplemented":
+            result.append(replace(cap, state=state, qualifiers={}))
+            continue
+        merged = {**cap.qualifiers, **_resolve_qualifiers(qualifiers, cap.id)}
+        result.append(replace(cap, state=state, qualifiers=merged))
+    return result
+
+
+#: Roll-up / fold order, most-available first.
+_STATE_ORDER: tuple[CapabilityState, ...] = (
+    "supported",
+    "unavailable",
+    "disabled",
+    "unimplemented",
+)
+_STATE_RANK = {s: i for i, s in enumerate(_STATE_ORDER)}
+
+
+def _leaves_under(prefix: str) -> list[str]:
+    """Registry leaf ids at or beneath a node id (the whole tree for the root)."""
+    if prefix == "":
+        return list(CAPABILITY_IDS)
+    return [cid for cid in CAPABILITY_IDS if cid == prefix or cid.startswith(prefix + ".")]
+
+
+def _child_id(prefix: str, seg: str) -> str:
+    return seg if prefix == "" else f"{prefix}.{seg}"
+
+
+def _resolve_state(states: Mapping[str, CapabilityState], cap_id: str) -> CapabilityState | None:
+    """Most-specific runtime-state override for ``cap_id`` (exact id, then groups)."""
+    key = cap_id
+    while True:
+        if key in states:
+            return states[key]
+        dot = key.rfind(".")
+        if dot < 0:
+            return None
+        key = key[:dot]
+
+
+def _narrow_states(caps: list[Capability], states: Mapping[str, CapabilityState]) -> list[Capability]:
+    """Fold the hook's runtime-availability states into the advertised list.
+
+    A state set on a leaf (or a group, fanning down) is applied only when it is
+    MORE restrictive than the surface's current state - so the hook can take a
+    served surface ``unavailable`` / ``disabled`` but never re-enable one config
+    or the missing implementation left off.
+    """
+    if not states:
+        return caps
+    out: list[Capability] = []
+    for cap in caps:
+        want = _resolve_state(states, cap.id)
+        cur = cap.state or "unimplemented"
+        if want is not None and _STATE_RANK.get(want, 99) > _STATE_RANK.get(cur, 99):
+            out.append(replace(cap, state=want))
+        else:
+            out.append(cap)
+    return out
+
+
+# --- typed capability tree (read) --------------------------------------------
+
+
+class CapabilityNode:
+    """A positioned node (group or leaf) in the advertised capability tree.
+
+    Backed by the flat advertised ``Capability`` list: a leaf reads its own
+    effective state and qualifiers; a group rolls its leaves up (supported if any
+    leaf is, else the most-available state) and recovers a group-wide qualifier
+    from a representative leaf.
+    """
+
+    __slots__ = ("_by_id", "_id")
+
+    def __init__(self, by_id: Mapping[str, Capability], node_id: str) -> None:
+        self._by_id = by_id
+        self._id = node_id
+
+    @property
+    def id(self) -> str:
+        """The node's dotted registry id (``""`` for the root)."""
+        return self._id
+
+    def state(self) -> CapabilityState:
+        """The node's effective state (a group rolls up the most-available leaf)."""
+        cap = self._by_id.get(self._id)
+        if cap is not None:
+            return cap.state if cap.state is not None else "unimplemented"
+        present = {self._by_id[lid].state for lid in _leaves_under(self._id) if lid in self._by_id}
+        for s in _STATE_ORDER:
+            if s in present:
+                return s
+        return "unimplemented"
+
+    def is_supported(self) -> bool:
+        """Whether the node is serviceable here and now."""
+        return self.state() == "supported"
+
+    def qualifiers(self) -> dict[str, str]:
+        """The node-scoped resolved qualifier bag (a representative leaf's, for a group)."""
+        cap = self._by_id.get(self._id)
+        if cap is not None:
+            return dict(cap.qualifiers)
+        for leaf in _leaves_under(self._id):
+            if leaf in self._by_id:
+                return dict(self._by_id[leaf].qualifiers)
+        return {}
+
+    def _qual(self, key: str) -> str | None:
+        for leaf in _leaves_under(self._id):
+            cap = self._by_id.get(leaf)
+            if cap is not None and key in cap.qualifiers:
+                return cap.qualifiers[key]
+        return None
+
+    def _bool(self, key: str, default: bool) -> bool:
+        v = self._qual(key)
+        return v == "true" if v is not None else default
+
+    def _int(self, key: str, default: int) -> int:
+        v = self._qual(key)
+        if v is not None:
+            try:
+                return int(v)
+            except ValueError:
+                pass
+        return default
+
+    def _child(self, seg: str) -> CapabilityNode:
+        return CapabilityNode(self._by_id, _child_id(self._id, seg))
+
+
+class TenantLeafCaps(CapabilityNode):
+    """Read view of a ``tenant`` leaf - its effective qualifiers."""
+
+    def multi_tenant(self) -> bool:
+        return self._bool(QUAL_MULTI_TENANT, False)
+
+    def tiered(self) -> bool:
+        return self._bool(QUAL_TIERED, False)
+
+
+class DirectoryQuotaLeafCaps(CapabilityNode):
+    """Read view of a ``quota.directory`` leaf - its effective qualifiers."""
+
+    def byte_granularity(self) -> int:
+        return self._int(QUAL_BYTE_GRANULARITY, 1)
+
+    def inodes(self) -> bool:
+        return self._bool(QUAL_INODES, True)
+
+    def id_assignment(self) -> IDAssignment | None:
+        return cast("IDAssignment | None", self._qual(QUAL_ID_ASSIGNMENT))
+
+    def multi_path_binding(self) -> bool:
+        return self._bool(QUAL_MULTI_PATH_BINDING, False)
+
+    def accounting(self) -> QuotaAccounting | None:
+        return cast("QuotaAccounting | None", self._qual(QUAL_ACCOUNTING))
+
+
+class UserQuotaLeafCaps(CapabilityNode):
+    """Read view of a ``quota.user`` leaf - its effective qualifiers."""
+
+    def byte_granularity(self) -> int:
+        return self._int(QUAL_BYTE_GRANULARITY, 1)
+
+    def inodes(self) -> bool:
+        return self._bool(QUAL_INODES, True)
+
+    def id_assignment(self) -> IDAssignment | None:
+        return cast("IDAssignment | None", self._qual(QUAL_ID_ASSIGNMENT))
+
+    def default_user_slot(self) -> bool:
+        return self._bool(QUAL_DEFAULT_USER_SLOT, True)
+
+
+class TenantCaps(CapabilityNode):
+    """Read view of the ``tenant`` group."""
+
+    def list(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, _child_id(self._id, "list"))
+
+    def get(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, _child_id(self._id, "get"))
+
+    def get_quota(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, _child_id(self._id, "getQuota"))
+
+    def list_quotas(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, _child_id(self._id, "listQuotas"))
+
+    def multi_tenant(self) -> bool:
+        return self._bool(QUAL_MULTI_TENANT, False)
+
+    def tiered(self) -> bool:
+        return self._bool(QUAL_TIERED, False)
+
+
+class VolumeCaps(CapabilityNode):
+    """Read view of the ``volume`` group (no typed qualifiers)."""
+
+    def list(self) -> CapabilityNode:
+        return self._child("list")
+
+    def get(self) -> CapabilityNode:
+        return self._child("get")
+
+    def create(self) -> CapabilityNode:
+        return self._child("create")
+
+    def delete(self) -> CapabilityNode:
+        return self._child("delete")
+
+
+class QuotaCaps(CapabilityNode):
+    """Read view of the ``quota`` group."""
+
+    def directory(self) -> DirectoryQuotaCaps:
+        return DirectoryQuotaCaps(self._by_id, _child_id(self._id, "directory"))
+
+    def user(self) -> UserQuotaCaps:
+        return UserQuotaCaps(self._by_id, _child_id(self._id, "user"))
+
+    def byte_granularity(self) -> int:
+        return self._int(QUAL_BYTE_GRANULARITY, 1)
+
+    def inodes(self) -> bool:
+        return self._bool(QUAL_INODES, True)
+
+    def id_assignment(self) -> IDAssignment | None:
+        return cast("IDAssignment | None", self._qual(QUAL_ID_ASSIGNMENT))
+
+
+class DirectoryQuotaCaps(CapabilityNode):
+    """Read view of the ``quota.directory`` group."""
+
+    def list(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, _child_id(self._id, "list"))
+
+    def get(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, _child_id(self._id, "get"))
+
+    def set(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, _child_id(self._id, "set"))
+
+    def delete(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, _child_id(self._id, "delete"))
+
+    def byte_granularity(self) -> int:
+        return self._int(QUAL_BYTE_GRANULARITY, 1)
+
+    def inodes(self) -> bool:
+        return self._bool(QUAL_INODES, True)
+
+    def id_assignment(self) -> IDAssignment | None:
+        return cast("IDAssignment | None", self._qual(QUAL_ID_ASSIGNMENT))
+
+    def multi_path_binding(self) -> bool:
+        return self._bool(QUAL_MULTI_PATH_BINDING, False)
+
+    def accounting(self) -> QuotaAccounting | None:
+        return cast("QuotaAccounting | None", self._qual(QUAL_ACCOUNTING))
+
+
+class UserQuotaCaps(CapabilityNode):
+    """Read view of the ``quota.user`` group."""
+
+    def list(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, _child_id(self._id, "list"))
+
+    def get(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, _child_id(self._id, "get"))
+
+    def set(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, _child_id(self._id, "set"))
+
+    def delete(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, _child_id(self._id, "delete"))
+
+    def byte_granularity(self) -> int:
+        return self._int(QUAL_BYTE_GRANULARITY, 1)
+
+    def inodes(self) -> bool:
+        return self._bool(QUAL_INODES, True)
+
+    def id_assignment(self) -> IDAssignment | None:
+        return cast("IDAssignment | None", self._qual(QUAL_ID_ASSIGNMENT))
+
+    def default_user_slot(self) -> bool:
+        return self._bool(QUAL_DEFAULT_USER_SLOT, True)
+
+
+class Capabilities(CapabilityNode):
+    """The typed, navigable read view of a provider's advertised capability tree.
+
+    Navigate to a group or straight to a leaf, then read a node's ``state`` /
+    ``is_supported`` and its typed qualifiers. Rebuilt from the advertised list
+    each call (retain it if you read repeatedly).
+    """
+
+    def raw_list(self) -> list[Capability]:
+        """The verbatim flat records this tree was built from - the wire form."""
+        return list(self._by_id.values())
+
+    def effective_list(self) -> list[Capability]:
+        """Every registry leaf with its folded effective state and resolved qualifiers."""
+        return [
+            Capability(
+                id=cid,
+                state=CapabilityNode(self._by_id, cid).state(),
+                qualifiers=CapabilityNode(self._by_id, cid).qualifiers(),
+            )
+            for cid in CAPABILITY_IDS
+        ]
+
+    def tenant(self) -> TenantCaps:
+        return TenantCaps(self._by_id, CAP_GROUP_TENANT)
+
+    def volume(self) -> VolumeCaps:
+        return VolumeCaps(self._by_id, CAP_GROUP_VOLUME)
+
+    def quota(self) -> QuotaCaps:
+        return QuotaCaps(self._by_id, CAP_GROUP_QUOTA)
+
+    def list_tenants(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, CAP_TENANT_LIST)
+
+    def get_tenant(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, CAP_TENANT_GET)
+
+    def get_tenant_quota(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, CAP_TENANT_GET_QUOTA)
+
+    def list_tenant_quotas(self) -> TenantLeafCaps:
+        return TenantLeafCaps(self._by_id, CAP_TENANT_LIST_QUOTAS)
+
+    def list_volumes(self) -> CapabilityNode:
+        return CapabilityNode(self._by_id, CAP_VOLUME_LIST)
+
+    def get_volume(self) -> CapabilityNode:
+        return CapabilityNode(self._by_id, CAP_VOLUME_GET)
+
+    def create_volume(self) -> CapabilityNode:
+        return CapabilityNode(self._by_id, CAP_VOLUME_CREATE)
+
+    def delete_volume(self) -> CapabilityNode:
+        return CapabilityNode(self._by_id, CAP_VOLUME_DELETE)
+
+    def list_directory_quotas(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, CAP_DIRECTORY_QUOTA_LIST)
+
+    def get_directory_quota(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, CAP_DIRECTORY_QUOTA_GET)
+
+    def set_directory_quota(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, CAP_DIRECTORY_QUOTA_SET)
+
+    def delete_directory_quota(self) -> DirectoryQuotaLeafCaps:
+        return DirectoryQuotaLeafCaps(self._by_id, CAP_DIRECTORY_QUOTA_DELETE)
+
+    def list_user_quotas(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, CAP_USER_QUOTA_LIST)
+
+    def get_user_quota(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, CAP_USER_QUOTA_GET)
+
+    def set_user_quota(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, CAP_USER_QUOTA_SET)
+
+    def delete_user_quota(self) -> UserQuotaLeafCaps:
+        return UserQuotaLeafCaps(self._by_id, CAP_USER_QUOTA_DELETE)
+
+
+def _new_capabilities(caps: list[Capability]) -> Capabilities:
+    """Build the typed read tree over an advertised ``Capability`` list."""
+    return Capabilities({cap.id: cap for cap in caps}, "")
+
+
+# --- typed capability tree (author write view) -------------------------------
+
+
+class ImplementationNode:
+    """A positioned node of the writable author view.
+
+    ``set_state`` feeds the node's runtime-availability (a group fans down to its
+    leaves); the SDK folds it with detection + config so an author can narrow a
+    surface (``"unavailable"`` / ``"disabled"``) but never conjure one the code
+    does not serve. ``set_qualifier`` is the node-scoped escape hatch for a
+    dynamic qualifier with no typed setter. Both chain (return the node).
+    """
+
+    __slots__ = ("_id", "_quals", "_states")
+
+    def __init__(
+        self,
+        quals: dict[str, dict[str, str]],
+        states: dict[str, CapabilityState],
+        node_id: str,
+    ) -> None:
+        self._quals = quals
+        self._states = states
+        self._id = node_id
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    def set_state(self, state: CapabilityState) -> ImplementationNode:
+        self._states[self._id] = state
+        return self
+
+    def set_qualifier(self, key: str, value: str) -> ImplementationNode:
+        self._quals.setdefault(self._id, {})[key] = value
+        return self
+
+    def _set(self, key: str, value: str) -> None:
+        self._quals.setdefault(self._id, {})[key] = value
+
+    def _child(self, seg: str) -> ImplementationNode:
+        return ImplementationNode(self._quals, self._states, _child_id(self._id, seg))
+
+
+class TenantLeafImplCaps(ImplementationNode):
+    """Writable view of a ``tenant`` leaf - a per-leaf qualifier override."""
+
+    def set_multi_tenant(self, v: bool) -> TenantLeafImplCaps:
+        self._set(QUAL_MULTI_TENANT, "true" if v else "false")
+        return self
+
+    def set_tiered(self, v: bool) -> TenantLeafImplCaps:
+        self._set(QUAL_TIERED, "true" if v else "false")
+        return self
+
+
+class DirectoryQuotaLeafImplCaps(ImplementationNode):
+    """Writable view of a ``quota.directory`` leaf - a per-leaf qualifier override."""
+
+    def set_byte_granularity(self, v: int) -> DirectoryQuotaLeafImplCaps:
+        self._set(QUAL_BYTE_GRANULARITY, str(v))
+        return self
+
+    def set_inodes(self, v: bool) -> DirectoryQuotaLeafImplCaps:
+        self._set(QUAL_INODES, "true" if v else "false")
+        return self
+
+    def set_id_assignment(self, v: IDAssignment) -> DirectoryQuotaLeafImplCaps:
+        self._set(QUAL_ID_ASSIGNMENT, v)
+        return self
+
+    def set_multi_path_binding(self, v: bool) -> DirectoryQuotaLeafImplCaps:
+        self._set(QUAL_MULTI_PATH_BINDING, "true" if v else "false")
+        return self
+
+    def set_accounting(self, v: QuotaAccounting) -> DirectoryQuotaLeafImplCaps:
+        self._set(QUAL_ACCOUNTING, v)
+        return self
+
+
+class UserQuotaLeafImplCaps(ImplementationNode):
+    """Writable view of a ``quota.user`` leaf - a per-leaf qualifier override."""
+
+    def set_byte_granularity(self, v: int) -> UserQuotaLeafImplCaps:
+        self._set(QUAL_BYTE_GRANULARITY, str(v))
+        return self
+
+    def set_inodes(self, v: bool) -> UserQuotaLeafImplCaps:
+        self._set(QUAL_INODES, "true" if v else "false")
+        return self
+
+    def set_id_assignment(self, v: IDAssignment) -> UserQuotaLeafImplCaps:
+        self._set(QUAL_ID_ASSIGNMENT, v)
+        return self
+
+    def set_default_user_slot(self, v: bool) -> UserQuotaLeafImplCaps:
+        self._set(QUAL_DEFAULT_USER_SLOT, "true" if v else "false")
+        return self
+
+
+class TenantImplCaps(ImplementationNode):
+    """Writable view of the ``tenant`` group."""
+
+    def list(self) -> TenantLeafImplCaps:
+        return TenantLeafImplCaps(self._quals, self._states, _child_id(self._id, "list"))
+
+    def get(self) -> TenantLeafImplCaps:
+        return TenantLeafImplCaps(self._quals, self._states, _child_id(self._id, "get"))
+
+    def get_quota(self) -> TenantLeafImplCaps:
+        return TenantLeafImplCaps(self._quals, self._states, _child_id(self._id, "getQuota"))
+
+    def list_quotas(self) -> TenantLeafImplCaps:
+        return TenantLeafImplCaps(self._quals, self._states, _child_id(self._id, "listQuotas"))
+
+    def set_multi_tenant(self, v: bool) -> TenantImplCaps:
+        self._set(QUAL_MULTI_TENANT, "true" if v else "false")
+        return self
+
+    def set_tiered(self, v: bool) -> TenantImplCaps:
+        self._set(QUAL_TIERED, "true" if v else "false")
+        return self
+
+
+class VolumeImplCaps(ImplementationNode):
+    """Writable view of the ``volume`` group (no typed qualifiers)."""
+
+    def list(self) -> ImplementationNode:
+        return self._child("list")
+
+    def get(self) -> ImplementationNode:
+        return self._child("get")
+
+    def create(self) -> ImplementationNode:
+        return self._child("create")
+
+    def delete(self) -> ImplementationNode:
+        return self._child("delete")
+
+
+class QuotaImplCaps(ImplementationNode):
+    """Writable view of the ``quota`` group."""
+
+    def directory(self) -> DirectoryQuotaImplCaps:
+        return DirectoryQuotaImplCaps(self._quals, self._states, _child_id(self._id, "directory"))
+
+    def user(self) -> UserQuotaImplCaps:
+        return UserQuotaImplCaps(self._quals, self._states, _child_id(self._id, "user"))
+
+    def set_byte_granularity(self, v: int) -> QuotaImplCaps:
+        self._set(QUAL_BYTE_GRANULARITY, str(v))
+        return self
+
+    def set_inodes(self, v: bool) -> QuotaImplCaps:
+        self._set(QUAL_INODES, "true" if v else "false")
+        return self
+
+    def set_id_assignment(self, v: IDAssignment) -> QuotaImplCaps:
+        self._set(QUAL_ID_ASSIGNMENT, v)
+        return self
+
+
+class DirectoryQuotaImplCaps(ImplementationNode):
+    """Writable view of the ``quota.directory`` group."""
+
+    def list(self) -> DirectoryQuotaLeafImplCaps:
+        return DirectoryQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "list"))
+
+    def get(self) -> DirectoryQuotaLeafImplCaps:
+        return DirectoryQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "get"))
+
+    def set(self) -> DirectoryQuotaLeafImplCaps:
+        return DirectoryQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "set"))
+
+    def delete(self) -> DirectoryQuotaLeafImplCaps:
+        return DirectoryQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "delete"))
+
+    def set_byte_granularity(self, v: int) -> DirectoryQuotaImplCaps:
+        self._set(QUAL_BYTE_GRANULARITY, str(v))
+        return self
+
+    def set_inodes(self, v: bool) -> DirectoryQuotaImplCaps:
+        self._set(QUAL_INODES, "true" if v else "false")
+        return self
+
+    def set_id_assignment(self, v: IDAssignment) -> DirectoryQuotaImplCaps:
+        self._set(QUAL_ID_ASSIGNMENT, v)
+        return self
+
+    def set_multi_path_binding(self, v: bool) -> DirectoryQuotaImplCaps:
+        self._set(QUAL_MULTI_PATH_BINDING, "true" if v else "false")
+        return self
+
+    def set_accounting(self, v: QuotaAccounting) -> DirectoryQuotaImplCaps:
+        self._set(QUAL_ACCOUNTING, v)
+        return self
+
+
+class UserQuotaImplCaps(ImplementationNode):
+    """Writable view of the ``quota.user`` group."""
+
+    def list(self) -> UserQuotaLeafImplCaps:
+        return UserQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "list"))
+
+    def get(self) -> UserQuotaLeafImplCaps:
+        return UserQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "get"))
+
+    def set(self) -> UserQuotaLeafImplCaps:
+        return UserQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "set"))
+
+    def delete(self) -> UserQuotaLeafImplCaps:
+        return UserQuotaLeafImplCaps(self._quals, self._states, _child_id(self._id, "delete"))
+
+    def set_byte_granularity(self, v: int) -> UserQuotaImplCaps:
+        self._set(QUAL_BYTE_GRANULARITY, str(v))
+        return self
+
+    def set_inodes(self, v: bool) -> UserQuotaImplCaps:
+        self._set(QUAL_INODES, "true" if v else "false")
+        return self
+
+    def set_id_assignment(self, v: IDAssignment) -> UserQuotaImplCaps:
+        self._set(QUAL_ID_ASSIGNMENT, v)
+        return self
+
+    def set_default_user_slot(self, v: bool) -> UserQuotaImplCaps:
+        self._set(QUAL_DEFAULT_USER_SLOT, "true" if v else "false")
+        return self
+
+
+class ImplementationCapabilities(ImplementationNode):
+    """The writable view handed to ``capability_qualifiers`` to refine a provider.
+
+    Navigate with the typed group accessors and amend in place with the typed
+    setters (a fact set on a group inherits to its leaves), or reach any node by
+    dotted id with ``get`` for a dynamic ``set_qualifier`` / ``set_state``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__({}, {}, "")
+
+    def tenant(self) -> TenantImplCaps:
+        return TenantImplCaps(self._quals, self._states, CAP_GROUP_TENANT)
+
+    def volume(self) -> VolumeImplCaps:
+        return VolumeImplCaps(self._quals, self._states, CAP_GROUP_VOLUME)
+
+    def quota(self) -> QuotaImplCaps:
+        return QuotaImplCaps(self._quals, self._states, CAP_GROUP_QUOTA)
+
+    def get(self, cap_id: str) -> ImplementationNode:
+        """A node positioned at an arbitrary capability id or dotted group prefix."""
+        return ImplementationNode(self._quals, self._states, cap_id)
+
+    def _collected(
+        self,
+    ) -> tuple[dict[str, dict[str, str]], dict[str, CapabilityState]]:
+        """The recorded (qualifier-overrides, runtime-states), keyed by node id."""
+        return self._quals, self._states

--- a/isvtest/src/isvtest/core/storage_provider/loader.py
+++ b/isvtest/src/isvtest/core/storage_provider/loader.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load the platform's ``StorageProvider`` from a Python file on disk.
+
+The loader imports it, calls the factory, and validates the result.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+import uuid
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+from isvtest.core.storage_provider.api import StorageProvider
+
+
+class ShimLoadError(Exception):
+    """The shim file could not be loaded or did not implement the contract."""
+
+
+def _factory_accepts_attributes(factory: Callable[..., object]) -> bool:
+    """True when ``build_api`` declares an ``attributes`` keyword (or ``**kwargs``).
+
+    Lets the loader pass manifest ``attributes`` to shims that opt in while
+    keeping the documented no-arg ``build_api()`` contract working for the rest.
+    """
+    try:
+        params = inspect.signature(factory).parameters
+    except (TypeError, ValueError):
+        return False
+    if "attributes" in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def build_api_from_path(
+    path: str | Path,
+    attributes: Mapping[str, str] | None = None,
+) -> StorageProvider:
+    """Load ``path`` as a Python module, call its ``build_api()``, return the ``StorageProvider``.
+
+    ``path`` is resolved against the current working directory if
+    relative; the caller is responsible for resolving against a
+    manifest-relative directory before calling.
+
+    ``attributes`` carries the provider's manifest ``attributes`` block. It is
+    forwarded as ``build_api(attributes=...)`` only when the shim's factory
+    opts in (declares an ``attributes`` keyword or ``**kwargs``); no-arg
+    factories keep working unchanged.
+
+    Raises ``ShimLoadError`` when the file is missing, has no
+    ``build_api`` callable, or returns something that isn't a
+    ``StorageProvider`` subclass.
+    """
+    shim_path = Path(path).resolve()
+    if not shim_path.is_file():
+        raise ShimLoadError(f"shim file not found: {shim_path}")
+
+    # Unique module name keeps multiple shims (or repeated loads in tests)
+    # from clobbering each other in ``sys.modules``.
+    module_name = f"_isvtest_shim_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, shim_path)
+    if spec is None or spec.loader is None:
+        raise ShimLoadError(f"cannot create import spec for {shim_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.modules.pop(module_name, None)
+        raise ShimLoadError(f"failed to import shim {shim_path}: {exc}") from exc
+
+    factory = getattr(module, "build_api", None)
+    if not callable(factory):
+        raise ShimLoadError(f"shim {shim_path} has no module-level build_api() callable")
+
+    try:
+        if _factory_accepts_attributes(factory):
+            api = factory(attributes=dict(attributes or {}))
+        else:
+            api = factory()
+    except Exception as exc:
+        raise ShimLoadError(f"build_api() in {shim_path} raised: {exc}") from exc
+
+    if not isinstance(api, StorageProvider):
+        raise ShimLoadError(
+            f"build_api() in {shim_path} returned {type(api).__name__}, expected a StorageProvider subclass"
+        )
+    return api

--- a/isvtest/src/isvtest/core/storage_provider/mock.py
+++ b/isvtest/src/isvtest/core/storage_provider/mock.py
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-memory ``MockStorageApi`` reference implementation.
+
+Used by the unit tests for the validation suite so validators can be exercised
+end-to-end without a real backend. Authored on ``Implementation``; tests that
+need the composed ``properties()`` / capability gating serve it through
+``new_implementation()`` (see ``test_storage_provider.py``).
+
+Which surfaces the mock backs is selected by composition, not config:
+``MockStorageApi`` mixes in the directory- and user-quota surfaces (so they
+answer), while a test that needs a narrower backend composes a mock from a
+subset of the mixins (``_MockCore``, ``_DirectoryQuotaMixin``,
+``_UserQuotaMixin``, and their list-less variants); a surface whose method is
+absent falls back to the base ``StorageProvider`` method, which raises
+``NotSupportedError`` - exactly what the validation suite probes for. Behaviour
+within a backed surface is tuned by the L2 qualifiers passed to ``__init__``.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections.abc import Mapping
+from dataclasses import replace
+from datetime import UTC, datetime
+
+from isvtest.core.storage_provider.api import (
+    API_VERSION,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_USER_QUOTA_SET,
+    QUAL_BYTE_GRANULARITY,
+    QUAL_DEFAULT_USER_SLOT,
+    QUAL_ID_ASSIGNMENT,
+    QUAL_INODES,
+    QUAL_MULTI_PATH_BINDING,
+    AuthenticationError,
+    ConflictError,
+    CreateVolumeRequest,
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DeleteVolumeRequest,
+    DirectoryQuota,
+    GetTenantQuotaRequest,
+    Implementation,
+    ImplementationCapabilities,
+    ListDirectoryQuotasRequest,
+    ListDirectoryQuotasResponse,
+    ListTenantQuotasRequest,
+    ListTenantQuotasResponse,
+    ListTenantsRequest,
+    ListTenantsResponse,
+    ListUserQuotasRequest,
+    ListUserQuotasResponse,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    NotFoundError,
+    NotSupportedError,
+    ProviderProperties,
+    QuotaExceededError,
+    QuotaLimits,
+    QuotaUsage,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    TagFilter,
+    Tenant,
+    TenantQuota,
+    UserQuota,
+    ValidationError,
+    VersionMetadata,
+    Volume,
+    _resolve_qualifiers,
+)
+
+
+def default_mock_core() -> ProviderProperties:
+    """VAST-shape default core for the mock (identity only; caps are derived)."""
+    return ProviderProperties(
+        provider_namespace="mock.nvidia.com",
+        provider_id="mock",
+        provider_metadata=VersionMetadata(vendor_name="NVIDIA", name="Mock", version="0.1.0"),
+        sdk_version=API_VERSION,
+        storage_type="file",
+        storage_protocols=["mock"],
+    )
+
+
+def _normalize_quota_hard(
+    hard: QuotaLimits | None,
+    *,
+    byte_granularity: int | None,
+    inodes_supported: bool,
+) -> QuotaLimits | None:
+    """Apply the backend's storage rules to caller-supplied ``hard`` caps.
+
+    * ``byte_granularity`` (when non-None) ceil-rounds ``hard.bytes`` to the
+      declared alignment so the returned DTO reflects the actual stored value.
+    * ``hard.inodes`` is dropped to ``None`` when the backend does not support an
+      inode dimension.
+    """
+    if hard is None:
+        return None
+    bytes_value = hard.bytes
+    if bytes_value is not None and byte_granularity is not None:
+        bytes_value = ((bytes_value + byte_granularity - 1) // byte_granularity) * byte_granularity
+    inodes_value = hard.inodes if inodes_supported else None
+    return QuotaLimits(bytes=bytes_value, inodes=inodes_value)
+
+
+def _tag_matches(tags: Mapping[str, str], f: TagFilter) -> bool:
+    if f.key not in tags:
+        return False
+    if not f.values:
+        return True
+    return tags[f.key] in f.values
+
+
+class _MockCore(Implementation):
+    """Required core + tenant + volume surfaces, with the in-memory state.
+
+    The quota surfaces live in the mixins so a test can compose a mock that does
+    not back them (their methods then fall back to the base raise).
+    """
+
+    def __init__(
+        self,
+        *,
+        tenant_id: str = "mock-tenant",
+        tenant_name: str = "mock tenant",
+        hard_limit_bytes: int = 100 * 1024**3,
+        healthy: bool = True,
+        core: ProviderProperties | None = None,
+        qualifiers: Mapping[str, Mapping[str, str]] | None = None,
+    ) -> None:
+        self._core = core or default_mock_core()
+        self._qualifiers = {k: dict(v) for k, v in (qualifiers or {}).items()}
+        self._default_tenant = tenant_id
+        self._tenant_name = tenant_name
+        self._hard_limit_bytes = hard_limit_bytes
+        self.healthy = healthy
+        if self._dir_qual(QUAL_MULTI_PATH_BINDING, "false") == "true":
+            raise NotImplementedError(
+                "MockStorageApi does not yet implement "
+                "QUAL_MULTI_PATH_BINDING='true'; leave it unset or subclass to "
+                "add the multi-binding semantics your test needs."
+            )
+        self._volumes: dict[str, Volume] = {}
+        self._directory_quotas: dict[tuple[str, str], list[DirectoryQuota]] = {}
+        self._user_quotas: dict[tuple[str, str], dict[str | None, UserQuota]] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Capability / qualifier helpers (read off the composed properties())
+    # ------------------------------------------------------------------
+
+    def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+        # Re-express the dict-shaped qualifiers this mock was built with onto the
+        # typed write view. A group id (e.g. ``quota.directory``) fans down to its
+        # leaves the same way ``_resolve_qualifiers`` does when composing.
+        for node_id, kv in self._qualifiers.items():
+            node = caps.get(node_id)
+            for key, value in kv.items():
+                node.set_qualifier(key, value)
+
+    def backend_metadata(self) -> VersionMetadata | None:
+        return self._core.backend_metadata
+
+    def _qual(self, cap_id: str, key: str, default: str | None) -> str | None:
+        # Resolve group-inherited qualifiers the same way properties() does.
+        return _resolve_qualifiers(self._qualifiers, cap_id).get(key, default)
+
+    def _dir_qual(self, key: str, default: str | None) -> str | None:
+        return self._qual(CAP_DIRECTORY_QUOTA_SET, key, default)
+
+    def _user_qual(self, key: str, default: str | None) -> str | None:
+        return self._qual(CAP_USER_QUOTA_SET, key, default)
+
+    @staticmethod
+    def _byte_granularity(value: str | None) -> int | None:
+        return int(value) if value else None
+
+    def _resolve_tenant(self, tenant_id: str | None) -> str:
+        resolved = tenant_id or self._default_tenant
+        if resolved != self._default_tenant:
+            raise NotFoundError(f"tenant {resolved!r} not found (mock has only {self._default_tenant!r})")
+        return resolved
+
+    # ------------------------------------------------------------------
+    # Required core
+    # ------------------------------------------------------------------
+
+    def health_check(self) -> None:
+        if not self.healthy:
+            raise AuthenticationError("mock backend marked unhealthy")
+
+    def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+        tenant = Tenant(id=self._default_tenant, name=self._tenant_name)
+        if not req.ids:
+            return ListTenantsResponse(tenants=(tenant,))
+        wanted = set(req.ids)
+        return ListTenantsResponse(tenants=(tenant,) if tenant.id in wanted else ())
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        resolved = self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            used = sum(v.size_bytes for v in self._volumes.values() if v.tenant_id == resolved)
+        return TenantQuota(
+            tenant_id=resolved,
+            hard_limit_bytes=self._hard_limit_bytes,
+            used_bytes=used,
+            name=self._tenant_name,
+        )
+
+    def list_tenant_quotas(self, req: ListTenantQuotasRequest) -> ListTenantQuotasResponse:
+        # Untiered backend: a single aggregate entry, equivalent to get_tenant_quota.
+        quota = self.get_tenant_quota(GetTenantQuotaRequest(tenant_id=req.tenant_id))
+        return ListTenantQuotasResponse(tenant_quotas=(quota,))
+
+    # ------------------------------------------------------------------
+    # Volumes
+    # ------------------------------------------------------------------
+
+    def create_volume(self, req: CreateVolumeRequest) -> Volume:
+        resolved = self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            used = sum(v.size_bytes for v in self._volumes.values() if v.tenant_id == resolved)
+            if used + req.size_bytes > self._hard_limit_bytes:
+                raise QuotaExceededError(
+                    f"create_volume would exceed tenant quota: {used + req.size_bytes} > {self._hard_limit_bytes}"
+                )
+            volume = Volume(
+                tenant_id=resolved,
+                id=f"vol-{uuid.uuid4().hex[:12]}",
+                size_bytes=req.size_bytes,
+                created_at=datetime.now(UTC),
+                type=req.volume_type,
+                state="available",
+                name=req.name,
+                tier=req.tier,
+                tags=dict(req.tags or {}),
+                used_bytes=0,
+                available_bytes=req.size_bytes,
+            )
+            self._volumes[volume.id] = volume
+            return volume
+
+    def delete_volume(self, req: DeleteVolumeRequest) -> None:
+        self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            self._volumes.pop(req.volume_id, None)
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        resolved = self._resolve_tenant(req.tenant_id)
+        wanted_ids = set(req.ids) if req.ids else None
+        filters = list(req.tag_filters)
+        with self._lock:
+            volumes = list(self._volumes.values())
+        result: list[Volume] = []
+        for vol in volumes:
+            if vol.tenant_id != resolved:
+                continue
+            if wanted_ids is not None and vol.id not in wanted_ids:
+                continue
+            if not all(_tag_matches(vol.tags, f) for f in filters):
+                continue
+            result.append(vol)
+        return ListVolumesResponse(volumes=tuple(result))
+
+
+class _DirectoryQuotaSetOnlyMixin:
+    """``set`` + ``delete`` directory-quota surfaces (Lustre-shape: no list)."""
+
+    def set_directory_quota(self: _MockCore, req: SetDirectoryQuotaRequest) -> DirectoryQuota:
+        quota = req.quota
+        resolved = self._resolve_tenant(quota.tenant_id)
+        id_assignment = self._dir_qual(QUAL_ID_ASSIGNMENT, "backend")
+
+        if id_assignment == "caller" and quota.id is None:
+            raise ValidationError("directory quota id is required when id_assignment='caller'")
+        if id_assignment == "backend" and quota.path is None:
+            raise ValidationError("directory quota path is required when id_assignment='backend'")
+
+        new_hard = _normalize_quota_hard(
+            quota.hard,
+            byte_granularity=self._byte_granularity(self._dir_qual(QUAL_BYTE_GRANULARITY, None)),
+            inodes_supported=self._dir_qual(QUAL_INODES, "true") != "false",
+        )
+        natural_attr = "id" if id_assignment == "caller" else "path"
+        natural_value = getattr(quota, natural_attr)
+
+        with self._lock:
+            records = self._directory_quotas.setdefault((resolved, quota.volume_id), [])
+            match_idx = next(
+                (i for i, r in enumerate(records) if getattr(r, natural_attr) == natural_value),
+                None,
+            )
+            if id_assignment == "backend" and quota.id is None:
+                new_id = records[match_idx].id if match_idx is not None else f"dq-{uuid.uuid4().hex[:8]}"
+            else:
+                new_id = quota.id
+            stored = replace(
+                quota,
+                tenant_id=resolved,
+                id=new_id,
+                hard=new_hard,
+                usage=QuotaUsage(),
+                attributes=dict(quota.attributes),
+            )
+            if match_idx is not None:
+                records[match_idx] = stored
+            else:
+                records.append(stored)
+            return stored
+
+    def delete_directory_quota(self: _MockCore, req: DeleteDirectoryQuotaRequest) -> None:
+        if req.path is None and req.id is None:
+            raise ValidationError("delete_directory_quota requires at least one of `path` or `id`")
+        resolved = self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            records = self._directory_quotas.get((resolved, req.volume_id))
+            if not records:
+                return
+            # Scan the whole list so a full match always wins over a partial
+            # (one-key) disagreement regardless of order.
+            full_idx: int | None = None
+            partial: DirectoryQuota | None = None
+            for i, r in enumerate(records):
+                path_match = req.path is None or r.path == req.path
+                id_match = req.id is None or r.id == req.id
+                if path_match and id_match:
+                    full_idx = i
+                    break
+                if req.path is not None and req.id is not None and (r.path == req.path or r.id == req.id):
+                    partial = r
+            if full_idx is not None:
+                del records[full_idx]
+                return
+            if partial is not None:
+                raise ConflictError(
+                    f"directory quota lookup mismatch on volume {req.volume_id!r}: "
+                    f"requested path={req.path!r}, id={req.id!r}; "
+                    f"found path={partial.path!r}, id={partial.id!r}"
+                )
+
+
+class _DirectoryQuotaMixin(_DirectoryQuotaSetOnlyMixin):
+    """Full directory-quota surface (list + the default-delegated get + set/delete)."""
+
+    def list_directory_quotas(self: _MockCore, req: ListDirectoryQuotasRequest) -> ListDirectoryQuotasResponse:
+        resolved = self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            return ListDirectoryQuotasResponse(
+                directory_quotas=tuple(self._directory_quotas.get((resolved, req.volume_id), []))
+            )
+
+
+class _UserQuotaSetOnlyMixin:
+    """``set`` + ``delete`` user-quota surfaces (Lustre-shape: no list)."""
+
+    def set_user_quota(self: _MockCore, req: SetUserQuotaRequest) -> UserQuota:
+        quota = req.quota
+        if quota.user is None and self._user_qual(QUAL_DEFAULT_USER_SLOT, "true") == "false":
+            raise NotSupportedError("default-user slot (user=None) not supported by this mock")
+        resolved = self._resolve_tenant(quota.tenant_id)
+
+        new_hard = _normalize_quota_hard(
+            quota.hard,
+            byte_granularity=self._byte_granularity(self._user_qual(QUAL_BYTE_GRANULARITY, None)),
+            inodes_supported=self._user_qual(QUAL_INODES, "true") != "false",
+        )
+        stored = replace(
+            quota,
+            tenant_id=resolved,
+            hard=new_hard,
+            usage=QuotaUsage(),
+            attributes=dict(quota.attributes),
+        )
+        with self._lock:
+            inner = self._user_quotas.setdefault((resolved, quota.volume_id), {})
+            inner[quota.user] = stored
+            return stored
+
+    def delete_user_quota(self: _MockCore, req: DeleteUserQuotaRequest) -> None:
+        if req.user is None and self._user_qual(QUAL_DEFAULT_USER_SLOT, "true") == "false":
+            raise NotSupportedError("default-user slot (user=None) not supported by this mock")
+        resolved = self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            inner = self._user_quotas.get((resolved, req.volume_id))
+            if inner is None:
+                return
+            inner.pop(req.user, None)
+
+
+class _UserQuotaMixin(_UserQuotaSetOnlyMixin):
+    """Full user-quota surface (list + the default-delegated get + set/delete)."""
+
+    def list_user_quotas(self: _MockCore, req: ListUserQuotasRequest) -> ListUserQuotasResponse:
+        resolved = self._resolve_tenant(req.tenant_id)
+        with self._lock:
+            return ListUserQuotasResponse(
+                user_quotas=tuple(self._user_quotas.get((resolved, req.volume_id), {}).values())
+            )
+
+
+class MockStorageApi(_DirectoryQuotaMixin, _UserQuotaMixin, _MockCore):
+    """Single-tenant in-memory ``StorageProvider`` for tests and templates.
+
+    Construct with ``MockStorageApi(tenant_id="t-1", hard_limit_bytes=...)`` to
+    populate the default tenant. Toggle ``healthy=False`` to make
+    ``health_check`` raise ``AuthenticationError``.
+
+    Backs both the directory- and user-quota surfaces (it mixes both in).
+    Pass ``qualifiers={CAP_GROUP_DIRECTORY_QUOTA: {QUAL_ID_ASSIGNMENT: "caller"}}``
+    to tune L2 semantic facts (id assignment, byte granularity, inode support,
+    default-user slot). A test that needs a backend WITHOUT a surface composes a
+    narrower mock from the mixins (e.g. ``class _NoDirectory(_UserQuotaMixin,
+    _MockCore)``) rather than toggling a flag - a surface whose method is absent
+    falls back to the base raise (``NotSupportedError``). The default is a
+    permissive VAST-shape: backend-assigned ids,
+    byte-exact granularity, inode dimension on, default-user slot on.
+    ``QUAL_MULTI_PATH_BINDING="true"`` is not implemented by this mock.
+    """

--- a/isvtest/src/isvtest/core/storage_provider/tests/__init__.py
+++ b/isvtest/src/isvtest/core/storage_provider/tests/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/isvtest/src/isvtest/core/storage_provider/tests/test_api.py
+++ b/isvtest/src/isvtest/core/storage_provider/tests/test_api.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``isvtest.core.storage_provider.api``.
+
+Cover ABC abstractness, the request/response surface defaults, the
+capability/qualifier model, the error taxonomy, and dataclass invariants. The
+``Implementation`` / ``new_implementation()`` composition is exercised in
+``test_provider.py``; the ``MockStorageApi`` exercise lives in ``test_mock.py``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_USER_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAPABILITY_IDS,
+    DEFAULT_INSTANCE_ID,
+    QUAL_ID_ASSIGNMENT,
+    AuthenticationError,
+    Capability,
+    ConflictError,
+    CreateVolumeRequest,
+    CsiSpec,
+    DeleteVolumeRequest,
+    DirectoryQuota,
+    GetDirectoryQuotaRequest,
+    GetTenantQuotaRequest,
+    GetTenantRequest,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    ListDirectoryQuotasRequest,
+    ListTenantQuotasRequest,
+    ListTenantsRequest,
+    ListTenantsResponse,
+    ListUserQuotasRequest,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    MountSpec,
+    NotFoundError,
+    NotSupportedError,
+    ProviderProperties,
+    QuotaExceededError,
+    QuotaLimits,
+    QuotaUsage,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    StorageApiError,
+    StorageProvider,
+    TagFilter,
+    Tenant,
+    TenantQuota,
+    UnavailableError,
+    UserQuota,
+    ValidationError,
+    VersionMetadata,
+    Volume,
+    instance_or_default,
+)
+
+
+def _all_caps() -> list[Capability]:
+    """Every registry id as a qualifier-free ``Capability`` entry (test data)."""
+    return [Capability(id=cid) for cid in CAPABILITY_IDS]
+
+
+def _props(**overrides) -> ProviderProperties:
+    """Minimal VAST-shape ProviderProperties for test fixtures (all caps present)."""
+    base = {
+        "provider_namespace": "test.nvidia.com",
+        "provider_id": "test",
+        "provider_metadata": VersionMetadata(vendor_name="NVIDIA", name="Test", version="0.1.0"),
+        "sdk_version": API_VERSION,
+        "storage_type": "file",
+        "storage_protocols": ["nfsv4"],
+        "_capability_list": _all_caps(),
+    }
+    base.update(overrides)
+    return ProviderProperties(**base)
+
+
+def _cap(props: ProviderProperties, cap_id: str) -> Capability | None:
+    """The advertised ``Capability`` record for ``cap_id``, or ``None``."""
+    for cap in props.capabilities().raw_list():
+        if cap.id == cap_id:
+            return cap
+    return None
+
+
+class _Minimal(StorageProvider):
+    """Concrete shim implementing only the three required methods."""
+
+    def properties(self) -> ProviderProperties:
+        return _props()
+
+    def health_check(self) -> None:
+        return None
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        return TenantQuota(tenant_id=req.tenant_id or "t", hard_limit_bytes=1, used_bytes=0, name="n")
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        return ListVolumesResponse()
+
+
+class TestAbcSurface:
+    def test_api_version_is_v1alpha1(self) -> None:
+        assert API_VERSION == "v1alpha1"
+
+    def test_storage_api_cannot_be_instantiated_directly(self) -> None:
+        with pytest.raises(TypeError):
+            StorageProvider()  # type: ignore[abstract]
+
+    def test_subclass_missing_abstract_methods_cannot_instantiate(self) -> None:
+        class Incomplete(StorageProvider):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_minimal_concrete_subclass_can_instantiate(self) -> None:
+        api = _Minimal()
+        api.health_check()
+        assert api.properties().provider_metadata.name == "Test"
+        assert api.get_tenant_quota(GetTenantQuotaRequest(tenant_id="t")).hard_limit_bytes == 1
+        assert api.list_volumes(ListVolumesRequest()).volumes == ()
+
+    def test_subclass_missing_properties_cannot_instantiate(self) -> None:
+        class NoProperties(StorageProvider):
+            def health_check(self) -> None:
+                return None
+
+            def get_tenant_quota(self, req):
+                return TenantQuota(tenant_id="t", hard_limit_bytes=1, used_bytes=0, name="n")
+
+            def list_volumes(self, req):
+                return ListVolumesResponse()
+
+        with pytest.raises(TypeError):
+            NoProperties()  # type: ignore[abstract]
+
+
+class TestOptionalMethodDefaults:
+    """The optional methods raise ``NotSupportedError`` by default."""
+
+    def test_list_tenants_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().list_tenants(ListTenantsRequest())
+
+    def test_get_tenant_default_raises_when_list_unsupported(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().get_tenant(GetTenantRequest(tenant_id="t"))
+
+    def test_create_volume_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().create_volume(CreateVolumeRequest(size_bytes=1, volume_type="file"))
+
+    def test_delete_volume_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().delete_volume(DeleteVolumeRequest(volume_id="vol-1"))
+
+    def test_get_volume_default_delegates_to_list_and_raises_not_found(self) -> None:
+        with pytest.raises(NotFoundError):
+            _Minimal().get_volume(GetVolumeRequest(volume_id="missing"))
+
+    def test_list_tenant_quotas_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().list_tenant_quotas(ListTenantQuotasRequest())
+
+
+class TestGetTenantDefault:
+    """The default get_tenant resolves None only when the backend has one tenant."""
+
+    class _OneTenant(_Minimal):
+        def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+            tenants = (Tenant(id="only"),)
+            if req.ids:
+                tenants = tuple(t for t in tenants if t.id in set(req.ids))
+            return ListTenantsResponse(tenants=tenants)
+
+    class _TwoTenants(_Minimal):
+        def list_tenants(self, req: ListTenantsRequest) -> ListTenantsResponse:
+            tenants = (Tenant(id="a"), Tenant(id="b"))
+            if req.ids:
+                tenants = tuple(t for t in tenants if t.id in set(req.ids))
+            return ListTenantsResponse(tenants=tenants)
+
+    def test_none_returns_sole_tenant(self) -> None:
+        assert self._OneTenant().get_tenant(GetTenantRequest()).id == "only"
+
+    def test_none_with_multiple_tenants_is_ambiguous(self) -> None:
+        with pytest.raises(ValidationError):
+            self._TwoTenants().get_tenant(GetTenantRequest())
+
+    def test_explicit_id_matches(self) -> None:
+        assert self._TwoTenants().get_tenant(GetTenantRequest(tenant_id="b")).id == "b"
+
+    def test_explicit_unknown_id_raises_not_found(self) -> None:
+        with pytest.raises(NotFoundError):
+            self._TwoTenants().get_tenant(GetTenantRequest(tenant_id="nope"))
+
+
+class TestQuotaMethodDefaults:
+    """The directory- and user-quota methods raise by default."""
+
+    class _DirectoryListOnly(_Minimal):
+        def list_directory_quotas(self, req: ListDirectoryQuotasRequest):
+            from isvtest.core.storage_provider import ListDirectoryQuotasResponse
+
+            return ListDirectoryQuotasResponse(
+                directory_quotas=(
+                    DirectoryQuota(tenant_id="t", volume_id=req.volume_id, path="/a", id="1"),
+                    DirectoryQuota(tenant_id="t", volume_id=req.volume_id, path="/b", id="2"),
+                )
+            )
+
+    class _UserListOnly(_Minimal):
+        def list_user_quotas(self, req: ListUserQuotasRequest):
+            from isvtest.core.storage_provider import ListUserQuotasResponse
+
+            return ListUserQuotasResponse(
+                user_quotas=(
+                    UserQuota(tenant_id="t", volume_id=req.volume_id, user=None),
+                    UserQuota(tenant_id="t", volume_id=req.volume_id, user="1001"),
+                )
+            )
+
+    def test_list_directory_quotas_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().list_directory_quotas(ListDirectoryQuotasRequest(volume_id="v"))
+
+    def test_set_directory_quota_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().set_directory_quota(
+                SetDirectoryQuotaRequest(DirectoryQuota(tenant_id="t", volume_id="v", path="/a"))
+            )
+
+    def test_delete_directory_quota_default_raises(self) -> None:
+        from isvtest.core.storage_provider import DeleteDirectoryQuotaRequest
+
+        with pytest.raises(NotSupportedError):
+            _Minimal().delete_directory_quota(DeleteDirectoryQuotaRequest(volume_id="v", path="/a"))
+
+    def test_get_directory_quota_default_propagates_not_supported(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().get_directory_quota(GetDirectoryQuotaRequest(volume_id="v", path="/a"))
+
+    def test_get_directory_quota_default_requires_path_or_id(self) -> None:
+        with pytest.raises(ValidationError):
+            self._DirectoryListOnly().get_directory_quota(GetDirectoryQuotaRequest(volume_id="v"))
+
+    def test_get_directory_quota_default_returns_match_via_list(self) -> None:
+        q = self._DirectoryListOnly().get_directory_quota(GetDirectoryQuotaRequest(volume_id="v", path="/a"))
+        assert q.path == "/a"
+        assert q.id == "1"
+
+    def test_get_directory_quota_default_raises_not_found(self) -> None:
+        with pytest.raises(NotFoundError):
+            self._DirectoryListOnly().get_directory_quota(GetDirectoryQuotaRequest(volume_id="v", path="/missing"))
+
+    def test_get_directory_quota_default_raises_conflict_on_key_disagreement(self) -> None:
+        with pytest.raises(ConflictError):
+            self._DirectoryListOnly().get_directory_quota(GetDirectoryQuotaRequest(volume_id="v", path="/a", id="2"))
+
+    def test_list_user_quotas_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().list_user_quotas(ListUserQuotasRequest(volume_id="v"))
+
+    def test_set_user_quota_default_raises(self) -> None:
+        with pytest.raises(NotSupportedError):
+            _Minimal().set_user_quota(SetUserQuotaRequest(UserQuota(tenant_id="t", volume_id="v", user="1001")))
+
+    def test_get_user_quota_default_returns_match_via_list(self) -> None:
+        q = self._UserListOnly().get_user_quota(GetUserQuotaRequest(volume_id="v", user="1001"))
+        assert q.user == "1001"
+
+    def test_get_user_quota_default_returns_default_user_slot(self) -> None:
+        q = self._UserListOnly().get_user_quota(GetUserQuotaRequest(volume_id="v", user=None))
+        assert q.user is None
+
+    def test_get_user_quota_default_raises_not_found(self) -> None:
+        with pytest.raises(NotFoundError):
+            self._UserListOnly().get_user_quota(GetUserQuotaRequest(volume_id="v", user="missing"))
+
+
+class TestCapabilityModel:
+    """``Capability`` carries the merged state + L2 qualifiers; read via ``capabilities()``."""
+
+    def test_capability_lookup_and_by_id(self) -> None:
+        props = _props(_capability_list=[Capability(id=CAP_USER_QUOTA_SET)])
+        cap = _cap(props, CAP_USER_QUOTA_SET)
+        assert cap is not None and cap.id == CAP_USER_QUOTA_SET
+        assert {c.id for c in props.capabilities().raw_list()} == {CAP_USER_QUOTA_SET}
+
+    def test_capability_absent_returns_none(self) -> None:
+        props = _props(_capability_list=[])
+        assert _cap(props, CAP_USER_QUOTA_SET) is None
+
+    def test_capability_carries_qualifiers(self) -> None:
+        props = _props(
+            _capability_list=[Capability(id=CAP_DIRECTORY_QUOTA_SET, qualifiers={QUAL_ID_ASSIGNMENT: "caller"})]
+        )
+        cap = _cap(props, CAP_DIRECTORY_QUOTA_SET)
+        assert cap is not None
+        assert cap.qualifiers[QUAL_ID_ASSIGNMENT] == "caller"
+
+
+class TestInstanceOrDefault:
+    def test_instance_or_default_helper(self) -> None:
+        assert instance_or_default("") == DEFAULT_INSTANCE_ID
+        assert instance_or_default("x") == "x"
+
+
+class TestErrorTaxonomy:
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            AuthenticationError,
+            ConflictError,
+            NotFoundError,
+            NotSupportedError,
+            QuotaExceededError,
+            UnavailableError,
+            ValidationError,
+        ],
+    )
+    def test_concrete_errors_are_storage_api_errors(self, exc_cls: type[Exception]) -> None:
+        assert issubclass(exc_cls, StorageApiError)
+        with pytest.raises(StorageApiError):
+            raise exc_cls("boom")
+
+
+class TestValueTypeInvariants:
+    """All shim value types are frozen dataclasses."""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            Tenant,
+            TenantQuota,
+            MountSpec,
+            CsiSpec,
+            Volume,
+            TagFilter,
+            DirectoryQuota,
+            UserQuota,
+            QuotaLimits,
+            QuotaUsage,
+            ProviderProperties,
+            VersionMetadata,
+            Capability,
+        ],
+    )
+    def test_value_types_are_frozen_dataclasses(self, cls: type) -> None:
+        assert dataclasses.is_dataclass(cls)
+        assert cls.__dataclass_params__.frozen is True  # type: ignore[attr-defined]
+
+    def test_tag_filter_existence_check_default(self) -> None:
+        assert TagFilter(key="k").values == ()
+
+    def test_tenant_minimal_construction(self) -> None:
+        t = Tenant(id="t-1")
+        assert t.id == "t-1"
+        assert t.name is None
+        assert t.attributes == {}
+
+    def test_tenant_quota_tier_and_id_default_unset(self) -> None:
+        q = TenantQuota(tenant_id="t", hard_limit_bytes=1, used_bytes=0, name="n")
+        assert q.tier is None
+        assert q.id == ""
+        tiered = TenantQuota(
+            tenant_id="t",
+            hard_limit_bytes=1,
+            used_bytes=0,
+            name="n",
+            tier="PERSISTENT_2",
+            id="q-1",
+        )
+        assert tiered.tier == "PERSISTENT_2"
+        assert tiered.id == "q-1"
+
+    def test_quota_limits_and_usage_default_to_unset(self) -> None:
+        assert QuotaLimits().bytes is None
+        assert QuotaLimits().inodes is None
+        assert QuotaLimits(bytes=1024, inodes=10).bytes == 1024
+        assert QuotaUsage().bytes is None
+
+    def test_directory_quota_construction(self) -> None:
+        q = DirectoryQuota(tenant_id="t", volume_id="v", path="/exports/a", id="42", hard=QuotaLimits(bytes=1024**3))
+        assert q.path == "/exports/a"
+        assert q.id == "42"
+        assert q.hard is not None and q.hard.bytes == 1024**3
+        assert q.usage == QuotaUsage()
+
+    def test_user_quota_construction(self) -> None:
+        default_slot = UserQuota(tenant_id="t", volume_id="v", user=None)
+        assert default_slot.user is None
+        assert default_slot.hard is None
+
+    def test_provider_properties_requires_identity(self) -> None:
+        props = _props()
+        assert props.provider_namespace == "test.nvidia.com"
+        assert props.provider_id == "test"
+        assert props.provider_metadata.version == "0.1.0"
+        assert props.storage_protocols == ["nfsv4"]
+        assert _cap(props, CAP_VOLUME_CREATE) is not None
+
+    def test_version_metadata_defaults_empty(self) -> None:
+        vm = VersionMetadata()
+        assert vm.vendor_name == ""
+        assert vm.version == ""

--- a/isvtest/src/isvtest/core/storage_provider/tests/test_loader.py
+++ b/isvtest/src/isvtest/core/storage_provider/tests/test_loader.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``isvtest.core.storage_provider.loader.build_api_from_path``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from isvtest.core.storage_provider import (
+    MockStorageApi,
+    ShimLoadError,
+    StorageProvider,
+    build_api_from_path,
+)
+
+
+def _write_shim(tmp_path: Path, body: str, filename: str = "api.py") -> Path:
+    """Write a temporary shim module for loader tests."""
+    shim = tmp_path / filename
+    shim.write_text(body)
+    return shim
+
+
+class TestBuildApiFromPath:
+    """Tests for BuildApiFromPath."""
+
+    def test_loads_mock_storage_api(self, tmp_path: Path) -> None:
+        """Verify loads mock storage api."""
+        shim = _write_shim(
+            tmp_path,
+            "from isvtest.core.storage_provider import MockStorageApi\n"
+            "def build_api():\n"
+            "    return MockStorageApi(tenant_id='unit-test')\n",
+        )
+        api = build_api_from_path(shim)
+        assert isinstance(api, StorageProvider)
+        assert isinstance(api, MockStorageApi)
+        api.health_check()
+
+    def test_missing_file_raises_shim_load_error(self, tmp_path: Path) -> None:
+        """Verify missing file raises shim load error."""
+        with pytest.raises(ShimLoadError, match="not found"):
+            build_api_from_path(tmp_path / "nope.py")
+
+    def test_missing_build_api_callable_raises(self, tmp_path: Path) -> None:
+        """Verify missing build api callable raises."""
+        shim = _write_shim(tmp_path, "x = 1\n")
+        with pytest.raises(ShimLoadError, match="build_api"):
+            build_api_from_path(shim)
+
+    def test_non_storageapi_return_raises(self, tmp_path: Path) -> None:
+        """Verify non storageapi return raises."""
+        shim = _write_shim(
+            tmp_path,
+            "def build_api():\n    return object()\n",
+        )
+        with pytest.raises(ShimLoadError, match="expected a StorageProvider subclass"):
+            build_api_from_path(shim)
+
+    def test_build_api_exception_is_wrapped(self, tmp_path: Path) -> None:
+        """Verify build api exception is wrapped."""
+        shim = _write_shim(
+            tmp_path,
+            "def build_api():\n    raise RuntimeError('boom')\n",
+        )
+        with pytest.raises(ShimLoadError, match="boom"):
+            build_api_from_path(shim)
+
+    def test_module_import_exception_is_wrapped(self, tmp_path: Path) -> None:
+        """Verify module import exception is wrapped."""
+        shim = _write_shim(tmp_path, "raise ImportError('cannot import')\n")
+        with pytest.raises(ShimLoadError, match="cannot import"):
+            build_api_from_path(shim)
+
+    def test_repeated_loads_get_independent_modules(self, tmp_path: Path) -> None:
+        """Verify repeated loads get independent modules."""
+        shim = _write_shim(
+            tmp_path,
+            "from isvtest.core.storage_provider import MockStorageApi\ndef build_api():\n    return MockStorageApi()\n",
+        )
+        api_a = build_api_from_path(shim)
+        api_b = build_api_from_path(shim)
+        assert api_a is not api_b
+
+    def test_attributes_forwarded_when_factory_opts_in(self, tmp_path: Path) -> None:
+        """Verify attributes forwarded when factory opts in."""
+        shim = _write_shim(
+            tmp_path,
+            "from isvtest.core.storage_provider import MockStorageApi\n"
+            "def build_api(attributes=None):\n"
+            "    return MockStorageApi(tenant_id=(attributes or {}).get('tenant', 'fallback'))\n",
+        )
+        api = build_api_from_path(shim, attributes={"tenant": "from-manifest"})
+        assert api._default_tenant == "from-manifest"
+
+    def test_attributes_ignored_for_no_arg_factory(self, tmp_path: Path) -> None:
+        """Verify attributes ignored for no arg factory."""
+        shim = _write_shim(
+            tmp_path,
+            "from isvtest.core.storage_provider import MockStorageApi\n"
+            "def build_api():\n    return MockStorageApi(tenant_id='no-arg')\n",
+        )
+        api = build_api_from_path(shim, attributes={"tenant": "ignored"})
+        assert api._default_tenant == "no-arg"

--- a/isvtest/src/isvtest/core/storage_provider/tests/test_mock.py
+++ b/isvtest/src/isvtest/core/storage_provider/tests/test_mock.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end exercise of ``MockStorageApi`` against the request/response surface."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from isvtest.core.storage_provider import (
+    CAP_GROUP_DIRECTORY_QUOTA,
+    CAP_GROUP_USER_QUOTA,
+    QUAL_BYTE_GRANULARITY,
+    QUAL_DEFAULT_USER_SLOT,
+    QUAL_ID_ASSIGNMENT,
+    QUAL_INODES,
+    QUAL_MULTI_PATH_BINDING,
+    AuthenticationError,
+    ConflictError,
+    CreateVolumeRequest,
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DeleteVolumeRequest,
+    DirectoryQuota,
+    GetDirectoryQuotaRequest,
+    GetTenantQuotaRequest,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    ListDirectoryQuotasRequest,
+    ListTenantQuotasRequest,
+    ListUserQuotasRequest,
+    ListVolumesRequest,
+    MockStorageApi,
+    NotFoundError,
+    NotSupportedError,
+    QuotaExceededError,
+    QuotaLimits,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    TagFilter,
+    UserQuota,
+    ValidationError,
+)
+from isvtest.core.storage_provider.mock import (
+    _DirectoryQuotaMixin,
+    _DirectoryQuotaSetOnlyMixin,
+    _MockCore,
+    _UserQuotaMixin,
+    _UserQuotaSetOnlyMixin,
+)
+
+
+class _MockNoDirectoryQuota(_UserQuotaMixin, _MockCore):
+    """Mock backend that backs user quotas but no directory quotas at all."""
+
+
+class _MockDirectorySetOnly(_DirectoryQuotaSetOnlyMixin, _UserQuotaMixin, _MockCore):
+    """Lustre-shape directory quotas: set/delete but no enumeration (list)."""
+
+
+class _MockNoUserQuota(_DirectoryQuotaMixin, _MockCore):
+    """Mock backend that backs directory quotas but no user quotas at all."""
+
+
+class _MockUserSetOnly(_DirectoryQuotaMixin, _UserQuotaSetOnlyMixin, _MockCore):
+    """Lustre-shape user quotas: set/delete but no enumeration (list)."""
+
+
+def _dir_quals(**kv: str) -> dict[str, dict[str, str]]:
+    """Build directory-quota qualifier test data."""
+    return {CAP_GROUP_DIRECTORY_QUOTA: dict(kv)}
+
+
+def _user_quals(**kv: str) -> dict[str, dict[str, str]]:
+    """Build user-quota qualifier test data."""
+    return {CAP_GROUP_USER_QUOTA: dict(kv)}
+
+
+class TestMockStorageApi:
+    """Tests for MockStorageApi."""
+
+    def test_health_check_passes_by_default(self) -> None:
+        """Verify health check passes by default."""
+        MockStorageApi().health_check()
+
+    def test_health_check_raises_when_unhealthy(self) -> None:
+        """Verify health check raises when unhealthy."""
+        api = MockStorageApi(healthy=False)
+        with pytest.raises(AuthenticationError):
+            api.health_check()
+
+    def test_create_volume_round_trip(self) -> None:
+        """Verify create volume round trip."""
+        api = MockStorageApi(tenant_id="t-1", hard_limit_bytes=10 * 1024**3)
+        vol = api.create_volume(
+            CreateVolumeRequest(
+                size_bytes=1024**3,
+                volume_type="file",
+                name="probe-1",
+                tags={"isvtest-run-id": "abc"},
+            )
+        )
+        assert vol.tenant_id == "t-1"
+        assert vol.id.startswith("vol-")
+        assert vol.state == "available"
+        assert vol.size_bytes == 1024**3
+        assert vol.name == "probe-1"
+        assert vol.tags == {"isvtest-run-id": "abc"}
+
+        fetched = api.get_volume(GetVolumeRequest(volume_id=vol.id))
+        assert fetched.id == vol.id
+
+    def test_tenant_quota_reflects_provisioned_volumes(self) -> None:
+        """Verify tenant quota reflects provisioned volumes."""
+        api = MockStorageApi(tenant_id="t-1", hard_limit_bytes=10 * 1024**3)
+        assert api.get_tenant_quota(GetTenantQuotaRequest()).used_bytes == 0
+
+        api.create_volume(CreateVolumeRequest(size_bytes=2 * 1024**3, volume_type="block"))
+        api.create_volume(CreateVolumeRequest(size_bytes=3 * 1024**3, volume_type="block"))
+        quota = api.get_tenant_quota(GetTenantQuotaRequest())
+        assert quota.tenant_id == "t-1"
+        assert quota.hard_limit_bytes == 10 * 1024**3
+        assert quota.used_bytes == 5 * 1024**3
+
+    def test_list_tenant_quotas_returns_single_untiered_entry(self) -> None:
+        """Verify list tenant quotas returns single untiered entry."""
+        api = MockStorageApi(tenant_id="t-1", hard_limit_bytes=10 * 1024**3)
+        resp = api.list_tenant_quotas(ListTenantQuotasRequest())
+        assert len(resp.tenant_quotas) == 1
+        only = resp.tenant_quotas[0]
+        assert only.tenant_id == "t-1"
+        assert only.tier is None
+
+    def test_delete_volume_is_idempotent(self) -> None:
+        """Verify delete volume is idempotent."""
+        api = MockStorageApi()
+        vol = api.create_volume(CreateVolumeRequest(size_bytes=1024, volume_type="file"))
+        api.delete_volume(DeleteVolumeRequest(volume_id=vol.id))
+        api.delete_volume(DeleteVolumeRequest(volume_id=vol.id))
+        api.delete_volume(DeleteVolumeRequest(volume_id="never-existed"))
+
+        with pytest.raises(NotFoundError):
+            api.get_volume(GetVolumeRequest(volume_id=vol.id))
+
+    def test_list_volumes_honors_ids_filter(self) -> None:
+        """Verify list volumes honors ids filter."""
+        api = MockStorageApi()
+        v1 = api.create_volume(CreateVolumeRequest(size_bytes=1024, volume_type="file"))
+        api.create_volume(CreateVolumeRequest(size_bytes=1024, volume_type="file"))
+        result = api.list_volumes(ListVolumesRequest(ids=(v1.id,))).volumes
+        assert [v.id for v in result] == [v1.id]
+
+    def test_list_volumes_honors_tag_filters(self) -> None:
+        """Verify list volumes honors tag filters."""
+        api = MockStorageApi()
+        api.create_volume(CreateVolumeRequest(size_bytes=1024, volume_type="file", tags={"env": "dev"}))
+        v2 = api.create_volume(CreateVolumeRequest(size_bytes=1024, volume_type="file", tags={"env": "prod"}))
+
+        result = api.list_volumes(ListVolumesRequest(tag_filters=(TagFilter("env", ("prod",)),))).volumes
+        assert [v.id for v in result] == [v2.id]
+
+        # Existence filter (empty values tuple) matches both.
+        result = api.list_volumes(ListVolumesRequest(tag_filters=(TagFilter("env"),))).volumes
+        assert len(result) == 2
+
+        # Conjunction: missing key means no match.
+        result = api.list_volumes(ListVolumesRequest(tag_filters=(TagFilter("missing-key"),))).volumes
+        assert result == ()
+
+    def test_quota_exceeded_raised_on_over_provision(self) -> None:
+        """Verify quota exceeded raised on over provision."""
+        api = MockStorageApi(hard_limit_bytes=1024)
+        with pytest.raises(QuotaExceededError):
+            api.create_volume(CreateVolumeRequest(size_bytes=2048, volume_type="file"))
+
+    def test_unknown_tenant_raises_not_found(self) -> None:
+        """Verify unknown tenant raises not found."""
+        api = MockStorageApi(tenant_id="t-1")
+        with pytest.raises(NotFoundError):
+            api.get_tenant_quota(GetTenantQuotaRequest(tenant_id="t-other"))
+
+
+@pytest.fixture(params=["backend", "caller"])
+def directory_id_assignment(request: pytest.FixtureRequest) -> Literal["backend", "caller"]:
+    """Parametrize directory-quota tests over both id-assignment modes."""
+    return request.param
+
+
+def _new_directory_quota(
+    *,
+    id_assignment: Literal["backend", "caller"],
+    path: str = "projects/team-a",
+    id: str = "q1",  # noqa: A002 -- matches DirectoryQuota.id field name
+    hard: QuotaLimits | None = None,
+) -> DirectoryQuota:
+    """Build a ``DirectoryQuota`` populated correctly for the given id mode."""
+    return DirectoryQuota(
+        tenant_id="mock-tenant",
+        volume_id="v1",
+        path=path,
+        id=id if id_assignment == "caller" else None,
+        hard=hard,
+    )
+
+
+class TestMockDirectoryQuotas:
+    """Round-trip the directory-quota surface across both id-assignment modes."""
+
+    def test_set_get_list_delete_round_trip(self, directory_id_assignment: Literal["backend", "caller"]) -> None:
+        """Verify set get list delete round trip."""
+        api = MockStorageApi(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: directory_id_assignment}))
+        stored = api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                _new_directory_quota(
+                    id_assignment=directory_id_assignment,
+                    hard=QuotaLimits(bytes=1024, inodes=10),
+                )
+            )
+        )
+
+        if directory_id_assignment == "caller":
+            assert stored.id == "q1"
+        else:
+            assert stored.id is not None
+            assert stored.id.startswith("dq-")
+        assert stored.path == "projects/team-a"
+        assert stored.hard == QuotaLimits(bytes=1024, inodes=10)
+
+        fetched_by_path = api.get_directory_quota(GetDirectoryQuotaRequest(volume_id="v1", path="projects/team-a"))
+        assert fetched_by_path.id == stored.id
+
+        fetched_by_id = api.get_directory_quota(GetDirectoryQuotaRequest(volume_id="v1", id=stored.id))
+        assert fetched_by_id.path == "projects/team-a"
+
+        listed = api.list_directory_quotas(ListDirectoryQuotasRequest(volume_id="v1")).directory_quotas
+        assert [q.path for q in listed] == ["projects/team-a"]
+
+        api.delete_directory_quota(DeleteDirectoryQuotaRequest(volume_id="v1", path="projects/team-a"))
+        with pytest.raises(NotFoundError):
+            api.get_directory_quota(GetDirectoryQuotaRequest(volume_id="v1", path="projects/team-a"))
+
+    def test_set_caller_mode_requires_id(self) -> None:
+        """Verify set caller mode requires id."""
+        api = MockStorageApi(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: "caller"}))
+        with pytest.raises(ValidationError):
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(DirectoryQuota(tenant_id="mock-tenant", volume_id="v1", path="/a", id=None))
+            )
+
+    def test_set_backend_mode_requires_path(self) -> None:
+        """Verify set backend mode requires path."""
+        api = MockStorageApi(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: "backend"}))
+        with pytest.raises(ValidationError):
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(
+                    DirectoryQuota(tenant_id="mock-tenant", volume_id="v1", path=None, id="forced")
+                )
+            )
+
+    def test_set_backend_mode_reuses_id_on_update(self) -> None:
+        """Verify set backend mode reuses id on update."""
+        api = MockStorageApi(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: "backend"}))
+        first = api.set_directory_quota(
+            SetDirectoryQuotaRequest(_new_directory_quota(id_assignment="backend", hard=QuotaLimits(bytes=1024)))
+        )
+        second = api.set_directory_quota(
+            SetDirectoryQuotaRequest(_new_directory_quota(id_assignment="backend", hard=QuotaLimits(bytes=2048)))
+        )
+        assert first.id == second.id
+        assert second.hard == QuotaLimits(bytes=2048)
+
+    def test_byte_granularity_ceil_rounds(self, directory_id_assignment: Literal["backend", "caller"]) -> None:
+        """Verify byte granularity ceil rounds."""
+        api = MockStorageApi(
+            qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: directory_id_assignment, QUAL_BYTE_GRANULARITY: "1024"})
+        )
+        stored = api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                _new_directory_quota(id_assignment=directory_id_assignment, hard=QuotaLimits(bytes=1500))
+            )
+        )
+        assert stored.hard is not None
+        assert stored.hard.bytes == 2048
+
+    def test_inodes_unsupported_drops_inode_limit(self, directory_id_assignment: Literal["backend", "caller"]) -> None:
+        """Verify inodes unsupported drops inode limit."""
+        api = MockStorageApi(
+            qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: directory_id_assignment, QUAL_INODES: "false"})
+        )
+        stored = api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                _new_directory_quota(id_assignment=directory_id_assignment, hard=QuotaLimits(bytes=1024, inodes=42))
+            )
+        )
+        assert stored.hard == QuotaLimits(bytes=1024, inodes=None)
+
+    def test_delete_missing_record_is_noop(self, directory_id_assignment: Literal["backend", "caller"]) -> None:
+        """Verify delete missing record is noop."""
+        api = MockStorageApi(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: directory_id_assignment}))
+        api.delete_directory_quota(DeleteDirectoryQuotaRequest(volume_id="v1", path="/never-set"))
+
+    def test_delete_with_disagreeing_keys_raises_conflict(
+        self, directory_id_assignment: Literal["backend", "caller"]
+    ) -> None:
+        """Verify delete with disagreeing keys raises conflict."""
+        api = MockStorageApi(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: directory_id_assignment}))
+        stored = api.set_directory_quota(
+            SetDirectoryQuotaRequest(_new_directory_quota(id_assignment=directory_id_assignment))
+        )
+        with pytest.raises(ConflictError):
+            api.delete_directory_quota(
+                DeleteDirectoryQuotaRequest(volume_id="v1", path=stored.path, id="never-existed")
+            )
+
+    def test_surface_absent_raises(self) -> None:
+        # A backend without the directory-quota mixin leaves every
+        # directory-quota call falling through to the base raise.
+        """Verify surface absent raises."""
+        api = _MockNoDirectoryQuota()
+        with pytest.raises(NotSupportedError):
+            api.list_directory_quotas(ListDirectoryQuotasRequest(volume_id="v1"))
+        with pytest.raises(NotSupportedError):
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(DirectoryQuota(tenant_id="mock-tenant", volume_id="v1", path="/a"))
+            )
+        with pytest.raises(NotSupportedError):
+            api.delete_directory_quota(DeleteDirectoryQuotaRequest(volume_id="v1", path="/a"))
+
+    def test_list_unsupported_raises(self, directory_id_assignment: Literal["backend", "caller"]) -> None:
+        # Lustre-shape: set/delete present, list absent.
+        """Verify list unsupported raises."""
+        api = _MockDirectorySetOnly(qualifiers=_dir_quals(**{QUAL_ID_ASSIGNMENT: directory_id_assignment}))
+        with pytest.raises(NotSupportedError):
+            api.list_directory_quotas(ListDirectoryQuotasRequest(volume_id="v1"))
+
+    def test_multi_path_binding_rejected_at_construction(self) -> None:
+        """Verify multi path binding rejected at construction."""
+        with pytest.raises(NotImplementedError):
+            MockStorageApi(qualifiers=_dir_quals(**{QUAL_MULTI_PATH_BINDING: "true"}))
+
+
+class TestMockUserQuotas:
+    """Round-trip the user-quota surface."""
+
+    def test_set_get_list_delete_per_user(self) -> None:
+        """Verify set get list delete per user."""
+        api = MockStorageApi()
+        stored = api.set_user_quota(
+            SetUserQuotaRequest(
+                UserQuota(tenant_id="mock-tenant", volume_id="v1", user="1001", hard=QuotaLimits(bytes=512, inodes=5))
+            )
+        )
+        assert stored.user == "1001"
+        assert stored.hard == QuotaLimits(bytes=512, inodes=5)
+
+        fetched = api.get_user_quota(GetUserQuotaRequest(volume_id="v1", user="1001"))
+        assert fetched.user == "1001"
+
+        listed = api.list_user_quotas(ListUserQuotasRequest(volume_id="v1")).user_quotas
+        assert [q.user for q in listed] == ["1001"]
+
+        api.delete_user_quota(DeleteUserQuotaRequest(volume_id="v1", user="1001"))
+        with pytest.raises(NotFoundError):
+            api.get_user_quota(GetUserQuotaRequest(volume_id="v1", user="1001"))
+
+    def test_default_user_slot_round_trip(self) -> None:
+        """Verify default user slot round trip."""
+        api = MockStorageApi()
+        stored = api.set_user_quota(
+            SetUserQuotaRequest(
+                UserQuota(tenant_id="mock-tenant", volume_id="v1", user=None, hard=QuotaLimits(bytes=2048))
+            )
+        )
+        assert stored.user is None
+        fetched = api.get_user_quota(GetUserQuotaRequest(volume_id="v1", user=None))
+        assert fetched.user is None
+        api.delete_user_quota(DeleteUserQuotaRequest(volume_id="v1", user=None))
+        with pytest.raises(NotFoundError):
+            api.get_user_quota(GetUserQuotaRequest(volume_id="v1", user=None))
+
+    def test_default_user_unsupported_raises(self) -> None:
+        """Verify default user unsupported raises."""
+        api = MockStorageApi(qualifiers=_user_quals(**{QUAL_DEFAULT_USER_SLOT: "false"}))
+        with pytest.raises(NotSupportedError):
+            api.set_user_quota(SetUserQuotaRequest(UserQuota(tenant_id="mock-tenant", volume_id="v1", user=None)))
+        with pytest.raises(NotSupportedError):
+            api.delete_user_quota(DeleteUserQuotaRequest(volume_id="v1", user=None))
+
+    def test_surface_absent_raises(self) -> None:
+        """Verify surface absent raises."""
+        api = _MockNoUserQuota()
+        with pytest.raises(NotSupportedError):
+            api.list_user_quotas(ListUserQuotasRequest(volume_id="v1"))
+        with pytest.raises(NotSupportedError):
+            api.set_user_quota(SetUserQuotaRequest(UserQuota(tenant_id="mock-tenant", volume_id="v1", user="1001")))
+        with pytest.raises(NotSupportedError):
+            api.delete_user_quota(DeleteUserQuotaRequest(volume_id="v1", user="1001"))
+
+    def test_byte_granularity_ceil_rounds(self) -> None:
+        """Verify byte granularity ceil rounds."""
+        api = MockStorageApi(qualifiers=_user_quals(**{QUAL_BYTE_GRANULARITY: "1024"}))
+        stored = api.set_user_quota(
+            SetUserQuotaRequest(
+                UserQuota(tenant_id="mock-tenant", volume_id="v1", user="1001", hard=QuotaLimits(bytes=1500))
+            )
+        )
+        assert stored.hard is not None
+        assert stored.hard.bytes == 2048
+
+    def test_inodes_unsupported_drops_inode_limit(self) -> None:
+        """Verify inodes unsupported drops inode limit."""
+        api = MockStorageApi(qualifiers=_user_quals(**{QUAL_INODES: "false"}))
+        stored = api.set_user_quota(
+            SetUserQuotaRequest(
+                UserQuota(tenant_id="mock-tenant", volume_id="v1", user="1001", hard=QuotaLimits(bytes=1024, inodes=42))
+            )
+        )
+        assert stored.hard == QuotaLimits(bytes=1024, inodes=None)
+
+    def test_list_unsupported_raises(self) -> None:
+        # Lustre-shape: set/delete present, list absent.
+        """Verify list unsupported raises."""
+        api = _MockUserSetOnly()
+        with pytest.raises(NotSupportedError):
+            api.list_user_quotas(ListUserQuotasRequest(volume_id="v1"))

--- a/isvtest/src/isvtest/core/storage_provider/tests/test_provider.py
+++ b/isvtest/src/isvtest/core/storage_provider/tests/test_provider.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``Implementation`` / ``new_implementation()`` authoring model.
+
+Covers capability detection from the overridden method set, gating (a
+non-``supported`` surface raises the matching error), the default-tenant wrapper,
+and qualifier / runtime-state composition via the ``capability_qualifiers`` hook.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from isvtest.core.storage_provider import (
+    API_VERSION,
+    CAP_TENANT_GET_QUOTA,
+    CAP_TENANT_LIST,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_GET,
+    CAP_VOLUME_LIST,
+    QUAL_TIERED,
+    CreateVolumeRequest,
+    GetTenantQuotaRequest,
+    GetVolumeRequest,
+    Implementation,
+    ImplementationCapabilities,
+    ListVolumesRequest,
+    ListVolumesResponse,
+    NotFoundError,
+    NotSupportedError,
+    ProviderProperties,
+    TenantQuota,
+    UnavailableError,
+    VersionMetadata,
+    new_implementation,
+    with_default_tenant,
+)
+
+
+def _core() -> ProviderProperties:
+    return ProviderProperties(
+        provider_namespace="test.nvidia.com",
+        provider_id="test",
+        provider_metadata=VersionMetadata(vendor_name="NVIDIA", name="Test", version="0.1.0"),
+        sdk_version=API_VERSION,
+        storage_type="file",
+        storage_protocols=["nfsv4"],
+    )
+
+
+class _QuotaVolumeImpl(Implementation):
+    """Backs tenant-quota + volume read only (the managed-K8s shape)."""
+
+    def health_check(self) -> None:
+        return None
+
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        return TenantQuota(tenant_id=req.tenant_id or "", hard_limit_bytes=100, used_bytes=0, name="t")
+
+    def list_volumes(self, req: ListVolumesRequest) -> ListVolumesResponse:
+        return ListVolumesResponse()
+
+
+def _states(api) -> dict[str, str | None]:
+    return {cap.id: cap.state for cap in api.properties().capabilities().raw_list()}
+
+
+class TestDetection:
+    def test_overridden_methods_are_supported(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl())
+        states = _states(api)
+        assert states[CAP_TENANT_GET_QUOTA] == "supported"
+        assert states[CAP_VOLUME_LIST] == "supported"
+
+    def test_composite_getters_ride_their_list_sibling(self) -> None:
+        # volume.get is served because list_volumes is (base get_volume delegates).
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl())
+        assert _states(api)[CAP_VOLUME_GET] == "supported"
+
+    def test_unimplemented_methods_are_unimplemented(self) -> None:
+        states = _states(new_implementation(core=_core(), impl=_QuotaVolumeImpl()))
+        assert states[CAP_TENANT_LIST] == "unimplemented"
+        assert states[CAP_VOLUME_CREATE] == "unimplemented"
+
+
+class TestGating:
+    def test_unimplemented_surface_raises_not_supported(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl())
+        with pytest.raises(NotSupportedError, match="not implemented"):
+            api.create_volume(CreateVolumeRequest(size_bytes=1, volume_type="file"))
+
+    def test_supported_surface_answers(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl())
+        assert api.list_volumes(ListVolumesRequest()).volumes == ()
+        # The composite getter delegates through and surfaces the real miss.
+        with pytest.raises(NotFoundError):
+            api.get_volume(GetVolumeRequest(volume_id="missing"))
+
+    def test_config_override_disables_a_supported_surface(self) -> None:
+        api = new_implementation(
+            core=_core(),
+            impl=_QuotaVolumeImpl(),
+            configured_capability_overrides={CAP_VOLUME_LIST: False},
+        )
+        assert _states(api)[CAP_VOLUME_LIST] == "disabled"
+        with pytest.raises(NotSupportedError, match="disabled by configuration"):
+            api.list_volumes(ListVolumesRequest())
+
+    def test_config_override_cannot_resurrect_unimplemented(self) -> None:
+        # A config "enable" can flip disabled->supported but never conjure a
+        # surface the code does not serve.
+        api = new_implementation(
+            core=_core(),
+            impl=_QuotaVolumeImpl(),
+            configured_capability_overrides={CAP_VOLUME_CREATE: True},
+        )
+        assert _states(api)[CAP_VOLUME_CREATE] == "unimplemented"
+        with pytest.raises(NotSupportedError):
+            api.create_volume(CreateVolumeRequest(size_bytes=1, volume_type="file"))
+
+    def test_hook_narrows_supported_to_unavailable(self) -> None:
+        class _Impl(_QuotaVolumeImpl):
+            def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+                caps.volume().list().set_state("unavailable")
+
+        api = new_implementation(core=_core(), impl=_Impl())
+        assert _states(api)[CAP_VOLUME_LIST] == "unavailable"
+        with pytest.raises(UnavailableError, match="currently unavailable"):
+            api.list_volumes(ListVolumesRequest())
+
+    def test_hook_cannot_re_enable_unimplemented(self) -> None:
+        class _Impl(_QuotaVolumeImpl):
+            def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+                # More available than the detected state -> ignored.
+                caps.get(CAP_VOLUME_CREATE).set_state("supported")
+
+        api = new_implementation(core=_core(), impl=_Impl())
+        assert _states(api)[CAP_VOLUME_CREATE] == "unimplemented"
+
+
+class TestDefaultTenant:
+    def test_injects_default_when_unspecified(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl(), default_tenant="t-def")
+        assert api.get_tenant_quota(GetTenantQuotaRequest()).tenant_id == "t-def"
+
+    def test_preserves_explicit_tenant(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl(), default_tenant="t-def")
+        assert api.get_tenant_quota(GetTenantQuotaRequest(tenant_id="other")).tenant_id == "other"
+
+    def test_no_default_leaves_tenant_unset(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl(), default_tenant="")
+        # Not wrapped: the impl sees the request verbatim (tenant_id None -> "").
+        assert api.get_tenant_quota(GetTenantQuotaRequest()).tenant_id == ""
+
+    def test_with_default_tenant_is_noop_when_empty(self) -> None:
+        api = new_implementation(core=_core(), impl=_QuotaVolumeImpl())
+        assert with_default_tenant(api, "") is api
+
+
+class TestQualifierComposition:
+    def test_group_qualifier_inherits_to_leaf(self) -> None:
+        class _Impl(_QuotaVolumeImpl):
+            def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+                caps.tenant().set_tiered(True)
+
+        props = new_implementation(core=_core(), impl=_Impl()).properties()
+        caps = props.capabilities()
+        cap = caps.get_tenant_quota()
+        assert cap.qualifiers()[QUAL_TIERED] == "true"
+        assert caps.tenant().get_quota().tiered() is True
+
+    def test_qualifier_dropped_on_unimplemented_surface(self) -> None:
+        class _Impl(_QuotaVolumeImpl):
+            def capability_qualifiers(self, caps: ImplementationCapabilities) -> None:
+                # quota.directory is not served -> its qualifiers are cleared.
+                caps.quota().directory().set_inodes(True)
+
+        props = new_implementation(core=_core(), impl=_Impl()).properties()
+        tree = props.capabilities()
+        assert tree.quota().directory().set().state() == "unimplemented"

--- a/isvtest/src/isvtest/validations/storage_provider.py
+++ b/isvtest/src/isvtest/validations/storage_provider.py
@@ -1,0 +1,526 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``StorageProviderApiCheck`` - StorageProvider API contract conformity.
+
+Drives the tenant-level subset of the ``StorageProvider`` shim contract against
+each provider declared in the manifest: health-check / auth, volume
+provisioning, and tenant quota visibility. Maps to acceptance tests
+N-019/N-020/N-021. Subtests are namespaced by API area so this fixture can
+later be split into discovery/volume/quota-specific siblings without
+disturbing how callers select it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import ClassVar
+
+from isvtest.core.storage import (
+    ManifestError,
+    Provider,
+    load_provider_registry,
+)
+from isvtest.core.storage_provider import (
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_TENANT_GET,
+    CAP_TENANT_GET_QUOTA,
+    CAP_TENANT_LIST,
+    CAP_TENANT_LIST_QUOTAS,
+    CAP_USER_QUOTA_DELETE,
+    CAP_USER_QUOTA_GET,
+    CAP_USER_QUOTA_LIST,
+    CAP_USER_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_GET,
+    CAP_VOLUME_LIST,
+    AuthenticationError,
+    CreateVolumeRequest,
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DeleteVolumeRequest,
+    DirectoryQuota,
+    GetDirectoryQuotaRequest,
+    GetTenantQuotaRequest,
+    GetTenantRequest,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    ListDirectoryQuotasRequest,
+    ListTenantQuotasRequest,
+    ListTenantsRequest,
+    ListUserQuotasRequest,
+    ListVolumesRequest,
+    NotSupportedError,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    StorageProvider,
+    UserQuota,
+)
+from isvtest.core.validation import BaseValidation
+
+# A deliberately nonexistent identifier used by the capability probes below. A correct
+# shim rejects it (NotFoundError / ValidationError / ...) before mutating
+# anything, whereas a stub for an unimplemented surface raises the
+# not-implemented sentinel (NotSupportedError / NotImplementedError) regardless
+# of input. Only the sentinel is a contract violation under a ``supported`` claim.
+_PROBE_ID = "__isvtest_capability_probe__"
+_PROBE_PATH = "/__isvtest_capability_probe__"
+
+# How to invoke each capability so the manifest-consistency subtest can confirm a
+# surface the manifest declares ``supported`` actually answers (does not raise
+# the not-implemented sentinel). Reads use a sentinel resource id; writes use a
+# sentinel tenant so the call is refused before committing. volume.create /
+# volume.delete are exercised end-to-end (with cleanup) in volume-provisioning -
+# the only place those mutating calls are made - so they are not probed here.
+_CAPABILITY_PROBES: dict[str, Callable[[StorageProvider], object]] = {
+    CAP_TENANT_LIST: lambda api: api.list_tenants(ListTenantsRequest()),
+    CAP_TENANT_GET: lambda api: api.get_tenant(GetTenantRequest()),
+    CAP_TENANT_GET_QUOTA: lambda api: api.get_tenant_quota(GetTenantQuotaRequest()),
+    CAP_TENANT_LIST_QUOTAS: lambda api: api.list_tenant_quotas(ListTenantQuotasRequest()),
+    CAP_VOLUME_LIST: lambda api: api.list_volumes(ListVolumesRequest()),
+    CAP_VOLUME_GET: lambda api: api.get_volume(GetVolumeRequest(volume_id=_PROBE_ID)),
+    CAP_DIRECTORY_QUOTA_LIST: lambda api: api.list_directory_quotas(ListDirectoryQuotasRequest(volume_id=_PROBE_ID)),
+    CAP_DIRECTORY_QUOTA_GET: lambda api: api.get_directory_quota(
+        GetDirectoryQuotaRequest(volume_id=_PROBE_ID, path=_PROBE_PATH)
+    ),
+    CAP_DIRECTORY_QUOTA_SET: lambda api: api.set_directory_quota(
+        SetDirectoryQuotaRequest(DirectoryQuota(tenant_id=_PROBE_ID, volume_id=_PROBE_ID, path=_PROBE_PATH))
+    ),
+    CAP_DIRECTORY_QUOTA_DELETE: lambda api: api.delete_directory_quota(
+        DeleteDirectoryQuotaRequest(volume_id=_PROBE_ID, path=_PROBE_PATH)
+    ),
+    CAP_USER_QUOTA_LIST: lambda api: api.list_user_quotas(ListUserQuotasRequest(volume_id=_PROBE_ID)),
+    CAP_USER_QUOTA_GET: lambda api: api.get_user_quota(GetUserQuotaRequest(volume_id=_PROBE_ID, user=_PROBE_ID)),
+    CAP_USER_QUOTA_SET: lambda api: api.set_user_quota(
+        SetUserQuotaRequest(UserQuota(tenant_id=_PROBE_ID, volume_id=_PROBE_ID, user=_PROBE_ID))
+    ),
+    CAP_USER_QUOTA_DELETE: lambda api: api.delete_user_quota(
+        DeleteUserQuotaRequest(volume_id=_PROBE_ID, user=_PROBE_ID)
+    ),
+}
+
+
+class StorageProviderApiCheck(BaseValidation):
+    """Validate the ``StorageProvider`` API contract per provider.
+
+    Iterates every provider in the manifest that declares a ``shim:``
+    block and reports four namespaced subtests per provider:
+
+    * ``manifest-consistency[<name>]`` - the manifest is a contract: its
+      declared identity (``type`` / ``provider.protocols`` /
+      ``provider.version``) must match the running shim's ``properties()``, and
+      every capability it declares ``supported`` (the ``native`` / ``default`` /
+      ``none`` block lowered to ``cap_id -> supported?``) must actually answer
+      when probed - a surface that raises ``NotSupportedError`` /
+      ``NotImplementedError`` under a ``supported`` claim fails. Omitted claims
+      and ``none`` claims are not checked. ``volume.create`` / ``volume.delete``
+      are verified in volume-provisioning (the only place those calls are made).
+    * ``api-authentication[<name>]`` - ``health_check()``
+    * ``volume-provisioning[<name>]`` - ``create_volume`` + ``delete_volume``
+      Falls back to ``list_volumes`` and reports skipped when the
+      shim raises ``NotSupportedError`` (managed-K8s providers whose CSI driver
+      owns provisioning) - unless the ``volume.create`` capability declares
+      otherwise, in which case the mismatch fails.
+    * ``tenant-quota[<name>]`` - ``get_tenant_quota`` with non-zero
+      ``hard_limit_bytes`` (and ``tenant_id`` matching the manifest's
+      ``tenant_id`` when declared)
+
+    Skipped (passed) when the manifest is unset, missing providers, or
+    contains no providers with a shim block.
+
+    Config keys (with defaults):
+        manifest_path: Path to the provider manifest YAML. In K8s mode
+            this is the mounted ConfigMap file; in bare-metal mode it's
+            a path on the management host. Empty -> the check is skipped.
+        volume_size_bytes: Size requested by the volume
+            (default: 1 GiB).
+    """
+
+    description: ClassVar[str] = "Validate StorageProvider API contract"
+    timeout: ClassVar[int] = 300
+    labels: ClassVar[tuple[str, ...]] = ("storage", "storage_provider_api")
+
+    def run(self) -> None:
+        """Load the manifest and drive per provider."""
+        try:
+            providers = load_provider_registry(self.config)
+        except ManifestError as exc:
+            self.set_failed(f"Failed to load provider manifest: {exc}")
+            return
+
+        if not providers:
+            self.set_passed("Skipped: no provider manifest configured (manifest_path unset). ")
+            return
+
+        shim_providers = [p for p in providers if p.has_shim]
+        if not shim_providers:
+            rest_only = [p.name for p in providers if p.shim_kind == "rest"]
+            csi_only = [p.name for p in providers if p.shim_kind is None]
+            note: list[str] = []
+            if rest_only:
+                note.append(f"REST shims skipped: {', '.join(sorted(rest_only))}")
+            if csi_only:
+                note.append(f"CSI-only providers (no management API to test) skipped: {', '.join(sorted(csi_only))}")
+            self.set_passed(
+                "Skipped: no provider in the manifest declares a Python `shim:` block; " + "; ".join(note)
+                if note
+                else "Skipped: no provider in the manifest declares a Python `shim:` block."
+            )
+            return
+
+        run_id = str(self.config.get("run_id") or uuid.uuid4().hex[:12])
+        volume_size_bytes = int(self.config.get("volume_size_bytes") or (1 << 30))
+
+        any_failed = False
+        for provider in shim_providers:
+            if not self._exercise_provider(provider, run_id=run_id, volume_size_bytes=volume_size_bytes):
+                any_failed = True
+
+        if any_failed:
+            self.set_failed("One or more provider shim subtests failed; see subtest details")
+        else:
+            self.set_passed(f"Storage shim verified for {', '.join(sorted(p.name for p in shim_providers))} ")
+
+    def _exercise_provider(
+        self,
+        provider: Provider,
+        *,
+        run_id: str,
+        volume_size_bytes: int,
+    ) -> bool:
+        """Drive the storage management API against one provider. Return True when all subtests pass."""
+        tag = provider.name
+        api = provider.api
+        assert api is not None  # has_shim filter above guarantees this
+        ok = True
+
+        # manifest <-> shim contract: declared identity / capabilities must
+        # match the running shim's properties() (and safe read-only probes).
+        if not self._exercise_manifest_consistency(provider, tag=tag):
+            ok = False
+
+        # authentication / reachability.
+        try:
+            api.health_check()
+            self.report_subtest(
+                f"api-authentication[{tag}]",
+                passed=True,
+                message="health_check() ok",
+            )
+        except AuthenticationError as exc:
+            self.report_subtest(
+                f"api-authentication[{tag}]",
+                passed=False,
+                message=f"health_check() raised AuthenticationError: {exc}",
+            )
+            # Skip downstream subtests for this provider - they all need a
+            # working auth surface. Other providers may still pass.
+            self.report_subtest(
+                f"volume-provisioning[{tag}]",
+                passed=True,
+                skipped=True,
+                message="api-authentication failed; volume-provisioning skipped",
+            )
+            self.report_subtest(
+                f"tenant-quota[{tag}]",
+                passed=True,
+                skipped=True,
+                message="api-authentication failed; tenant-quota skipped",
+            )
+            return False
+        except Exception as exc:
+            self.report_subtest(
+                f"api-authentication[{tag}]",
+                passed=False,
+                message=f"health_check() raised {type(exc).__name__}: {exc}",
+            )
+            ok = False
+
+        # volume provisioning + cleanup.
+        if not self._exercise_volume_provisioning(
+            api,
+            tag=tag,
+            run_id=run_id,
+            volume_size_bytes=volume_size_bytes,
+            volume_type=provider.volume_type,
+            declared_create=provider.expected_capabilities.get(CAP_VOLUME_CREATE),
+        ):
+            ok = False
+
+        # tenant quota visible with non-zero hard limit.
+        if not self._exercise_tenant_quota(api, tag=tag, declared_tenant_id=provider.tenant_id):
+            ok = False
+
+        return ok
+
+    def _exercise_manifest_consistency(self, provider: Provider, *, tag: str) -> bool:
+        """Assert the manifest's declared identity/capabilities match the shim.
+
+        The manifest is a contract: a customer cannot declare values the running
+        shim does not back. Identity is cross-checked against ``properties()``;
+        every capability the manifest declares ``supported`` is probed at runtime
+        and fails if the shim raises ``NotSupportedError`` / ``NotImplementedError``
+        (any other error means the sentinel probe input was rejected, not the
+        surface). Claims the manifest omits, and ``none`` claims, are not checked.
+        ``create_volume`` / ``delete_volume`` are enforced in the
+        volume-provisioning subtest (the only place those calls are made).
+        """
+        api = provider.api
+        assert api is not None
+        try:
+            props = api.properties()
+        except Exception as exc:
+            self.report_subtest(
+                f"manifest-consistency[{tag}]",
+                passed=False,
+                message=f"properties() raised {type(exc).__name__}: {exc}",
+            )
+            return False
+
+        mismatches: list[str] = []
+
+        # Storage type is always known (manifest type / provider.type).
+        if props.storage_type != provider.volume_type:
+            mismatches.append(
+                f"storage_type: manifest={provider.volume_type!r} != shim.properties()={props.storage_type!r}"
+            )
+
+        # Wire protocols: every protocol the manifest declares must be advertised.
+        if provider.storage_protocols:
+            declared = {p.lower() for p in provider.storage_protocols}
+            advertised = {p.lower() for p in props.storage_protocols}
+            missing = declared - advertised
+            if missing:
+                mismatches.append(
+                    f"storage_protocols: manifest declares {sorted(declared)} but shim "
+                    f"advertises {sorted(advertised)} (missing {sorted(missing)})"
+                )
+
+        shim_version = props.provider_metadata.version if props.provider_metadata else None
+        if provider.provider_version is not None and str(provider.provider_version) != str(shim_version):
+            mismatches.append(f"provider.version: manifest={provider.provider_version!r} != shim={shim_version!r}")
+
+        # Capabilities: every surface the manifest declares ``supported`` must
+        # actually answer. Probe it live - a stub that raises the not-implemented
+        # sentinel under a ``supported`` claim is a contract violation (any other
+        # error means the sentinel probe input was rejected, not the surface).
+        for cap_id, probe in _CAPABILITY_PROBES.items():
+            if not provider.expected_capabilities.get(cap_id):
+                continue  # only enforce surfaces the manifest claims supported
+            try:
+                probe(api)
+            except (NotSupportedError, NotImplementedError) as exc:
+                mismatches.append(
+                    f"{cap_id}: manifest declares supported but the shim raised "
+                    f"{type(exc).__name__} when probed ({exc})"
+                )
+            except Exception:
+                # Non-sentinel error -> the surface is wired up; the deliberately
+                # the sentinel probe input was rejected, which is the expected outcome.
+                pass
+
+        if mismatches:
+            self.report_subtest(
+                f"manifest-consistency[{tag}]",
+                passed=False,
+                message="manifest disagrees with shim: " + "; ".join(mismatches),
+            )
+            return False
+
+        self.report_subtest(
+            f"manifest-consistency[{tag}]",
+            passed=True,
+            message=(
+                f"manifest matches shim (type={props.storage_type}, "
+                f"protocols={list(props.storage_protocols)}, version={shim_version})"
+            ),
+        )
+        return True
+
+    def _exercise_volume_provisioning(
+        self,
+        api: StorageProvider,
+        *,
+        tag: str,
+        run_id: str,
+        volume_size_bytes: int,
+        volume_type: str,
+        declared_create: bool | None = None,
+    ) -> bool:
+        """create + delete with NotSupportedError fallback to list_volumes.
+
+        When the manifest declares the ``volume.create`` capability, the
+        observed behavior must match: declaring ``true`` and getting
+        ``NotSupportedError`` (or declaring ``false`` and succeeding) is a
+        contract violation rather than the silent CSI-owns-lifecycle skip.
+        """
+        volume_name = f"isvtest-{run_id}-{tag}"
+        tags = {
+            "isvtest-run-id": run_id,
+            "provider": tag,
+            "test-case": "N-020",
+        }
+
+        try:
+            volume = api.create_volume(
+                CreateVolumeRequest(
+                    size_bytes=volume_size_bytes,
+                    volume_type=volume_type,  # type: ignore[arg-type]
+                    name=volume_name,
+                    tags=tags,
+                )
+            )
+        except NotSupportedError:
+            if declared_create:
+                self.report_subtest(
+                    f"volume-provisioning[{tag}]",
+                    passed=False,
+                    message=(
+                        "manifest volume.create=true but create_volume raised NotSupportedError (contract violation)"
+                    ),
+                )
+                return False
+            # Managed-K8s provider: CSI handles provisioning. Fall back
+            # to asserting at least one CSI-provisioned volume is visible
+            # (fallback path).
+            try:
+                existing = list(api.list_volumes(ListVolumesRequest()).volumes)
+            except Exception as exc:
+                self.report_subtest(
+                    f"volume-provisioning[{tag}]",
+                    passed=False,
+                    message=(f"create_volume not implemented and list_volumes() raised {type(exc).__name__}: {exc}"),
+                )
+                return False
+            self.report_subtest(
+                f"volume-provisioning[{tag}]",
+                passed=True,
+                skipped=True,
+                message=(
+                    f"create_volume not implemented; observed {len(existing)} "
+                    f"CSI-provisioned volume(s) via list_volumes()"
+                ),
+            )
+            return True
+        except Exception as exc:
+            self.report_subtest(
+                f"volume-provisioning[{tag}]",
+                passed=False,
+                message=f"create_volume raised {type(exc).__name__}: {exc}",
+            )
+            return False
+
+        try:
+            if declared_create is False:
+                self.report_subtest(
+                    f"volume-provisioning[{tag}]",
+                    passed=False,
+                    message=(
+                        "manifest volume.create=false but create_volume "
+                        f"succeeded (returned volume {volume.id}; contract violation)"
+                    ),
+                )
+                return False
+            if volume.state not in ("creating", "available"):
+                self.report_subtest(
+                    f"volume-provisioning[{tag}]",
+                    passed=False,
+                    message=(
+                        f"create_volume returned volume {volume.id} in unexpected state "
+                        f"{volume.state!r} (expected creating/available)"
+                    ),
+                )
+                return False
+
+            if volume.mount is not None:
+                access = f"mount={volume.mount.source}"
+            elif volume.csi is not None:
+                access = f"csi={volume.csi.driver}#{volume.csi.volume_handle}"
+            else:
+                access = "access=n/a"
+            self.report_subtest(
+                f"volume-provisioning[{tag}]",
+                passed=True,
+                message=(
+                    f"created volume {volume.id} (state={volume.state}, {access}, size_bytes={volume.size_bytes})"
+                ),
+            )
+            return True
+        finally:
+            try:
+                api.delete_volume(DeleteVolumeRequest(volume_id=volume.id))
+            except NotSupportedError:
+                self.log.warning(
+                    "Provider %r implements create_volume but not delete_volume; "
+                    "volume %s left behind (tags include isvtest-run-id=%s for orphan sweep)",
+                    tag,
+                    volume.id,
+                    run_id,
+                )
+            except Exception as exc:
+                self.log.warning(
+                    "Provider %r delete_volume(%s) raised %s: %s",
+                    tag,
+                    volume.id,
+                    type(exc).__name__,
+                    exc,
+                )
+
+    def _exercise_tenant_quota(self, api: StorageProvider, *, tag: str, declared_tenant_id: str | None = None) -> bool:
+        """tenant quota exists with non-zero hard limit (and matches declared tenant_id)."""
+        try:
+            quota = api.get_tenant_quota(GetTenantQuotaRequest())
+        except Exception as exc:
+            self.report_subtest(
+                f"tenant-quota[{tag}]",
+                passed=False,
+                message=f"get_tenant_quota() raised {type(exc).__name__}: {exc}",
+            )
+            return False
+
+        if declared_tenant_id and quota.tenant_id != declared_tenant_id:
+            self.report_subtest(
+                f"tenant-quota[{tag}]",
+                passed=False,
+                message=(
+                    f"manifest tenant_id={declared_tenant_id!r} != "
+                    f"get_tenant_quota().tenant_id={quota.tenant_id!r} (contract violation)"
+                ),
+            )
+            return False
+
+        if quota.hard_limit_bytes <= 0:
+            self.report_subtest(
+                f"tenant-quota[{tag}]",
+                passed=False,
+                message=(
+                    f"get_tenant_quota() returned hard_limit_bytes={quota.hard_limit_bytes} "
+                    f"for tenant {quota.tenant_id!r} (expected > 0)"
+                ),
+            )
+            return False
+
+        self.report_subtest(
+            f"tenant-quota[{tag}]",
+            passed=True,
+            message=(
+                f"tenant {quota.tenant_id!r} hard_limit_bytes={quota.hard_limit_bytes}, used_bytes={quota.used_bytes}"
+            ),
+        )
+        return True

--- a/isvtest/src/isvtest/validations/storage_quota_enforcement.py
+++ b/isvtest/src/isvtest/validations/storage_quota_enforcement.py
@@ -16,19 +16,21 @@
 """``StorageDirectoryQuotaEnforcementCheck`` - end-to-end directory-quota test.
 
 Unlike ``StorageProviderApiCheck`` (which probes quota surfaces with sentinel ids),
-this check runs real CRUD against a mounted PVC and proves enforcement by
+this check runs real CRUD against mounted storage and proves enforcement by
 writing past the hard limit:
 
-1. Acquire a volume (provision RWX PVC + BusyBox pod, or reuse ``pvc_name`` /
-   ``pod_name``).
-2. Resolve the bound PV's CSI ``volumeHandle`` to the shim ``volume_id``.
+1. Acquire a volume (provision RWX PVC + BusyBox pod, reuse ``pvc_name`` /
+   ``pod_name``, or create a backend-native volume and mount its advertised
+   ``Volume.mount`` locally when Kubernetes is unavailable).
+2. Resolve the acquired storage to the shim ``volume_id``.
 3. ``directory-quota-crud``: empty subdir → set/get/update/list/delete round-trip.
 4. ``directory-quota-enforcement``: below-limit write succeeds; over-limit writes
    eventually fail with a no-space / quota error (settle delay between chunks
    for backends with async usage accounting).
 
 Skipped when no manifest provider declares full directory-quota CRUD support,
-no StorageClass/PVC is configured, or no cluster is reachable. Unreleased —
+no Kubernetes/CSI or native volume-acquisition path is available, or the native
+volume does not return mount instructions. Unreleased —
 run with ``ISVTEST_INCLUDE_UNRELEASED=1``.
 
 Config keys (with defaults):
@@ -48,13 +50,17 @@ Config keys (with defaults):
         (defaults 240 / 300).
     namespace_prefix / image / timeout: Ephemeral ns prefix, BusyBox image,
         per-command timeout (defaults ``isvtest-dq`` / ``busybox:1.36`` / 600).
+    volume_size_bytes: Native volume size for non-Kubernetes acquisition
+        (default 1 GiB, or enough to exceed the enforcement hard limit).
 """
 
 from __future__ import annotations
 
 import shlex
+import tempfile
 import time
 import uuid
+from collections.abc import Callable
 from typing import ClassVar
 
 from isvtest.config.settings import get_k8s_csi_shared_fs_storage_class
@@ -63,18 +69,24 @@ from isvtest.core.k8s import (
     get_kubectl_command,
     is_k8s_available,
 )
+from isvtest.core.runners import CommandResult
 from isvtest.core.storage import ManifestError, Provider, load_provider_registry
 from isvtest.core.storage_provider import (
     CAP_DIRECTORY_QUOTA_DELETE,
     CAP_DIRECTORY_QUOTA_GET,
     CAP_DIRECTORY_QUOTA_LIST,
     CAP_DIRECTORY_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_DELETE,
+    CreateVolumeRequest,
     DeleteDirectoryQuotaRequest,
+    DeleteVolumeRequest,
     DirectoryQuota,
     GetDirectoryQuotaRequest,
     GetVolumeRequest,
     ListDirectoryQuotasRequest,
     ListVolumesRequest,
+    MountSpec,
     NotFoundError,
     QuotaLimits,
     SetDirectoryQuotaRequest,
@@ -115,14 +127,14 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
       a below-limit write succeeds and sustained over-limit writes are
       eventually blocked with a no-space / quota-exceeded error.
 
-    Skipped (passed) when the manifest is unset, no provider declares
-    ``quota.directory.set``, no StorageClass / PVC is configured, or no
-    Kubernetes cluster is reachable.
+    Skipped (passed) when the manifest is unset, no provider declares full
+    directory-quota CRUD, or no Kubernetes/CSI or native volume-acquisition path
+    is available.
     """
 
     description: ClassVar[str] = "Exercise directory-quota CRUD and enforcement against a live volume"
     timeout: ClassVar[int] = 600
-    labels: ClassVar[tuple[str, ...]] = ("kubernetes", "storage", "storage_provider_api", "slow")
+    labels: ClassVar[tuple[str, ...]] = ("storage", "storage_provider_api", "slow")
 
     def run(self) -> None:
         """Load the manifest and drive each directory-quota-capable shim provider."""
@@ -159,23 +171,17 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
 
         self._storage_class = str(self.config.get("storage_class") or get_k8s_csi_shared_fs_storage_class() or "")
         self._pvc_namespace = str(self.config.get("pvc_namespace") or "default")
-        if not self._storage_class and not self._pvc_name:
-            self.set_passed("Skipped: no storage_class or pvc_name configured to acquire a volume")
-            return
-
-        if not is_k8s_available():
-            self.set_passed("Skipped: no reachable Kubernetes cluster")
-            return
-
-        self._kubectl_parts = get_kubectl_command()
-        self._kubectl_base = get_kubectl_base_shell()
         self._pvc_size = str(self.config.get("pvc_size") or "5Gi")
         self._create_hard = int(self.config.get("create_hard_bytes") or (1 << 30))
         self._enforce_hard = int(self.config.get("enforcement_hard_bytes") or (64 * _MIB))
+        self._volume_size = int(self.config.get("volume_size_bytes") or max(1 << 30, self._enforce_hard * 2))
         self._bind_timeout = int(self.config.get("bind_timeout_s") or 240)
         self._write_timeout = int(self.config.get("write_timeout_s") or 300)
         self._image = str(self.config.get("image") or _DEFAULT_IMAGE)
         self._ns_prefix = str(self.config.get("namespace_prefix") or "isvtest-dq")
+        self._k8s_available = is_k8s_available()
+        self._kubectl_parts = get_kubectl_command() if self._k8s_available else []
+        self._kubectl_base = get_kubectl_base_shell() if self._k8s_available else "kubectl"
 
         any_failed = False
         for provider in candidates:
@@ -194,8 +200,26 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
     # ------------------------------------------------------------------
 
     def _exercise_provider(self, provider: Provider) -> bool:
-        """Acquire a volume, then run the CRUD + enforcement subtests. Return True on pass."""
+        """Choose Kubernetes/CSI or native acquisition, then run quota subtests."""
+        native_volume = _native_volume_lifecycle(provider)
+        if self._k8s_available and not native_volume:
+            return self._exercise_provider_k8s(provider)
+        if native_volume:
+            return self._exercise_provider_native(provider)
+        if self._k8s_available:
+            return self._exercise_provider_k8s(provider)
+        self._skip_both(
+            provider.name,
+            "no reachable Kubernetes cluster and provider does not declare native volume.create/delete",
+        )
+        return True
+
+    def _exercise_provider_k8s(self, provider: Provider) -> bool:
+        """Acquire a Kubernetes PVC-backed volume, then run quota subtests."""
         tag = provider.name
+        if not self._storage_class and not self._pvc_name:
+            self._skip_both(tag, "no storage_class or pvc_name configured to acquire a Kubernetes volume")
+            return True
         api = provider.api
         assert api is not None
 
@@ -251,8 +275,12 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
                 self._fail_both(tag, f"mkdir /data/{subdir} failed: {mk.stderr.strip() or mk.stdout.strip()}")
                 return False
 
-            crud_ok = self._run_crud(api, tag, volume, subdir, namespace, pod_name)
-            enforce_ok = self._run_enforcement(api, tag, volume, subdir, namespace, pod_name)
+            crud_ok = self._run_crud(api, tag, volume, subdir)
+
+            def writer(relpath: str, count_mib: int) -> CommandResult:
+                return self._dd(namespace, pod_name, f"/data/{relpath}", count_mib)
+
+            enforce_ok = self._run_enforcement(api, tag, volume, subdir, writer)
             return crud_ok and enforce_ok
         finally:
             self._cleanup(
@@ -267,6 +295,60 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
                 pvc_created=pvc_created,
                 pod_created=pod_created,
             )
+
+    def _exercise_provider_native(self, provider: Provider) -> bool:
+        """Create and mount a backend-native volume, then run quota subtests."""
+        tag = provider.name
+        api = provider.api
+        assert api is not None
+
+        run_id = uuid.uuid4().hex[:8]
+        volume: Volume | None = None
+        volume_id = ""
+        mount_dir = ""
+        mounted = False
+        subdir = ""
+        try:
+            volume = api.create_volume(
+                CreateVolumeRequest(
+                    size_bytes=self._volume_size,
+                    volume_type=provider.volume_type,
+                    tenant_id=provider.tenant_id,
+                    name=f"isvtest-dq-{run_id}",
+                    tags={"isvtest-run-id": run_id, "provider": tag, "test-case": "directory-quota-enforcement"},
+                )
+            )
+            volume_id = volume.id
+        except Exception as exc:
+            self._fail_both(tag, f"native create_volume raised {type(exc).__name__}: {exc}")
+            return False
+
+        try:
+            if volume.mount is None:
+                self._skip_both(tag, "native volume created but returned no mount instructions (Volume.mount is None)")
+                return True
+
+            mount_dir = tempfile.mkdtemp(prefix=f"{self._ns_prefix}-{run_id}-")
+            if not self._mount_native_volume(volume.mount, mount_dir):
+                self._fail_both(tag, f"failed to mount native volume {volume_id!r} at {mount_dir!r}")
+                return False
+            mounted = True
+
+            subdir = f"isvtest-dq-{run_id}"
+            mk = self._exec_local(f"mkdir -p {shlex.quote(f'{mount_dir}/{subdir}')}")
+            if mk.exit_code != 0:
+                self._fail_both(tag, f"mkdir {mount_dir}/{subdir} failed: {mk.stderr.strip() or mk.stdout.strip()}")
+                return False
+
+            crud_ok = self._run_crud(api, tag, volume, subdir)
+
+            def writer(relpath: str, count_mib: int) -> CommandResult:
+                return self._dd_local(mount_dir, relpath, count_mib)
+
+            enforce_ok = self._run_enforcement(api, tag, volume, subdir, writer)
+            return crud_ok and enforce_ok
+        finally:
+            self._cleanup_native(api, volume_id, provider.tenant_id, mount_dir, mounted, subdir)
 
     # ------------------------------------------------------------------
     # Subtests
@@ -298,9 +380,7 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
                 return False, last
             time.sleep(_READBACK_POLL_S)
 
-    def _run_crud(
-        self, api: StorageProvider, tag: str, volume: Volume, subdir: str, namespace: str, pod_name: str
-    ) -> bool:
+    def _run_crud(self, api: StorageProvider, tag: str, volume: Volume, subdir: str) -> bool:
         """create -> get -> update -> get -> list -> delete -> get round-trip."""
         name = f"directory-quota-crud[{tag}]"
         vol_id = volume.id
@@ -387,7 +467,12 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
         return True
 
     def _run_enforcement(
-        self, api: StorageProvider, tag: str, volume: Volume, subdir: str, namespace: str, pod_name: str
+        self,
+        api: StorageProvider,
+        tag: str,
+        volume: Volume,
+        subdir: str,
+        writer: Callable[[str, int], CommandResult],
     ) -> bool:
         """Set a hard limit, then prove a below-limit write passes and an above-limit write is blocked."""
         name = f"directory-quota-enforcement[{tag}]"
@@ -410,7 +495,7 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
         hard_mib = max(1, self._enforce_hard // _MIB)
         under_mib = max(1, hard_mib // 4)
 
-        under = self._dd(namespace, pod_name, f"/data/{subdir}/under", under_mib)
+        under = writer(f"{subdir}/under", under_mib)
         if under.exit_code != 0:
             self.report_subtest(
                 name,
@@ -431,7 +516,7 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
         last = under
         while written_mib < cap_mib:
             chunk += 1
-            last = self._dd(namespace, pod_name, f"/data/{subdir}/over_{chunk}", chunk_mib)
+            last = writer(f"{subdir}/over_{chunk}", chunk_mib)
             if last.exit_code != 0:
                 break
             written_mib += chunk_mib
@@ -529,17 +614,38 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
         # scheduled; confirm it reached Bound before proceeding.
         return _poll_pvc_bound(self.run_command, self._kubectl_base, namespace, pvc_name, 10)
 
-    def _exec(self, namespace: str, pod_name: str, inner: str, timeout: int | None = None):
+    def _exec(self, namespace: str, pod_name: str, inner: str, timeout: int | None = None) -> CommandResult:
         cmd = (
             f"{self._kubectl_base} exec -n {shlex.quote(namespace)} {shlex.quote(pod_name)} "
             f"-- sh -c {shlex.quote(inner)}"
         )
         return self.run_command(cmd, timeout=timeout or self.timeout)
 
-    def _dd(self, namespace: str, pod_name: str, path: str, count_mib: int):
-        """Write ``count_mib`` MiB to ``path`` and flush; non-zero exit means the write was refused."""
+    def _exec_local(self, inner: str, timeout: int | None = None) -> CommandResult:
+        """Run a local shell command through the validation runner."""
+        return self.run_command(inner, timeout=timeout or self.timeout)
+
+    def _dd(self, namespace: str, pod_name: str, path: str, count_mib: int) -> CommandResult:
+        """Write ``count_mib`` MiB to ``path`` in the Kubernetes probe pod."""
         inner = f"dd if=/dev/zero of={shlex.quote(path)} bs=1M count={count_mib} 2>&1; ec=$?; sync; exit $ec"
         return self._exec(namespace, pod_name, inner, timeout=self._write_timeout)
+
+    def _dd_local(self, mount_dir: str, relpath: str, count_mib: int) -> CommandResult:
+        """Write ``count_mib`` MiB to a path under a native local mount."""
+        path = f"{mount_dir.rstrip('/')}/{relpath.lstrip('/')}"
+        inner = f"dd if=/dev/zero of={shlex.quote(path)} bs=1M count={count_mib} 2>&1; ec=$?; sync; exit $ec"
+        return self._exec_local(inner, timeout=self._write_timeout)
+
+    def _mount_native_volume(self, mount: MountSpec, mount_dir: str) -> bool:
+        """Mount a backend-native volume on the validation host."""
+        opts = f" -o {shlex.quote(mount.options)}" if mount.options else ""
+        res = self.run_command(
+            f"mount -t {shlex.quote(mount.fs_type)}{opts} {shlex.quote(mount.source)} {shlex.quote(mount_dir)}"
+        )
+        if res.exit_code != 0:
+            self.log.error("mount failed for %s at %s: %s", mount.source, mount_dir, res.stderr or res.stdout)
+            return False
+        return True
 
     def _cleanup(
         self,
@@ -585,16 +691,57 @@ class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
         except Exception as exc:  # cleanup is best-effort
             self.log.warning("cleanup failed in namespace %s: %s", namespace, exc)
 
+    def _cleanup_native(
+        self,
+        api: StorageProvider | None,
+        volume_id: str,
+        tenant_id: str | None,
+        mount_dir: str,
+        mounted: bool,
+        subdir: str,
+    ) -> None:
+        """Best-effort cleanup for a native volume-acquisition run."""
+        try:
+            if subdir and volume_id and api is not None:
+                try:
+                    api.delete_directory_quota(
+                        DeleteDirectoryQuotaRequest(volume_id=volume_id, tenant_id=tenant_id, path=subdir)
+                    )
+                except (StorageApiError, NotFoundError):
+                    pass
+            if mounted and subdir:
+                self._exec_local(f"rm -rf {shlex.quote(f'{mount_dir}/{subdir}')}")
+            if mounted:
+                self.run_command(f"umount {shlex.quote(mount_dir)}")
+            if mount_dir:
+                self.run_command(f"rmdir {shlex.quote(mount_dir)}")
+            if volume_id and api is not None:
+                api.delete_volume(DeleteVolumeRequest(volume_id=volume_id, tenant_id=tenant_id))
+        except Exception as exc:  # cleanup is best-effort
+            self.log.warning("native cleanup failed for volume %s: %s", volume_id, exc)
+
     def _fail_both(self, tag: str, message: str) -> None:
         self.report_subtest(f"directory-quota-crud[{tag}]", False, message)
         self.report_subtest(f"directory-quota-enforcement[{tag}]", False, message)
 
+    def _skip_both(self, tag: str, message: str) -> None:
+        self.report_subtest(f"directory-quota-crud[{tag}]", True, message, skipped=True)
+        self.report_subtest(f"directory-quota-enforcement[{tag}]", True, message, skipped=True)
+
 
 def _hard(quota: DirectoryQuota) -> int | None:
-    """The hard byte limit of a returned quota (``None`` when unset)."""
-    return quota.hard.bytes if quota.hard is not None else None
+    """Return the byte hard limit from a directory-quota record."""
+    return None if quota.hard is None else quota.hard.bytes
 
 
 def _norm(path: str | None) -> str:
-    """Normalize a volume-relative path for comparison (strip surrounding slashes)."""
+    """Normalize provider-returned paths for volume-relative comparisons."""
     return (path or "").strip("/")
+
+
+def _native_volume_lifecycle(provider: Provider) -> bool:
+    """Return True when the manifest declares backend-native volume lifecycle."""
+    return (
+        provider.capability_states.get(CAP_VOLUME_CREATE) == "native"
+        and provider.capability_states.get(CAP_VOLUME_DELETE) == "native"
+    )

--- a/isvtest/src/isvtest/validations/storage_quota_enforcement.py
+++ b/isvtest/src/isvtest/validations/storage_quota_enforcement.py
@@ -1,0 +1,600 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``StorageDirectoryQuotaEnforcementCheck`` - end-to-end directory-quota test.
+
+Unlike ``StorageProviderApiCheck`` (which probes quota surfaces with sentinel ids),
+this check runs real CRUD against a mounted PVC and proves enforcement by
+writing past the hard limit:
+
+1. Acquire a volume (provision RWX PVC + BusyBox pod, or reuse ``pvc_name`` /
+   ``pod_name``).
+2. Resolve the bound PV's CSI ``volumeHandle`` to the shim ``volume_id``.
+3. ``directory-quota-crud``: empty subdir → set/get/update/list/delete round-trip.
+4. ``directory-quota-enforcement``: below-limit write succeeds; over-limit writes
+   eventually fail with a no-space / quota error (settle delay between chunks
+   for backends with async usage accounting).
+
+Skipped when no manifest provider declares full directory-quota CRUD support,
+no StorageClass/PVC is configured, or no cluster is reachable. Unreleased —
+run with ``ISVTEST_INCLUDE_UNRELEASED=1``.
+
+Config keys (with defaults):
+    manifest_path: Provider manifest YAML (same as StorageProviderApiCheck).
+        Empty -> skipped.
+    storage_class: RWX StorageClass for the probe PVC. Defaults to
+        ``get_k8s_csi_shared_fs_storage_class()`` (env ``K8S_CSI_SHARED_FS_SC``).
+    pvc_name / pvc_namespace: Reuse a bound PVC (namespace default ``default``).
+    pod_name: Reuse a Ready pod that mounts that PVC at ``/data``; requires
+        ``pvc_name``. Cleanup then only removes the probe subdir + quota.
+    pvc_size: Provisioned PVC size (default ``5Gi``); must exceed
+        ``enforcement_hard_bytes``.
+    create_hard_bytes: Hard limit for CRUD create (default 1 GiB).
+    enforcement_hard_bytes: Hard limit for enforcement + CRUD update
+        (default 64 MiB).
+    bind_timeout_s / write_timeout_s: PVC/pod Ready and write timeouts
+        (defaults 240 / 300).
+    namespace_prefix / image / timeout: Ephemeral ns prefix, BusyBox image,
+        per-command timeout (defaults ``isvtest-dq`` / ``busybox:1.36`` / 600).
+"""
+
+from __future__ import annotations
+
+import shlex
+import time
+import uuid
+from typing import ClassVar
+
+from isvtest.config.settings import get_k8s_csi_shared_fs_storage_class
+from isvtest.core.k8s import (
+    get_kubectl_base_shell,
+    get_kubectl_command,
+    is_k8s_available,
+)
+from isvtest.core.storage import ManifestError, Provider, load_provider_registry
+from isvtest.core.storage_provider import (
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_SET,
+    DeleteDirectoryQuotaRequest,
+    DirectoryQuota,
+    GetDirectoryQuotaRequest,
+    GetVolumeRequest,
+    ListDirectoryQuotasRequest,
+    ListVolumesRequest,
+    NotFoundError,
+    QuotaLimits,
+    SetDirectoryQuotaRequest,
+    StorageApiError,
+    StorageProvider,
+    Volume,
+)
+from isvtest.core.validation import BaseValidation
+from isvtest.validations.k8s_storage import (
+    _apply_mount_pod_manifest,
+    _apply_pvc_manifest,
+    _get_pvc_json,
+    _poll_pvc_bound,
+    _wait_pod_ready,
+)
+
+_MIB = 1 << 20
+_DEFAULT_IMAGE = "busybox:1.36"
+# Substrings that indicate an over-limit write failed for quota / ENOSPC.
+_ENOSPC_TOKENS: tuple[str, ...] = ("no space left", "disk quota exceeded", "quota exceeded")
+# Settle between over-limit write chunks (async usage accounting, e.g. NFS).
+_ENFORCE_SETTLE_S = 4
+# Poll window after set_directory_quota before treating hard-limit mismatch as fail.
+_READBACK_TIMEOUT_S = 30
+_READBACK_POLL_S = 2
+
+
+class StorageDirectoryQuotaEnforcementCheck(BaseValidation):
+    """Exercise directory-quota CRUD and prove enforcement via PVC writes.
+
+    Reports two subtests per shim provider that declares directory quotas:
+
+    * ``directory-quota-crud[<provider>]`` - create / get / update / get / list
+      / delete / get round-trip against an empty subdirectory of a real volume,
+      asserting the stored hard limit matches each write and that the record
+      disappears after delete.
+    * ``directory-quota-enforcement[<provider>]`` - with the hard limit set,
+      a below-limit write succeeds and sustained over-limit writes are
+      eventually blocked with a no-space / quota-exceeded error.
+
+    Skipped (passed) when the manifest is unset, no provider declares
+    ``quota.directory.set``, no StorageClass / PVC is configured, or no
+    Kubernetes cluster is reachable.
+    """
+
+    description: ClassVar[str] = "Exercise directory-quota CRUD and enforcement against a live volume"
+    timeout: ClassVar[int] = 600
+    labels: ClassVar[tuple[str, ...]] = ("kubernetes", "storage", "storage_provider_api", "slow")
+
+    def run(self) -> None:
+        """Load the manifest and drive each directory-quota-capable shim provider."""
+        self._pod_name = str(self.config.get("pod_name") or "")
+        self._pvc_name = str(self.config.get("pvc_name") or "")
+        if self._pod_name and not self._pvc_name:
+            self.set_failed("pod_name requires pvc_name: the supplied pod must already mount the PVC under test")
+            return
+
+        try:
+            providers = load_provider_registry(self.config)
+        except ManifestError as exc:
+            self.set_failed(f"Failed to load provider manifest: {exc}")
+            return
+        except Exception as exc:  # ShimLoadError etc. - missing env, bad shim
+            self.set_failed(f"Failed to load provider shim(s): {exc}")
+            return
+
+        required_caps = (
+            CAP_DIRECTORY_QUOTA_SET,
+            CAP_DIRECTORY_QUOTA_GET,
+            CAP_DIRECTORY_QUOTA_LIST,
+            CAP_DIRECTORY_QUOTA_DELETE,
+        )
+        candidates = [
+            p for p in providers if p.has_shim and all(p.expected_capabilities.get(cap) for cap in required_caps)
+        ]
+        if not candidates:
+            self.set_passed(
+                "Skipped: no manifest provider declares full directory-quota CRUD supported "
+                f"(requires {', '.join(required_caps)})"
+            )
+            return
+
+        self._storage_class = str(self.config.get("storage_class") or get_k8s_csi_shared_fs_storage_class() or "")
+        self._pvc_namespace = str(self.config.get("pvc_namespace") or "default")
+        if not self._storage_class and not self._pvc_name:
+            self.set_passed("Skipped: no storage_class or pvc_name configured to acquire a volume")
+            return
+
+        if not is_k8s_available():
+            self.set_passed("Skipped: no reachable Kubernetes cluster")
+            return
+
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+        self._pvc_size = str(self.config.get("pvc_size") or "5Gi")
+        self._create_hard = int(self.config.get("create_hard_bytes") or (1 << 30))
+        self._enforce_hard = int(self.config.get("enforcement_hard_bytes") or (64 * _MIB))
+        self._bind_timeout = int(self.config.get("bind_timeout_s") or 240)
+        self._write_timeout = int(self.config.get("write_timeout_s") or 300)
+        self._image = str(self.config.get("image") or _DEFAULT_IMAGE)
+        self._ns_prefix = str(self.config.get("namespace_prefix") or "isvtest-dq")
+
+        any_failed = False
+        for provider in candidates:
+            if not self._exercise_provider(provider):
+                any_failed = True
+
+        if any_failed:
+            self.set_failed("One or more directory-quota subtests failed; see subtest details")
+        else:
+            self.set_passed(
+                "Directory-quota CRUD + enforcement verified for " + ", ".join(sorted(p.name for p in candidates))
+            )
+
+    # ------------------------------------------------------------------
+    # Per-provider orchestration
+    # ------------------------------------------------------------------
+
+    def _exercise_provider(self, provider: Provider) -> bool:
+        """Acquire a volume, then run the CRUD + enforcement subtests. Return True on pass."""
+        tag = provider.name
+        api = provider.api
+        assert api is not None
+
+        run_id = uuid.uuid4().hex[:8]
+        namespace = f"{self._ns_prefix}-{run_id}"
+        ns_created = False
+        pvc_created = False
+        pod_created = False
+        pod_name = self._pod_name or f"dq-probe-{run_id}"
+        subdir = ""
+        volume_id = ""
+        tenant_id = provider.tenant_id
+
+        if self._pvc_name:
+            namespace = self._pvc_namespace
+            pvc_name = self._pvc_name
+        else:
+            pvc_name = f"dq-probe-{run_id}"
+
+        try:
+            if not self._pvc_name:
+                if not self._create_namespace(namespace):
+                    self._fail_both(tag, f"failed to create namespace {namespace!r}")
+                    return False
+                ns_created = True
+                if not self._provision_pvc(namespace, pvc_name):
+                    self._fail_both(tag, f"failed to provision PVC {pvc_name!r} on {self._storage_class!r}")
+                    return False
+                pvc_created = True
+
+            if self._pod_name:
+                ready, werr = _wait_pod_ready(
+                    self.run_command, self._kubectl_base, namespace, pod_name, self._bind_timeout
+                )
+                if not ready:
+                    self._fail_both(tag, f"supplied pod {pod_name!r} in namespace {namespace!r} is not Ready: {werr}")
+                    return False
+            else:
+                if not self._launch_mount_pod(namespace, pod_name, pvc_name):
+                    self._fail_both(tag, f"mount pod {pod_name!r} did not become Ready")
+                    return False
+                pod_created = True
+
+            volume, verr = self._resolve_volume(api, namespace, pvc_name, tenant_id)
+            if volume is None:
+                self._fail_both(tag, f"could not resolve shim volume for PVC {pvc_name!r}: {verr}")
+                return False
+            volume_id = volume.id
+
+            subdir = f"isvtest-dq-{run_id}"
+            mk = self._exec(namespace, pod_name, f"mkdir -p /data/{shlex.quote(subdir)}")
+            if mk.exit_code != 0:
+                self._fail_both(tag, f"mkdir /data/{subdir} failed: {mk.stderr.strip() or mk.stdout.strip()}")
+                return False
+
+            crud_ok = self._run_crud(api, tag, volume, subdir, namespace, pod_name)
+            enforce_ok = self._run_enforcement(api, tag, volume, subdir, namespace, pod_name)
+            return crud_ok and enforce_ok
+        finally:
+            self._cleanup(
+                namespace,
+                pod_name,
+                pvc_name,
+                subdir,
+                api,
+                volume_id,
+                tenant_id,
+                ns_created=ns_created,
+                pvc_created=pvc_created,
+                pod_created=pod_created,
+            )
+
+    # ------------------------------------------------------------------
+    # Subtests
+    # ------------------------------------------------------------------
+
+    def _await_hard(
+        self, api: StorageProvider, vol_id: str, subdir: str, expected: int, tenant_id: str | None = None
+    ) -> tuple[bool, int | None]:
+        """Poll ``get_directory_quota`` until hard bytes equal ``expected``.
+
+        Returns ``(matched, last_seen)``. Treats ``NotFoundError`` as not-yet-
+        published. On timeout, ``last_seen`` is whatever the backend last
+        returned (including ``None``).
+        """
+        deadline = time.monotonic() + _READBACK_TIMEOUT_S
+        last: int | None = None
+        while True:
+            try:
+                last = _hard(
+                    api.get_directory_quota(
+                        GetDirectoryQuotaRequest(volume_id=vol_id, tenant_id=tenant_id, path=subdir)
+                    )
+                )
+            except NotFoundError:
+                last = None
+            if last == expected:
+                return True, last
+            if time.monotonic() >= deadline:
+                return False, last
+            time.sleep(_READBACK_POLL_S)
+
+    def _run_crud(
+        self, api: StorageProvider, tag: str, volume: Volume, subdir: str, namespace: str, pod_name: str
+    ) -> bool:
+        """create -> get -> update -> get -> list -> delete -> get round-trip."""
+        name = f"directory-quota-crud[{tag}]"
+        vol_id = volume.id
+        try:
+            # create
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(
+                    DirectoryQuota(
+                        tenant_id=volume.tenant_id,
+                        volume_id=vol_id,
+                        path=subdir,
+                        hard=QuotaLimits(bytes=self._create_hard),
+                    )
+                )
+            )
+            matched, seen = self._await_hard(api, vol_id, subdir, self._create_hard, tenant_id=volume.tenant_id)
+            if not matched:
+                self.report_subtest(
+                    name,
+                    False,
+                    f"after create, hard={seen} != {self._create_hard} (re-read for {_READBACK_TIMEOUT_S}s)",
+                )
+                return False
+
+            # update
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(
+                    DirectoryQuota(
+                        tenant_id=volume.tenant_id,
+                        volume_id=vol_id,
+                        path=subdir,
+                        hard=QuotaLimits(bytes=self._enforce_hard),
+                    )
+                )
+            )
+            matched, seen = self._await_hard(api, vol_id, subdir, self._enforce_hard, tenant_id=volume.tenant_id)
+            if not matched:
+                self.report_subtest(
+                    name,
+                    False,
+                    f"after update, hard={seen} != {self._enforce_hard} (re-read for {_READBACK_TIMEOUT_S}s)",
+                )
+                return False
+
+            # list contains our subdir quota
+            listed = api.list_directory_quotas(
+                ListDirectoryQuotasRequest(volume_id=vol_id, tenant_id=volume.tenant_id)
+            ).directory_quotas
+            if not any(_norm(q.path) == _norm(subdir) for q in listed):
+                self.report_subtest(
+                    name, False, f"subdir {subdir!r} not in list_directory_quotas ({[q.path for q in listed]})"
+                )
+                return False
+        except (StorageApiError, NotFoundError) as exc:
+            self.report_subtest(name, False, f"CRUD raised {type(exc).__name__}: {exc}")
+            return False
+
+        # NOTE: delete happens after enforcement so the enforcement subtest can
+        # rely on the (update-set) hard limit still being in place. We verify the
+        # delete here to keep the CRUD assertions together.
+        try:
+            api.delete_directory_quota(
+                DeleteDirectoryQuotaRequest(volume_id=vol_id, tenant_id=volume.tenant_id, path=subdir)
+            )
+        except (StorageApiError, NotFoundError) as exc:
+            self.report_subtest(name, False, f"delete raised {type(exc).__name__}: {exc}")
+            return False
+        try:
+            api.get_directory_quota(GetDirectoryQuotaRequest(volume_id=vol_id, tenant_id=volume.tenant_id, path=subdir))
+        except NotFoundError:
+            pass  # expected - the record is gone
+        except StorageApiError as exc:
+            self.report_subtest(name, False, f"get after delete raised {type(exc).__name__}: {exc}")
+            return False
+        else:
+            self.report_subtest(name, False, "get after delete returned a quota (delete did not remove it)")
+            return False
+
+        self.report_subtest(
+            name,
+            True,
+            f"create({self._create_hard}) -> update({self._enforce_hard}) -> list -> delete round-trip verified",
+        )
+        return True
+
+    def _run_enforcement(
+        self, api: StorageProvider, tag: str, volume: Volume, subdir: str, namespace: str, pod_name: str
+    ) -> bool:
+        """Set a hard limit, then prove a below-limit write passes and an above-limit write is blocked."""
+        name = f"directory-quota-enforcement[{tag}]"
+        vol_id = volume.id
+        try:
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(
+                    DirectoryQuota(
+                        tenant_id=volume.tenant_id,
+                        volume_id=vol_id,
+                        path=subdir,
+                        hard=QuotaLimits(bytes=self._enforce_hard),
+                    )
+                )
+            )
+        except (StorageApiError, NotFoundError) as exc:
+            self.report_subtest(name, False, f"set_directory_quota raised {type(exc).__name__}: {exc}")
+            return False
+
+        hard_mib = max(1, self._enforce_hard // _MIB)
+        under_mib = max(1, hard_mib // 4)
+
+        under = self._dd(namespace, pod_name, f"/data/{subdir}/under", under_mib)
+        if under.exit_code != 0:
+            self.report_subtest(
+                name,
+                False,
+                f"below-limit write ({under_mib} MiB, limit {hard_mib} MiB) failed: "
+                f"{(under.stderr or under.stdout).strip()[:200]}",
+            )
+            return False
+
+        # Keep writing hard-limit-sized chunks (with a settle delay so the
+        # backend's usage accounting can refresh) until a write is refused or we
+        # have written well past the limit. This tolerates backends that enforce
+        # asynchronously without weakening the "must be blocked" assertion.
+        chunk_mib = max(16, hard_mib)
+        cap_mib = max(hard_mib * 6, hard_mib + 512)
+        written_mib = under_mib
+        chunk = 0
+        last = under
+        while written_mib < cap_mib:
+            chunk += 1
+            last = self._dd(namespace, pod_name, f"/data/{subdir}/over_{chunk}", chunk_mib)
+            if last.exit_code != 0:
+                break
+            written_mib += chunk_mib
+            time.sleep(_ENFORCE_SETTLE_S)
+
+        blocked = last.exit_code != 0
+        combined = f"{last.stdout}\n{last.stderr}".lower()
+        right_reason = any(tok in combined for tok in _ENOSPC_TOKENS)
+        if blocked and right_reason:
+            self.report_subtest(
+                name,
+                True,
+                f"limit {hard_mib} MiB enforced: writes blocked after ~{written_mib} MiB with a no-space/quota error",
+            )
+            return True
+        if blocked and not right_reason:
+            self.report_subtest(
+                name,
+                False,
+                f"over-limit write failed but not with a no-space/quota error: {combined.strip()[:200]}",
+            )
+            return False
+        self.report_subtest(
+            name,
+            False,
+            f"wrote ~{written_mib} MiB into a {hard_mib} MiB quota without being blocked - not enforced",
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    # Volume resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_volume(
+        self, api: StorageProvider, namespace: str, pvc_name: str, tenant_id: str | None
+    ) -> tuple[Volume | None, str]:
+        """Map the bound PVC to the shim's Volume via the PV's csi.volumeHandle."""
+        payload, err = _get_pvc_json(self.run_command, self._kubectl_base, namespace, pvc_name)
+        if payload is None:
+            return None, f"kubectl get pvc failed: {err}"
+        pv_name = str((payload.get("spec") or {}).get("volumeName") or "")
+        if not pv_name:
+            return None, "PVC has no spec.volumeName (not Bound?)"
+        handle_res = self.run_command(
+            f"{self._kubectl_base} get pv {shlex.quote(pv_name)} -o jsonpath={shlex.quote('{.spec.csi.volumeHandle}')}"
+        )
+        handle = handle_res.stdout.strip()
+        if handle_res.exit_code != 0 or not handle:
+            return None, f"could not read PV {pv_name!r} csi.volumeHandle: {handle_res.stderr.strip()}"
+
+        # Fast path: the shim resolves a CSI volume handle directly.
+        try:
+            return api.get_volume(GetVolumeRequest(volume_id=handle, tenant_id=tenant_id)), ""
+        except (NotFoundError, StorageApiError):
+            pass
+        # Fallback: match by CSI handle or absolute path across the inventory.
+        try:
+            volumes = api.list_volumes(ListVolumesRequest(tenant_id=tenant_id)).volumes
+        except StorageApiError as exc:
+            return None, f"list_volumes raised {type(exc).__name__}: {exc}"
+        for vol in volumes:
+            if vol.csi is not None and vol.csi.volume_handle == handle:
+                return vol, ""
+            if handle.endswith(str(vol.attributes.get("path") or "\x00")):
+                return vol, ""
+        return None, f"no shim volume matches PV handle {handle!r}"
+
+    # ------------------------------------------------------------------
+    # Kubernetes helpers
+    # ------------------------------------------------------------------
+
+    def _create_namespace(self, namespace: str) -> bool:
+        res = self.run_command(f"{self._kubectl_base} create namespace {shlex.quote(namespace)}")
+        return res.exit_code == 0
+
+    def _provision_pvc(self, namespace: str, pvc_name: str) -> bool:
+        rc, err = _apply_pvc_manifest(
+            self._kubectl_parts, namespace, pvc_name, self._storage_class, "ReadWriteMany", self._pvc_size, self.timeout
+        )
+        if rc != 0:
+            self.log.error("kubectl apply failed for PVC %s: %s", pvc_name, err.strip())
+            return False
+        return True
+
+    def _launch_mount_pod(self, namespace: str, pod_name: str, pvc_name: str) -> bool:
+        rc, err = _apply_mount_pod_manifest(self._kubectl_parts, namespace, pod_name, pvc_name, self.timeout)
+        if rc != 0:
+            self.log.error("kubectl apply failed for mount pod %s: %s", pod_name, err.strip())
+            return False
+        ready, werr = _wait_pod_ready(self.run_command, self._kubectl_base, namespace, pod_name, self._bind_timeout)
+        if not ready:
+            self.log.error("mount pod %s not Ready: %s", pod_name, werr)
+            return False
+        # For WaitForFirstConsumer classes the PVC binds only once the pod is
+        # scheduled; confirm it reached Bound before proceeding.
+        return _poll_pvc_bound(self.run_command, self._kubectl_base, namespace, pvc_name, 10)
+
+    def _exec(self, namespace: str, pod_name: str, inner: str, timeout: int | None = None):
+        cmd = (
+            f"{self._kubectl_base} exec -n {shlex.quote(namespace)} {shlex.quote(pod_name)} "
+            f"-- sh -c {shlex.quote(inner)}"
+        )
+        return self.run_command(cmd, timeout=timeout or self.timeout)
+
+    def _dd(self, namespace: str, pod_name: str, path: str, count_mib: int):
+        """Write ``count_mib`` MiB to ``path`` and flush; non-zero exit means the write was refused."""
+        inner = f"dd if=/dev/zero of={shlex.quote(path)} bs=1M count={count_mib} 2>&1; ec=$?; sync; exit $ec"
+        return self._exec(namespace, pod_name, inner, timeout=self._write_timeout)
+
+    def _cleanup(
+        self,
+        namespace: str,
+        pod_name: str,
+        pvc_name: str,
+        subdir: str,
+        api: StorageProvider | None,
+        volume_id: str,
+        tenant_id: str | None = None,
+        *,
+        ns_created: bool,
+        pvc_created: bool,
+        pod_created: bool,
+    ) -> None:
+        try:
+            if ns_created:
+                self.run_command(
+                    f"{self._kubectl_base} delete namespace {shlex.quote(namespace)} "
+                    f"--wait=false --ignore-not-found=true"
+                )
+                return
+            # Reused PVC/pod: drop only the probe quota and subdirectory.
+            if subdir and volume_id and api is not None:
+                try:
+                    api.delete_directory_quota(
+                        DeleteDirectoryQuotaRequest(volume_id=volume_id, tenant_id=tenant_id, path=subdir)
+                    )
+                except (StorageApiError, NotFoundError):
+                    pass
+            if subdir and pod_name:
+                self._exec(namespace, pod_name, f"rm -rf /data/{shlex.quote(subdir)}")
+            if pod_created:
+                self.run_command(
+                    f"{self._kubectl_base} delete pod {shlex.quote(pod_name)} -n {shlex.quote(namespace)} "
+                    f"--wait=false --ignore-not-found=true"
+                )
+            if pvc_created:
+                self.run_command(
+                    f"{self._kubectl_base} delete pvc {shlex.quote(pvc_name)} -n {shlex.quote(namespace)} "
+                    f"--wait=false --ignore-not-found=true"
+                )
+        except Exception as exc:  # cleanup is best-effort
+            self.log.warning("cleanup failed in namespace %s: %s", namespace, exc)
+
+    def _fail_both(self, tag: str, message: str) -> None:
+        self.report_subtest(f"directory-quota-crud[{tag}]", False, message)
+        self.report_subtest(f"directory-quota-enforcement[{tag}]", False, message)
+
+
+def _hard(quota: DirectoryQuota) -> int | None:
+    """The hard byte limit of a returned quota (``None`` when unset)."""
+    return quota.hard.bytes if quota.hard is not None else None
+
+
+def _norm(path: str | None) -> str:
+    """Normalize a volume-relative path for comparison (strip surrounding slashes)."""
+    return (path or "").strip("/")

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -18,17 +18,21 @@
 import json
 import os
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from isvtest.core.k8s import (
     TERMINAL_WAITING_REASONS,
     TRANSIENT_WAITING_REASONS,
     KubectlParseError,
+    ensure_incluster_kubeconfig,
     get_k8s_provider,
     get_kubectl_base_shell,
     get_kubectl_command,
+    is_k8s_available,
     kubectl_items_or_fail,
     parse_kubectl_json,
     parse_kubectl_json_items,
@@ -50,9 +54,11 @@ class _StubValidation:
     """Minimal stand-in exposing ``set_failed`` for parser-helper tests."""
 
     def __init__(self) -> None:
+        """Initialize the object with its configured dependencies."""
         self.error: str | None = None
 
     def set_failed(self, error: str, output: str = "") -> None:
+        """Handle set failed."""
         self.error = error
 
 
@@ -157,10 +163,156 @@ class TestGetKubectlCommandOverride:
                 get_kubectl_command()
 
 
+class TestEnsureInclusterKubeconfig:
+    """Tests for the in-cluster kubeconfig bootstrap."""
+
+    @staticmethod
+    def _sa_dir(tmp_path: Path) -> Path:
+        """Build a stand-in for the projected ServiceAccount mount."""
+        sa = tmp_path / "serviceaccount"
+        sa.mkdir()
+        (sa / "token").write_text("sa-token-value")
+        (sa / "ca.crt").write_text("ca-pem")
+        (sa / "namespace").write_text("storage-system\n")
+        return sa
+
+    def _run(self, sa_dir: Path, env: dict[str, str], home: Path) -> str | None:
+        """Invoke the bootstrap with a patched SA mount and HOME."""
+        ensure_incluster_kubeconfig.cache_clear()
+        with (
+            patch.dict(os.environ, {**env, "HOME": str(home)}, clear=True),
+            patch("isvtest.core.k8s._INCLUSTER_SA_DIR", sa_dir),
+        ):
+            path = ensure_incluster_kubeconfig()
+            self._kubeconfig_env = os.environ.get("KUBECONFIG")
+        return path
+
+    def test_generates_kubeconfig_in_pod(self, tmp_path: Path) -> None:
+        """In a pod with no kubeconfig, one is written and KUBECONFIG points at it."""
+        sa = self._sa_dir(tmp_path)
+        path = self._run(
+            sa,
+            {"KUBERNETES_SERVICE_HOST": "10.0.0.1", "KUBERNETES_SERVICE_PORT": "443"},
+            tmp_path / "home",
+        )
+
+        assert path is not None
+        assert self._kubeconfig_env == path
+        cfg = yaml.safe_load(Path(path).read_text())
+        assert cfg["clusters"][0]["cluster"]["server"] == "https://10.0.0.1:443"
+        assert cfg["clusters"][0]["cluster"]["certificate-authority"] == str(sa / "ca.crt")
+        assert cfg["contexts"][0]["context"]["namespace"] == "storage-system"
+
+    def test_references_token_by_path_not_value(self, tmp_path: Path) -> None:
+        """The token is referenced via tokenFile so it neither leaks nor goes stale."""
+        sa = self._sa_dir(tmp_path)
+        path = self._run(sa, {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, tmp_path / "home")
+
+        assert path is not None
+        raw = Path(path).read_text()
+        assert "sa-token-value" not in raw
+        cfg = yaml.safe_load(raw)
+        assert cfg["users"][0]["user"]["tokenFile"] == str(sa / "token")
+
+    def test_defaults_port_when_unset(self, tmp_path: Path) -> None:
+        """A pod exposing only KUBERNETES_SERVICE_HOST still gets a usable server URL."""
+        sa = self._sa_dir(tmp_path)
+        path = self._run(sa, {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, tmp_path / "home")
+
+        assert path is not None
+        cfg = yaml.safe_load(Path(path).read_text())
+        assert cfg["clusters"][0]["cluster"]["server"] == "https://10.0.0.1:443"
+
+    def test_brackets_ipv6_host(self, tmp_path: Path) -> None:
+        """On an IPv6 cluster the bare literal must be bracketed to form a valid URL."""
+        sa = self._sa_dir(tmp_path)
+        path = self._run(
+            sa,
+            {"KUBERNETES_SERVICE_HOST": "fd00::1", "KUBERNETES_SERVICE_PORT": "443"},
+            tmp_path / "home",
+        )
+
+        assert path is not None
+        cfg = yaml.safe_load(Path(path).read_text())
+        assert cfg["clusters"][0]["cluster"]["server"] == "https://[fd00::1]:443"
+
+    def test_existing_kubeconfig_env_wins(self, tmp_path: Path) -> None:
+        """An explicit KUBECONFIG is never overwritten."""
+        sa = self._sa_dir(tmp_path)
+        path = self._run(
+            sa,
+            {"KUBERNETES_SERVICE_HOST": "10.0.0.1", "KUBECONFIG": "/explicit/config"},
+            tmp_path / "home",
+        )
+
+        assert path is None
+        assert self._kubeconfig_env == "/explicit/config"
+
+    def test_existing_home_kubeconfig_wins(self, tmp_path: Path) -> None:
+        """A ~/.kube/config on disk takes precedence over the generated one."""
+        home = tmp_path / "home"
+        (home / ".kube").mkdir(parents=True)
+        (home / ".kube" / "config").write_text("apiVersion: v1\n")
+        sa = self._sa_dir(tmp_path)
+
+        path = self._run(sa, {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, home)
+
+        assert path is None
+        assert self._kubeconfig_env is None
+
+    def test_noop_outside_cluster(self, tmp_path: Path) -> None:
+        """Off-cluster (no KUBERNETES_SERVICE_HOST) the bootstrap does nothing."""
+        sa = self._sa_dir(tmp_path)
+        path = self._run(sa, {}, tmp_path / "home")
+
+        assert path is None
+        assert self._kubeconfig_env is None
+
+    def test_noop_without_serviceaccount_mount(self, tmp_path: Path) -> None:
+        """The env vars alone are not enough; the token/CA must actually be mounted."""
+        path = self._run(tmp_path / "absent", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, tmp_path / "home")
+
+        assert path is None
+        assert self._kubeconfig_env is None
+
+
+class TestIsK8sAvailable:
+    """Tests for the cluster-reachability probe."""
+
+    @staticmethod
+    def _completed(returncode: int) -> subprocess.CompletedProcess[str]:
+        """Build a minimal CompletedProcess for kubectl probe tests."""
+        return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr="")
+
+    def test_probes_version_endpoint_not_cluster_info(self) -> None:
+        """Reachability must use ``/version``, not ``cluster-info`` (RBAC)."""
+        with patch("isvtest.core.k8s.run_kubectl", return_value=self._completed(0)) as run:
+            assert is_k8s_available() is True
+        args = run.call_args[0][0]
+        assert args == ["get", "--raw", "/version"]
+        assert "cluster-info" not in args
+
+    def test_false_when_unreachable(self) -> None:
+        """Verify false when unreachable."""
+        with patch("isvtest.core.k8s.run_kubectl", return_value=self._completed(1)):
+            assert is_k8s_available() is False
+
+    def test_false_when_kubectl_missing(self) -> None:
+        """Verify false when kubectl missing."""
+        with patch("isvtest.core.k8s.run_kubectl", side_effect=FileNotFoundError):
+            assert is_k8s_available() is False
+
+    def test_false_on_timeout(self) -> None:
+        """Verify false on timeout."""
+        with patch("isvtest.core.k8s.run_kubectl", side_effect=subprocess.TimeoutExpired(cmd="kubectl", timeout=10)):
+            assert is_k8s_available() is False
+
+
 class TestGetKubectlBaseShellArgs:
     """Tests for get_kubectl_base_shell() args composition."""
 
     def test_composes_args_with_quoting(self) -> None:
+        """Verify composes args with quoting."""
         with (
             patch.dict(os.environ, {"KUBECTL": "kubectl"}, clear=True),
             patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/kubectl"),
@@ -169,6 +321,7 @@ class TestGetKubectlBaseShellArgs:
         assert result == "kubectl get pod my-pod -n default"
 
     def test_quotes_arg_with_spaces(self) -> None:
+        """Verify quotes arg with spaces."""
         with (
             patch.dict(os.environ, {"KUBECTL": "kubectl"}, clear=True),
             patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/kubectl"),
@@ -182,19 +335,23 @@ class TestKubectlJsonParsers:
     """Tests for structured kubectl JSON parser helpers."""
 
     def test_parse_kubectl_json_object(self) -> None:
+        """Verify parse kubectl json object."""
         payload = parse_kubectl_json(_command_result(json.dumps({"kind": "Pod"})), "pod")
         assert payload == {"kind": "Pod"}
 
     def test_parse_kubectl_json_reports_invalid_json(self) -> None:
+        """Verify parse kubectl json reports invalid json."""
         with pytest.raises(KubectlParseError, match="Failed to parse pod"):
             parse_kubectl_json(_command_result("not-json"), "pod")
 
     def test_parse_kubectl_json_items_extracts_items(self) -> None:
+        """Verify parse kubectl json items extracts items."""
         payload = json.dumps({"items": [{"metadata": {"name": "n1"}}]})
         items = parse_kubectl_json_items(_command_result(payload), "node list")
         assert items == [{"metadata": {"name": "n1"}}]
 
     def test_parse_kubectl_json_items_requires_items_list(self) -> None:
+        """Verify parse kubectl json items requires items list."""
         with pytest.raises(KubectlParseError, match="expected 'items' list"):
             parse_kubectl_json_items(_command_result(json.dumps({"items": {}})), "node list")
 
@@ -203,6 +360,7 @@ class TestKubectlItemsOrFail:
     """Tests for the validation-aware ``kubectl_items_or_fail`` helper."""
 
     def test_returns_items_on_success(self) -> None:
+        """Verify returns items on success."""
         validation = _StubValidation()
         payload = json.dumps({"items": [{"metadata": {"name": "n1"}}]})
         items = kubectl_items_or_fail(validation, _command_result(payload), "node list")
@@ -210,6 +368,7 @@ class TestKubectlItemsOrFail:
         assert validation.error is None
 
     def test_routes_exec_failure_to_set_failed(self) -> None:
+        """Verify routes exec failure to set failed."""
         validation = _StubValidation()
         result = _command_result("", exit_code=1, stderr="cluster unavailable")
         items = kubectl_items_or_fail(validation, result, "node list")
@@ -217,6 +376,7 @@ class TestKubectlItemsOrFail:
         assert validation.error == "Failed to get node list: cluster unavailable"
 
     def test_routes_parse_failure_to_set_failed(self) -> None:
+        """Verify routes parse failure to set failed."""
         validation = _StubValidation()
         items = kubectl_items_or_fail(validation, _command_result("not-json"), "node list")
         assert items is None
@@ -228,6 +388,7 @@ class TestPodStatusReason:
     """Tests for ``pod_status_reason`` kubectl STATUS-column emulation."""
 
     def test_container_waiting_reason_wins_over_phase(self) -> None:
+        """Verify container waiting reason wins over phase."""
         pod = {
             "status": {
                 "phase": "Pending",
@@ -240,14 +401,17 @@ class TestPodStatusReason:
         # Regression: evicted pods carry ``status.reason: Evicted`` but no
         # informative container state; kubectl shows "Evicted" in STATUS so
         # ``error_states: [Evicted]`` configs must still match.
+        """Verify pod level reason overrides phase when no container state."""
         pod = {"status": {"phase": "Failed", "reason": "Evicted"}}
         assert pod_status_reason(pod) == "Evicted"
 
     def test_falls_back_to_phase_when_reason_absent(self) -> None:
+        """Verify falls back to phase when reason absent."""
         pod = {"status": {"phase": "Running"}}
         assert pod_status_reason(pod) == "Running"
 
     def test_returns_unknown_when_phase_missing(self) -> None:
+        """Verify returns unknown when phase missing."""
         assert pod_status_reason({}) == "Unknown"
 
 
@@ -255,25 +419,32 @@ class TestPodStateFromResult:
     """Tests for the result-aware ``pod_state_from_result`` wrapper."""
 
     def test_parses_command_result_stdout_on_success(self) -> None:
+        """Verify parses command result stdout on success."""
         payload = json.dumps({"status": {"phase": "Running"}})
         assert pod_state_from_result(_command_result(payload)) == ("Running", "", "")
 
     def test_inspects_stderr_on_command_result_failure(self) -> None:
+        """Verify inspects stderr on command result failure."""
         result = _command_result("", exit_code=1, stderr='Error from server (NotFound): pods "x" not found')
         assert pod_state_from_result(result) == ("NotFound", "", "")
 
     def test_accepts_completed_process(self) -> None:
+        """Verify accepts completed process."""
         payload = json.dumps({"status": {"phase": "Succeeded"}})
         completed = subprocess.CompletedProcess(args=["kubectl"], returncode=0, stdout=payload, stderr="")
         assert pod_state_from_result(completed) == ("Succeeded", "", "")
 
     def test_completed_process_failure_uses_stderr(self) -> None:
+        """Verify completed process failure uses stderr."""
         completed = subprocess.CompletedProcess(args=["kubectl"], returncode=1, stdout="", stderr="boom")
         assert pod_state_from_result(completed) == ("Unknown", "", "")
 
 
 class TestWaitForMultiplePodsCompletion:
+    """Tests for WaitForMultiplePodsCompletion."""
+
     def test_duplicate_targets_complete_after_unique_pods_finish(self) -> None:
+        """Verify duplicate targets complete after unique pods finish."""
         payload = json.dumps(
             {
                 "items": [
@@ -298,11 +469,15 @@ class TestWaitForMultiplePodsCompletion:
 
 
 class TestParsePodState:
+    """Tests for ParsePodState."""
+
     def test_running_pod(self) -> None:
+        """Verify running pod."""
         payload = json.dumps({"status": {"phase": "Running"}})
         assert parse_pod_state(payload, "") == ("Running", "", "")
 
     def test_pending_with_waiting_reason(self) -> None:
+        """Verify pending with waiting reason."""
         payload = json.dumps(
             {
                 "status": {
@@ -319,45 +494,61 @@ class TestParsePodState:
         assert msg == "back-off"
 
     def test_notfound_from_stderr(self) -> None:
+        """Verify notfound from stderr."""
         stderr = 'Error from server (NotFound): pods "my-pod" not found'
         assert parse_pod_state("", stderr) == ("NotFound", "", "")
 
     def test_unknown_on_generic_failure(self) -> None:
+        """Verify unknown on generic failure."""
         assert parse_pod_state("", "connection refused") == ("Unknown", "", "")
 
     def test_unknown_on_malformed_json(self) -> None:
+        """Verify unknown on malformed json."""
         assert parse_pod_state("not json", "") == ("Unknown", "", "")
 
     def test_missing_container_statuses(self) -> None:
+        """Verify missing container statuses."""
         payload = json.dumps({"status": {"phase": "Pending"}})
         assert parse_pod_state(payload, "") == ("Pending", "", "")
 
 
 class TestParseServerVersion:
+    """Tests for ParseServerVersion."""
+
     def test_strips_build_metadata(self) -> None:
+        """Verify strips build metadata."""
         assert parse_server_version(json.dumps({"serverVersion": {"gitVersion": "v1.30.2+abc"}})) == "v1.30.2"
 
     def test_plain_git_version(self) -> None:
+        """Verify plain git version."""
         assert parse_server_version(json.dumps({"serverVersion": {"gitVersion": "v1.31.3"}})) == "v1.31.3"
 
     def test_missing_server_version(self) -> None:
+        """Verify missing server version."""
         assert parse_server_version(json.dumps({})) is None
 
     def test_malformed_json(self) -> None:
+        """Verify malformed json."""
         assert parse_server_version("not json") is None
 
     def test_unexpected_format(self) -> None:
+        """Verify unexpected format."""
         assert parse_server_version(json.dumps({"serverVersion": {"gitVersion": "1.x.y"}})) is None
 
 
 class TestWaitingReasonConstants:
+    """Tests for WaitingReasonConstants."""
+
     def test_terminal_reasons_are_frozen(self) -> None:
+        """Verify terminal reasons are frozen."""
         assert "ImagePullBackOff" in TERMINAL_WAITING_REASONS
         assert isinstance(TERMINAL_WAITING_REASONS, frozenset)
 
     def test_transient_reasons_are_frozen(self) -> None:
+        """Verify transient reasons are frozen."""
         assert "ErrImagePull" in TRANSIENT_WAITING_REASONS
         assert isinstance(TRANSIENT_WAITING_REASONS, frozenset)
 
     def test_terminal_and_transient_are_disjoint(self) -> None:
+        """Verify terminal and transient are disjoint."""
         assert TERMINAL_WAITING_REASONS.isdisjoint(TRANSIENT_WAITING_REASONS)

--- a/isvtest/tests/test_storage.py
+++ b/isvtest/tests/test_storage.py
@@ -358,13 +358,18 @@ class TestIdentityAndCapabilities:
                 ],
             },
         )
-        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        caps = provider.expected_capabilities
+        states = provider.capability_states
         assert caps["tenant.list"] is False
         assert caps["tenant.getQuota"] is True
         assert caps["volume.create"] is True
         assert caps["volume.list"] is True
         assert caps["quota.directory.set"] is False
         assert caps["quota.user.get"] is False
+        assert states["tenant.getQuota"] == "native"
+        assert states["volume.create"] == "native"
+        assert states["quota.user.get"] == "none"
 
     def test_package_default_capabilities_apply(self, tmp_path: Path) -> None:
         path = _write_manifest(
@@ -375,11 +380,14 @@ class TestIdentityAndCapabilities:
                 "providers": [{"name": "p", "type": "file", "capabilities": {"volumeManagement": "native"}}],
             },
         )
-        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        caps = provider.expected_capabilities
         # volume.* native via provider block; everything else falls to package default none.
         assert caps["volume.create"] is True
         assert caps["quota.user.set"] is False
         assert caps["tenant.list"] is False
+        assert provider.capability_states["volume.create"] == "native"
+        assert provider.capability_states["quota.user.set"] == "none"
 
     def test_package_default_capabilities_camelcase_key(self, tmp_path: Path) -> None:
         # The camelCase `defaultCapabilities` key mirrors the upstream package
@@ -404,6 +412,7 @@ class TestIdentityAndCapabilities:
         )
         provider = load_provider_registry({"manifest_path": str(path)})[0]
         assert provider.expected_capabilities == {}
+        assert provider.capability_states == {}
 
     def test_capability_qualifiers_parsed(self, tmp_path: Path) -> None:
         path = _write_manifest(
@@ -455,6 +464,7 @@ class TestIdentityAndCapabilities:
         )
         provider = load_provider_registry({"manifest_path": str(path)})[0]
         assert provider.expected_capabilities == {}
+        assert provider.capability_states == {}
 
 
 class TestInstanceConfig:
@@ -485,6 +495,7 @@ class TestInstanceConfig:
         provider = load_provider_registry({"manifest_path": str(path)})[0]
         assert provider.tenant_id == "manifest-tenant"
         assert provider.expected_capabilities["volume.create"] is True
+        assert provider.capability_states["volume.create"] == "native"
         assert provider.storage_classes == ()
 
     def test_sibling_config_overrides_tenant_and_capabilities(self, tmp_path: Path) -> None:
@@ -510,6 +521,8 @@ class TestInstanceConfig:
         # volume.create disabled by the instance; volume.list still native.
         assert provider.expected_capabilities["volume.create"] is False
         assert provider.expected_capabilities["volume.list"] is True
+        assert provider.capability_states["volume.create"] == "none"
+        assert provider.capability_states["volume.list"] == "native"
 
     def test_group_override_expands_to_leaves(self, tmp_path: Path) -> None:
         path = self._manifest(tmp_path)
@@ -520,11 +533,13 @@ class TestInstanceConfig:
                 "instance": {"provider": {"capabilities": {"volume": "disabled"}}},
             },
         )
-        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        caps = provider.expected_capabilities
         assert caps["volume.list"] is False
         assert caps["volume.get"] is False
         assert caps["volume.create"] is False
         assert caps["volume.delete"] is False
+        assert provider.capability_states["volume.delete"] == "none"
 
     def test_enable_adds_undeclared_capability(self, tmp_path: Path) -> None:
         path = self._manifest(tmp_path)
@@ -535,10 +550,12 @@ class TestInstanceConfig:
                 "instance": {"provider": {"capabilities": {"tenant.list": "enabled"}}},
             },
         )
-        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        caps = provider.expected_capabilities
         # tenant.list was undeclared (unchecked) in the manifest; the instance
         # enables it, so it becomes an expected-supported surface.
         assert caps["tenant.list"] is True
+        assert provider.capability_states["tenant.list"] == "native"
 
     def test_explicit_instance_config_path(self, tmp_path: Path) -> None:
         path = self._manifest(tmp_path)
@@ -566,8 +583,10 @@ class TestInstanceConfig:
                 "instance": {"provider": {"capabilities": {"volume.create": False}}},
             },
         )
-        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        caps = provider.expected_capabilities
         assert caps["volume.create"] is False
+        assert provider.capability_states["volume.create"] == "none"
 
     def test_unknown_capability_key_raises(self, tmp_path: Path) -> None:
         path = self._manifest(tmp_path)

--- a/isvtest/tests/test_storage.py
+++ b/isvtest/tests/test_storage.py
@@ -173,7 +173,7 @@ class TestLoadProviderRegistry:
             tmp_path / "m.yaml",
             {"schema_version": "v1alpha2", "providers": [{"type": "file"}]},
         )
-        with pytest.raises(ManifestError, match="name .*is required"):
+        with pytest.raises(ManifestError, match=r"name .*is required"):
             load_provider_registry({"manifest_path": str(path)})
 
     def test_invalid_provider_type_raises(self, tmp_path: Path) -> None:
@@ -250,7 +250,7 @@ class TestLoadProviderRegistry:
                 "providers": [{"name": "weird", "type": "file", "shim": {"kind": "binary", "module": "x"}}],
             },
         )
-        with pytest.raises(ManifestError, match="shim.kind"):
+        with pytest.raises(ManifestError, match=r"shim.kind"):
             load_provider_registry({"manifest_path": str(path)})
 
     def test_python_shim_requires_module(self, tmp_path: Path) -> None:
@@ -261,7 +261,7 @@ class TestLoadProviderRegistry:
                 "providers": [{"name": "p", "type": "file", "shim": {"kind": "python"}}],
             },
         )
-        with pytest.raises(ManifestError, match="shim.module is required"):
+        with pytest.raises(ManifestError, match=r"shim.module is required"):
             load_provider_registry({"manifest_path": str(path)})
 
 
@@ -337,7 +337,7 @@ class TestIdentityAndCapabilities:
             tmp_path / "m.yaml",
             {"schema_version": "v1alpha2", "providers": [{"provider": {"type": "file"}}]},
         )
-        with pytest.raises(ManifestError, match="name .*is required"):
+        with pytest.raises(ManifestError, match=r"name .*is required"):
             load_provider_registry({"manifest_path": str(path)})
 
     def test_hierarchical_capabilities_lowered_to_cap_ids(self, tmp_path: Path) -> None:

--- a/isvtest/tests/test_storage.py
+++ b/isvtest/tests/test_storage.py
@@ -1,0 +1,594 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``isvtest.core.storage.load_provider_registry``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from isvtest.core.storage import (
+    ManifestError,
+    Provider,
+    load_provider_registry,
+)
+from isvtest.core.storage_provider import MockStorageApi, StorageProvider
+
+_MOCK_SHIM_BODY = (
+    "from isvtest.core.storage_provider import MockStorageApi\n"
+    "def build_api():\n"
+    "    return MockStorageApi(tenant_id='reg-test')\n"
+)
+
+
+def _write_manifest(path: Path, payload: dict) -> Path:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False))
+    return path
+
+
+def _shim_provider(name: str = "p1", module: str = "shim.py", **extra) -> dict:
+    entry = {
+        "name": name,
+        "type": "file",
+        "tenant_id": "tenant-1",
+        "shim": {"kind": "python", "module": module},
+    }
+    entry.update(extra)
+    return entry
+
+
+class TestLoadProviderRegistry:
+    def test_empty_manifest_path_returns_empty_list(self) -> None:
+        assert load_provider_registry({}) == []
+        assert load_provider_registry({"manifest_path": ""}) == []
+        assert load_provider_registry({"manifest_path": "   "}) == []
+
+    def test_missing_manifest_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ManifestError, match="not found"):
+            load_provider_registry({"manifest_path": str(tmp_path / "missing.yaml")})
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "broken.yaml"
+        path.write_text("schema_version: v1alpha2\nproviders: [unterminated\n")
+        with pytest.raises(ManifestError, match="failed to parse"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_unsupported_schema_version_raises(self, tmp_path: Path) -> None:
+        path = _write_manifest(tmp_path / "m.yaml", {"schema_version": "v0", "providers": []})
+        with pytest.raises(ManifestError, match="schema_version"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_providers_must_be_list(self, tmp_path: Path) -> None:
+        path = _write_manifest(tmp_path / "m.yaml", {"schema_version": "v1alpha2", "providers": {}})
+        with pytest.raises(ManifestError, match="providers must be a list"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_python_shim_is_loaded(self, tmp_path: Path) -> None:
+        (tmp_path / "shim.py").write_text(_MOCK_SHIM_BODY)
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {"schema_version": "v1alpha2", "providers": [_shim_provider()]},
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert len(providers) == 1
+        provider = providers[0]
+        assert isinstance(provider, Provider)
+        assert provider.name == "p1"
+        assert provider.volume_type == "file"
+        assert provider.tenant_id == "tenant-1"
+        assert provider.has_shim is True
+        assert isinstance(provider.api, StorageProvider)
+        assert isinstance(provider.api, MockStorageApi)
+
+    def test_rest_shim_kind_returns_provider_without_api(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "rest-only",
+                        "type": "file",
+                        "tenant_id": "t-rest",
+                        "shim": {"kind": "rest", "endpoint": "https://example.com"},
+                    }
+                ],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert len(providers) == 1
+        assert providers[0].shim_kind == "rest"
+        assert providers[0].api is None
+        assert providers[0].has_shim is False
+
+    def test_provider_without_shim_has_no_api(self, tmp_path: Path) -> None:
+        # A provider with no `shim:` block (e.g. CSI-only, not yet onboarded) is
+        # carried through with no api; StorageProviderApiCheck skips it. Extra
+        # vendor keys the loader does not consume are ignored harmlessly.
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "ebs",
+                        "type": "block",
+                        "tenant_id": "123456789012",
+                        "csi": {"provisioner": "ebs.csi.aws.com", "storage_classes": ["gp3"]},
+                    }
+                ],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert providers[0].shim_kind is None
+        assert providers[0].api is None
+        assert providers[0].has_shim is False
+
+    def test_multi_provider_manifest_preserves_order(self, tmp_path: Path) -> None:
+        (tmp_path / "shim.py").write_text(_MOCK_SHIM_BODY)
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    _shim_provider(name="alpha"),
+                    {"name": "beta", "type": "block", "tenant_id": "t"},
+                    _shim_provider(name="gamma"),
+                ],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert [p.name for p in providers] == ["alpha", "beta", "gamma"]
+        assert [p.has_shim for p in providers] == [True, False, True]
+
+    def test_duplicate_provider_name_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "shim.py").write_text(_MOCK_SHIM_BODY)
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [_shim_provider(name="dup"), _shim_provider(name="dup")],
+            },
+        )
+        with pytest.raises(ManifestError, match="duplicate"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_missing_provider_name_raises(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {"schema_version": "v1alpha2", "providers": [{"type": "file"}]},
+        )
+        with pytest.raises(ManifestError, match="name .*is required"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_invalid_provider_type_raises(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {"schema_version": "v1alpha2", "providers": [{"name": "p", "type": "object"}]},
+        )
+        with pytest.raises(ManifestError, match="type must be"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_shim_module_resolved_relative_to_manifest_dir(self, tmp_path: Path) -> None:
+        sub = tmp_path / "shims"
+        sub.mkdir()
+        (sub / "api.py").write_text(_MOCK_SHIM_BODY)
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [_shim_provider(module="shims/api.py")],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert providers[0].has_shim is True
+
+    def test_shim_load_failure_wrapped_as_manifest_error(self, tmp_path: Path) -> None:
+        (tmp_path / "broken.py").write_text("raise SyntaxError('nope')\n")
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {"schema_version": "v1alpha2", "providers": [_shim_provider(module="broken.py")]},
+        )
+        with pytest.raises(ManifestError, match="failed to load shim"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_invalid_capability_state_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "shim.py").write_text(_MOCK_SHIM_BODY)
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [_shim_provider(capabilities={"volumeManagement": "yes"})],
+            },
+        )
+        with pytest.raises(ManifestError, match="capability state must be one of"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_attributes_are_string_coerced(self, tmp_path: Path) -> None:
+        (tmp_path / "shim.py").write_text(_MOCK_SHIM_BODY)
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [_shim_provider(attributes={"region": "us-east-1", "count": 3})],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert providers[0].attributes == {"region": "us-east-1", "count": "3"}
+
+    def test_integer_tenant_id_is_string_coerced(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [{"name": "aws", "type": "block", "tenant_id": 123456789012}],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert providers[0].tenant_id == "123456789012"
+
+    def test_unsupported_shim_kind_raises(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [{"name": "weird", "type": "file", "shim": {"kind": "binary", "module": "x"}}],
+            },
+        )
+        with pytest.raises(ManifestError, match="shim.kind"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_python_shim_requires_module(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [{"name": "p", "type": "file", "shim": {"kind": "python"}}],
+            },
+        )
+        with pytest.raises(ManifestError, match="shim.module is required"):
+            load_provider_registry({"manifest_path": str(path)})
+
+
+class TestIdentityAndCapabilities:
+    def test_name_and_type_derived_from_provider_block(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "namespace": "aws.amazon.com",
+                "providers": [
+                    {
+                        "id": "fsx-lustre",
+                        "provider": {"type": "FILE", "protocols": ["lustre"], "version": "0.1.0"},
+                        "tenant_id": "123456789012",
+                    }
+                ],
+            },
+        )
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.name == "fsx-lustre"
+        assert provider.volume_type == "file"
+        assert provider.provider_namespace == "aws.amazon.com"
+        assert provider.provider_id == "fsx-lustre"
+        assert provider.provider_version == "0.1.0"
+        assert provider.storage_protocols == ("lustre",)
+
+    def test_explicit_name_type_win_over_provider_block(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "explicit-name",
+                        "type": "block",
+                        "id": "other",
+                        "provider": {"type": "file"},
+                    }
+                ],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert providers[0].name == "explicit-name"
+        assert providers[0].volume_type == "block"
+
+    def test_legacy_identity_block_is_fallback(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "identity": {
+                            "provider": {"domain": "aws.amazon.com", "id": "fsx", "version": "0.2.0"},
+                            "storage_type": "FILE",
+                            "storage_protocol": "lustre",
+                        },
+                        "tenant_id": "1",
+                    }
+                ],
+            },
+        )
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.name == "fsx"
+        assert provider.volume_type == "file"
+        assert provider.provider_namespace == "aws.amazon.com"
+        assert provider.storage_protocols == ("lustre",)
+        assert provider.provider_version == "0.2.0"
+
+    def test_missing_name_and_id_raises(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {"schema_version": "v1alpha2", "providers": [{"provider": {"type": "file"}}]},
+        )
+        with pytest.raises(ManifestError, match="name .*is required"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_hierarchical_capabilities_lowered_to_cap_ids(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "p",
+                        "type": "file",
+                        "capabilities": {
+                            "tenantManagement": {"list": "none", "get": "none", "getQuota": "native"},
+                            "volumeManagement": "native",
+                            "quotaManagement": "none",
+                        },
+                    }
+                ],
+            },
+        )
+        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        assert caps["tenant.list"] is False
+        assert caps["tenant.getQuota"] is True
+        assert caps["volume.create"] is True
+        assert caps["volume.list"] is True
+        assert caps["quota.directory.set"] is False
+        assert caps["quota.user.get"] is False
+
+    def test_package_default_capabilities_apply(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "default_capabilities": {"default": "none"},
+                "providers": [{"name": "p", "type": "file", "capabilities": {"volumeManagement": "native"}}],
+            },
+        )
+        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        # volume.* native via provider block; everything else falls to package default none.
+        assert caps["volume.create"] is True
+        assert caps["quota.user.set"] is False
+        assert caps["tenant.list"] is False
+
+    def test_package_default_capabilities_camelcase_key(self, tmp_path: Path) -> None:
+        # The camelCase `defaultCapabilities` key mirrors the upstream package
+        # manifest and resolves identically to the snake_case alias.
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "defaultCapabilities": {"default": "none"},
+                "providers": [{"name": "p", "type": "file", "capabilities": {"volumeManagement": "native"}}],
+            },
+        )
+        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        assert caps["volume.create"] is True
+        assert caps["quota.user.set"] is False
+        assert caps["tenant.list"] is False
+
+    def test_no_capabilities_leaves_map_empty(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {"schema_version": "v1alpha2", "providers": [{"name": "p", "type": "file"}]},
+        )
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.expected_capabilities == {}
+
+    def test_capability_qualifiers_parsed(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "p",
+                        "type": "file",
+                        "capability_qualifiers": {"quota.directory": {"idAssignment": "backend"}},
+                    }
+                ],
+            },
+        )
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.capability_qualifiers == {"quota.directory": {"idAssignment": "backend"}}
+
+    def test_unconsumed_sections_are_ignored(self, tmp_path: Path) -> None:
+        # csi / topology / protocol_expectations are no longer part of the
+        # manifest contract (the CSI/NFS/POSIX checks are config-driven). Any
+        # such leftover keys are ignored harmlessly rather than rejected.
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "p",
+                        "type": "file",
+                        "csi": {"storage_classes_by_type": {"shared_fs": "sc"}},
+                        "topology": {"node_selector": {"k": "v"}},
+                        "protocol_expectations": {"nfs": {"version": "3"}},
+                    }
+                ],
+            },
+        )
+        providers = load_provider_registry({"manifest_path": str(path)})
+        assert providers[0].name == "p"
+        assert not hasattr(providers[0], "csi")
+
+    def test_v1alpha1_manifest_has_empty_capabilities(self, tmp_path: Path) -> None:
+        path = _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "providers": [{"name": "p", "type": "file", "tenant_id": "t"}],
+            },
+        )
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.expected_capabilities == {}
+
+
+class TestInstanceConfig:
+    """The optional second layer: a per-instance ``config.yaml`` overlaying the
+    manifest's defaultTenant / storageClasses / capabilities (consume-only)."""
+
+    def _manifest(self, tmp_path: Path) -> Path:
+        return _write_manifest(
+            tmp_path / "m.yaml",
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "p",
+                        "type": "file",
+                        "tenant_id": "manifest-tenant",
+                        "capabilities": {
+                            "volumeManagement": "native",
+                            "tenantManagement": {"getQuota": "native"},
+                        },
+                    }
+                ],
+            },
+        )
+
+    def test_no_sibling_config_leaves_manifest_untouched(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.tenant_id == "manifest-tenant"
+        assert provider.expected_capabilities["volume.create"] is True
+        assert provider.storage_classes == ()
+
+    def test_sibling_config_overrides_tenant_and_capabilities(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        _write_manifest(
+            tmp_path / "config.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {
+                    "id": "default",
+                    "provider": {
+                        "defaultTenant": "instance-tenant",
+                        "storageClasses": ["sc-fast", "sc-bulk"],
+                        # disable a manifest-native leaf; enable a group.
+                        "capabilities": {"volume.create": "disabled"},
+                    },
+                },
+            },
+        )
+        provider = load_provider_registry({"manifest_path": str(path)})[0]
+        assert provider.tenant_id == "instance-tenant"
+        assert provider.storage_classes == ("sc-fast", "sc-bulk")
+        # volume.create disabled by the instance; volume.list still native.
+        assert provider.expected_capabilities["volume.create"] is False
+        assert provider.expected_capabilities["volume.list"] is True
+
+    def test_group_override_expands_to_leaves(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        _write_manifest(
+            tmp_path / "config.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {"provider": {"capabilities": {"volume": "disabled"}}},
+            },
+        )
+        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        assert caps["volume.list"] is False
+        assert caps["volume.get"] is False
+        assert caps["volume.create"] is False
+        assert caps["volume.delete"] is False
+
+    def test_enable_adds_undeclared_capability(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        _write_manifest(
+            tmp_path / "config.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {"provider": {"capabilities": {"tenant.list": "enabled"}}},
+            },
+        )
+        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        # tenant.list was undeclared (unchecked) in the manifest; the instance
+        # enables it, so it becomes an expected-supported surface.
+        assert caps["tenant.list"] is True
+
+    def test_explicit_instance_config_path(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        inst = _write_manifest(
+            tmp_path / "elsewhere.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {"provider": {"defaultTenant": "explicit-tenant"}},
+            },
+        )
+        provider = load_provider_registry({"manifest_path": str(path), "instance_config_path": str(inst)})[0]
+        assert provider.tenant_id == "explicit-tenant"
+
+    def test_missing_explicit_instance_config_raises(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        with pytest.raises(ManifestError, match="instance config file not found"):
+            load_provider_registry({"manifest_path": str(path), "instance_config_path": str(tmp_path / "nope.yaml")})
+
+    def test_bool_override_value_accepted(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        _write_manifest(
+            tmp_path / "config.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {"provider": {"capabilities": {"volume.create": False}}},
+            },
+        )
+        caps = load_provider_registry({"manifest_path": str(path)})[0].expected_capabilities
+        assert caps["volume.create"] is False
+
+    def test_unknown_capability_key_raises(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        _write_manifest(
+            tmp_path / "config.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {"provider": {"capabilities": {"bogus.surface": "enabled"}}},
+            },
+        )
+        with pytest.raises(ManifestError, match="unknown capability key"):
+            load_provider_registry({"manifest_path": str(path)})
+
+    def test_bad_override_value_raises(self, tmp_path: Path) -> None:
+        path = self._manifest(tmp_path)
+        _write_manifest(
+            tmp_path / "config.yaml",
+            {
+                "schema_version": "v1alpha1",
+                "instance": {"provider": {"capabilities": {"volume.create": "on"}}},
+            },
+        )
+        with pytest.raises(ManifestError, match="must be 'enabled' or 'disabled'"):
+            load_provider_registry({"manifest_path": str(path)})

--- a/isvtest/tests/test_storage_provider.py
+++ b/isvtest/tests/test_storage_provider.py
@@ -1,0 +1,492 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``StorageProviderApiCheck`` driven through ``MockStorageApi``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from isvtest.core.storage import Provider
+from isvtest.core.storage_provider import (
+    CAP_TENANT_LIST,
+    CAP_USER_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    AuthenticationError,
+    CreateVolumeRequest,
+    GetTenantQuotaRequest,
+    ListTenantsRequest,
+    ListVolumesRequest,
+    MockStorageApi,
+    NotSupportedError,
+    StorageProvider,
+    TagFilter,
+    TenantQuota,
+    Volume,
+    new_implementation,
+)
+from isvtest.core.storage_provider.mock import default_mock_core
+from isvtest.validations.storage_provider import StorageProviderApiCheck
+
+_MOCK_SHIM_BODY = (
+    "from isvtest.core.storage_provider import MockStorageApi, new_implementation\n"
+    "from isvtest.core.storage_provider.mock import default_mock_core\n"
+    "def build_api():\n"
+    "    return new_implementation(\n"
+    "        core=default_mock_core(),\n"
+    "        impl=MockStorageApi(tenant_id='unit-test', hard_limit_bytes=10 * 1024**3),\n"
+    "    )\n"
+)
+
+
+def _served(impl: MockStorageApi) -> StorageProvider:
+    """Serve a mock ``Implementation`` the way a shim's ``build_api()`` would.
+
+    Composes it through ``new_implementation`` so ``properties()`` and capability
+    gating are live (the mock resolves its own default tenant internally, so no
+    ``default_tenant`` wrapping is applied).
+    """
+    return new_implementation(core=default_mock_core(), impl=impl)
+
+
+def _write_manifest_with_mock_shim(tmp_path: Path) -> Path:
+    (tmp_path / "shim.py").write_text(_MOCK_SHIM_BODY)
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "v1alpha2",
+                "providers": [
+                    {
+                        "name": "mock-fs",
+                        "type": "file",
+                        "tenant_id": "unit-test",
+                        "shim": {"kind": "python", "module": "shim.py"},
+                    }
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+    return manifest
+
+
+def _outcomes(check: StorageProviderApiCheck) -> dict[str, dict[str, Any]]:
+    return {r["name"]: r for r in check._subtest_results}
+
+
+class TestStorageProviderApiCheckSkipPaths:
+    def test_missing_manifest_path_skips_cleanly(self) -> None:
+        check = StorageProviderApiCheck(config={})
+        check.run()
+        assert check.passed
+        assert "manifest_path unset" in check._output
+
+    def test_manifest_missing_file_fails(self, tmp_path: Path) -> None:
+        check = StorageProviderApiCheck(config={"manifest_path": str(tmp_path / "nope.yaml")})
+        check.run()
+        assert not check.passed
+        assert "Failed to load provider manifest" in check._error
+
+    def test_no_python_shim_skips_with_note(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "m.yaml"
+        manifest.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": "v1alpha2",
+                    "providers": [
+                        {"name": "ebs", "type": "block", "tenant_id": "t"},
+                        {
+                            "name": "rest-fs",
+                            "type": "file",
+                            "tenant_id": "t",
+                            "shim": {"kind": "rest", "endpoint": "https://x"},
+                        },
+                    ],
+                },
+                sort_keys=False,
+            )
+        )
+        check = StorageProviderApiCheck(config={"manifest_path": str(manifest)})
+        check.run()
+        assert check.passed
+        assert "rest-fs" in check._output
+        assert "ebs" in check._output
+
+
+class TestStorageProviderApiCheckHappyPath:
+    def test_full_n019_n020_n021_path(self, tmp_path: Path) -> None:
+        manifest = _write_manifest_with_mock_shim(tmp_path)
+        check = StorageProviderApiCheck(config={"manifest_path": str(manifest), "volume_size_bytes": 1024 * 1024})
+        check.run()
+        assert check.passed, f"unexpected error: {check._error}"
+        outcomes = _outcomes(check)
+        assert outcomes["api-authentication[mock-fs]"]["passed"]
+        assert outcomes["volume-provisioning[mock-fs]"]["passed"]
+        assert outcomes["tenant-quota[mock-fs]"]["passed"]
+        assert all(not r["skipped"] for r in check._subtest_results)
+
+    def test_volume_is_deleted_on_pass(self, tmp_path: Path) -> None:
+        manifest = _write_manifest_with_mock_shim(tmp_path)
+        check = StorageProviderApiCheck(config={"manifest_path": str(manifest)})
+
+        captured: dict[str, Provider] = {}
+        original = StorageProviderApiCheck._exercise_provider
+
+        def spy(self: StorageProviderApiCheck, provider: Provider, **kw: Any) -> bool:
+            captured["provider"] = provider
+            return original(self, provider, **kw)
+
+        with patch.object(StorageProviderApiCheck, "_exercise_provider", new=spy):
+            check.run()
+
+        api = captured["provider"].api
+        assert isinstance(api, StorageProvider)
+        assert api.list_volumes(ListVolumesRequest()).volumes == ()
+
+
+class _FailHealth(MockStorageApi):
+    def health_check(self) -> None:
+        raise AuthenticationError("nope")
+
+
+class _NoCreate(MockStorageApi):
+    def create_volume(self, req: CreateVolumeRequest) -> Volume:
+        raise NotSupportedError("CSI owns lifecycle")
+
+    def delete_volume(self, req: Any) -> None:
+        raise NotSupportedError("CSI owns lifecycle")
+
+
+class _NoCreateAndListBroken(_NoCreate):
+    def list_volumes(self, req: ListVolumesRequest) -> Any:
+        raise RuntimeError("list_volumes blew up")
+
+
+class _NoListTenants(MockStorageApi):
+    def list_tenants(self, req: ListTenantsRequest) -> Any:
+        raise NotSupportedError("tenant enumeration not supported")
+
+
+class _NoDirectorySet(MockStorageApi):
+    """Backs everything except directory-quota set, which is a raising stub."""
+
+    def set_directory_quota(self, req: Any) -> Any:
+        raise NotSupportedError("directory quota set not supported")
+
+
+class _NoUserSet(MockStorageApi):
+    """Backs everything except user-quota set (raises NotImplementedError stub)."""
+
+    def set_user_quota(self, req: Any) -> Any:
+        raise NotImplementedError("user quota set not wired up")
+
+
+class _ZeroQuota(MockStorageApi):
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        return TenantQuota(tenant_id=req.tenant_id or "t", hard_limit_bytes=0, used_bytes=0, name="empty")
+
+
+class _BrokenQuota(MockStorageApi):
+    def get_tenant_quota(self, req: GetTenantQuotaRequest) -> TenantQuota:
+        raise RuntimeError("kaboom")
+
+
+def _check_with_api(api: StorageProvider, *, name: str = "p") -> StorageProviderApiCheck:
+    """Construct a StorageProviderApiCheck wired around a synthetic ``Provider``."""
+    provider = Provider(name=name, volume_type="file", tenant_id="t", shim_kind="python", api=api)
+    check = StorageProviderApiCheck(config={"manifest_path": "ignored"})
+
+    def _fake_registry(_config: Any) -> list[Provider]:
+        return [provider]
+
+    check.__dict__["__patch_registry__"] = _fake_registry
+    return check
+
+
+@pytest.fixture
+def patched_registry():
+    """Yield a context manager that swaps in ``load_provider_registry`` per check."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx(check: StorageProviderApiCheck):
+        with patch(
+            "isvtest.validations.storage_provider.load_provider_registry",
+            side_effect=check.__dict__["__patch_registry__"],
+        ):
+            yield
+
+    return _ctx
+
+
+class TestStorageProviderApiCheckFailureModes:
+    def test_authentication_error_short_circuits_provider(self, patched_registry: Any) -> None:
+        check = _check_with_api(_served(_FailHealth(tenant_id="t")), name="bad-auth")
+        with patched_registry(check):
+            check.run()
+        assert not check.passed
+        outcomes = _outcomes(check)
+        assert not outcomes["api-authentication[bad-auth]"]["passed"]
+        assert outcomes["volume-provisioning[bad-auth]"]["skipped"]
+        assert outcomes["tenant-quota[bad-auth]"]["skipped"]
+
+    def test_not_supported_create_falls_back_to_list_volumes(self, patched_registry: Any) -> None:
+        check = _check_with_api(_served(_NoCreate(tenant_id="t")), name="csi-only")
+        with patched_registry(check):
+            check.run()
+        outcomes = _outcomes(check)
+        assert outcomes["api-authentication[csi-only]"]["passed"]
+        assert outcomes["volume-provisioning[csi-only]"]["skipped"]
+        assert outcomes["tenant-quota[csi-only]"]["passed"]
+        assert check.passed, check._error
+
+    def test_not_supported_create_with_broken_list_fails(self, patched_registry: Any) -> None:
+        check = _check_with_api(_served(_NoCreateAndListBroken(tenant_id="t")), name="busted")
+        with patched_registry(check):
+            check.run()
+        outcomes = _outcomes(check)
+        assert not outcomes["volume-provisioning[busted]"]["passed"]
+        assert "list_volumes" in outcomes["volume-provisioning[busted]"]["message"]
+        assert not check.passed
+
+    def test_zero_hard_limit_fails_tenant_quota_subtest(self, patched_registry: Any) -> None:
+        check = _check_with_api(_served(_ZeroQuota(tenant_id="t")), name="zero")
+        with patched_registry(check):
+            check.run()
+        outcomes = _outcomes(check)
+        assert not outcomes["tenant-quota[zero]"]["passed"]
+        assert "hard_limit_bytes=0" in outcomes["tenant-quota[zero]"]["message"]
+        assert not check.passed
+
+    def test_get_tenant_quota_exception_fails_subtest(self, patched_registry: Any) -> None:
+        check = _check_with_api(_served(_BrokenQuota(tenant_id="t")), name="broken")
+        with patched_registry(check):
+            check.run()
+        outcomes = _outcomes(check)
+        assert not outcomes["tenant-quota[broken]"]["passed"]
+        assert "kaboom" in outcomes["tenant-quota[broken]"]["message"]
+        assert not check.passed
+
+
+def _run_provider(provider: Provider, patched_registry: Any) -> StorageProviderApiCheck:
+    """Run the check against a fully-specified ``Provider`` (identity/capabilities)."""
+    check = StorageProviderApiCheck(config={"manifest_path": "ignored"})
+    check.__dict__["__patch_registry__"] = lambda _config: [provider]
+    with patched_registry(check):
+        check.run()
+    return check
+
+
+class TestStorageProviderApiCheckManifestContract:
+    """The manifest is a contract: declared identity/capabilities must match the shim."""
+
+    def test_consistency_passes_when_manifest_matches_shim(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="ok",
+            volume_type="file",
+            tenant_id="t",
+            storage_protocols=("mock",),
+            provider_version="0.1.0",
+            expected_capabilities={
+                "quota.directory.set": True,
+                "quota.user.set": True,
+                CAP_TENANT_LIST: True,
+            },
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        assert _outcomes(check)["manifest-consistency[ok]"]["passed"]
+        assert check.passed, check._error
+
+    def test_storage_type_mismatch_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="bt",
+            volume_type="block",
+            tenant_id="t",
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["manifest-consistency[bt]"]
+        assert not result["passed"]
+        assert "storage_type" in result["message"]
+        assert not check.passed
+
+    def test_protocol_mismatch_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="p",
+            volume_type="file",
+            tenant_id="t",
+            storage_protocols=("nfsv4",),
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["manifest-consistency[p]"]
+        assert not result["passed"]
+        assert "storage_protocols" in result["message"]
+
+    def test_version_mismatch_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="v",
+            volume_type="file",
+            tenant_id="t",
+            provider_version="9.9.9",
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["manifest-consistency[v]"]
+        assert not result["passed"]
+        assert "provider.version" in result["message"]
+
+    def test_directory_set_declared_supported_but_raises_fails(self, patched_registry: Any) -> None:
+        # Declaring quota.directory.set supported while the shim raises the
+        # not-implemented sentinel is a contract violation.
+        provider = Provider(
+            name="dq",
+            volume_type="file",
+            tenant_id="t",
+            expected_capabilities={"quota.directory.set": True},
+            shim_kind="python",
+            api=_served(_NoDirectorySet(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["manifest-consistency[dq]"]
+        assert not result["passed"]
+        assert "quota.directory.set" in result["message"]
+
+    def test_user_set_declared_supported_but_raises_fails(self, patched_registry: Any) -> None:
+        # NotImplementedError is treated as the not-implemented sentinel too.
+        provider = Provider(
+            name="uq",
+            volume_type="file",
+            tenant_id="t",
+            expected_capabilities={CAP_USER_QUOTA_SET: True},
+            shim_kind="python",
+            api=_served(_NoUserSet(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["manifest-consistency[uq]"]
+        assert not result["passed"]
+        assert "quota.user.set" in result["message"]
+
+    def test_capability_declared_none_is_not_probed(self, patched_registry: Any) -> None:
+        # A surface the manifest declares unsupported (none/False) is not probed,
+        # so a shim that happens to back it is fine - only ``supported`` claims
+        # are enforced.
+        provider = Provider(
+            name="lt",
+            volume_type="file",
+            tenant_id="t",
+            expected_capabilities={CAP_TENANT_LIST: False, CAP_USER_QUOTA_SET: False},
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        assert _outcomes(check)["manifest-consistency[lt]"]["passed"]
+
+    def test_list_tenants_declared_true_but_unsupported_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="lt2",
+            volume_type="file",
+            tenant_id="t",
+            expected_capabilities={CAP_TENANT_LIST: True},
+            shim_kind="python",
+            api=_served(_NoListTenants(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["manifest-consistency[lt2]"]
+        assert not result["passed"]
+        assert "tenant.list" in result["message"]
+
+    def test_create_volume_declared_true_but_unsupported_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="cv",
+            volume_type="file",
+            tenant_id="t",
+            expected_capabilities={CAP_VOLUME_CREATE: True},
+            shim_kind="python",
+            api=_served(_NoCreate(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["volume-provisioning[cv]"]
+        assert not result["passed"]
+        assert "volume.create=true" in result["message"]
+        assert not check.passed
+
+    def test_create_volume_declared_false_but_supported_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="cv2",
+            volume_type="file",
+            tenant_id="t",
+            expected_capabilities={CAP_VOLUME_CREATE: False},
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="t")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["volume-provisioning[cv2]"]
+        assert not result["passed"]
+        assert "volume.create=false" in result["message"]
+
+    def test_tenant_id_mismatch_fails(self, patched_registry: Any) -> None:
+        provider = Provider(
+            name="tn",
+            volume_type="file",
+            tenant_id="declared-tenant",
+            shim_kind="python",
+            api=_served(MockStorageApi(tenant_id="actual-tenant")),
+        )
+        check = _run_provider(provider, patched_registry)
+        result = _outcomes(check)["tenant-quota[tn]"]
+        assert not result["passed"]
+        assert "tenant_id" in result["message"]
+        assert not check.passed
+
+
+class TestStorageProviderApiCheckVolumeTags:
+    def test_probe_volume_is_tagged_with_run_id(self, patched_registry: Any) -> None:
+        api = _served(MockStorageApi(tenant_id="t"))
+        check = _check_with_api(api, name="tagged")
+        check.config["run_id"] = "abc123"
+
+        seen: dict[str, dict[str, str]] = {}
+        original_create = api.create_volume
+
+        def spy_create(req: CreateVolumeRequest) -> Volume:
+            vol = original_create(req)
+            seen[vol.id] = dict(vol.tags)
+            return vol
+
+        with patched_registry(check), patch.object(api, "create_volume", side_effect=spy_create):
+            check.run()
+
+        assert seen, "create_volume was not exercised"
+        tags = next(iter(seen.values()))
+        assert tags.get("isvtest-run-id") == "abc123"
+        assert tags.get("test-case") == "N-020"
+        assert tags.get("provider") == "tagged"
+
+        # Orphan-sweep convention: filtering by run id matches the (deleted) probe.
+        assert (
+            api.list_volumes(ListVolumesRequest(tag_filters=(TagFilter("isvtest-run-id", ("abc123",)),))).volumes == ()
+        )

--- a/isvtest/tests/test_storage_quota_enforcement.py
+++ b/isvtest/tests/test_storage_quota_enforcement.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``StorageDirectoryQuotaEnforcementCheck`` helpers.
+
+Covers ``_await_hard`` read-back polling, reused PVC/pod cleanup, and
+``pod_name`` without ``pvc_name`` config rejection.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from isvtest.core.storage import Provider
+from isvtest.core.storage_provider import (
+    CAP_DIRECTORY_QUOTA_DELETE,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_SET,
+    DirectoryQuota,
+    NotFoundError,
+    QuotaLimits,
+)
+from isvtest.validations.storage_quota_enforcement import StorageDirectoryQuotaEnforcementCheck
+
+_WANT = 1 << 30
+
+
+class _Api:
+    """Minimal StorageProvider stand-in returning a scripted read sequence.
+
+    Each entry is a hard-byte value, or an exception instance to raise.
+    """
+
+    def __init__(self, *sequence):
+        self.sequence = list(sequence)
+        self.calls = 0
+        self.requests = []
+
+    def get_directory_quota(self, req):
+        self.calls += 1
+        self.requests.append(req)
+        item = self.sequence[min(self.calls - 1, len(self.sequence) - 1)]
+        if isinstance(item, Exception):
+            raise item
+        return DirectoryQuota(
+            tenant_id="t",
+            volume_id=req.volume_id,
+            path=req.path,
+            hard=None if item is None else QuotaLimits(bytes=item),
+        )
+
+
+@pytest.fixture
+def check():
+    return StorageDirectoryQuotaEnforcementCheck()
+
+
+@pytest.fixture(autouse=True)
+def no_sleep():
+    """Keep the poll's wall-clock behaviour out of the test's runtime."""
+    with patch("isvtest.validations.storage_quota_enforcement.time.sleep"):
+        yield
+
+
+class TestAwaitHard:
+    def test_returns_on_first_read_when_already_published(self, check):
+        api = _Api(_WANT)
+        assert check._await_hard(api, "v1", "sub", _WANT) == (True, _WANT)
+        assert api.calls == 1
+
+    def test_threads_explicit_tenant_to_provider_calls(self, check):
+        api = _Api(_WANT)
+        assert check._await_hard(api, "v1", "sub", _WANT, tenant_id="tenant-a") == (True, _WANT)
+        assert api.requests[0].tenant_id == "tenant-a"
+
+    def test_converges_when_limit_is_published_late(self, check):
+        api = _Api(None, None, _WANT)
+        assert check._await_hard(api, "v1", "sub", _WANT) == (True, _WANT)
+        assert api.calls == 3
+
+    def test_tolerates_not_found_before_the_record_appears(self, check):
+        api = _Api(NotFoundError("nope"), _WANT)
+        assert check._await_hard(api, "v1", "sub", _WANT) == (True, _WANT)
+
+    def test_sees_through_a_stale_previous_value(self, check):
+        api = _Api(_WANT, _WANT, 64 << 20)
+        assert check._await_hard(api, "v1", "sub", 64 << 20) == (True, 64 << 20)
+
+    def test_gives_up_and_reports_the_last_value_seen(self, check):
+        api = _Api(None)
+        with patch(
+            "isvtest.validations.storage_quota_enforcement.time.monotonic",
+            side_effect=[0.0, 100.0, 200.0],
+        ):
+            assert check._await_hard(api, "v1", "sub", _WANT) == (False, None)
+
+    def test_reports_a_wrong_stored_value_rather_than_none(self, check):
+        api = _Api(123)
+        with patch(
+            "isvtest.validations.storage_quota_enforcement.time.monotonic",
+            side_effect=[0.0, 100.0, 200.0],
+        ):
+            assert check._await_hard(api, "v1", "sub", _WANT) == (False, 123)
+
+
+class _CleanupApi:
+    """Records directory-quota deletions attempted during cleanup."""
+
+    def __init__(self):
+        self.deleted: list[tuple[str, str | None, str]] = []
+
+    def delete_directory_quota(self, req):
+        self.deleted.append((req.volume_id, req.tenant_id, req.path))
+
+
+class TestCleanup:
+    def test_own_namespace_is_deleted_wholesale(self, check):
+        check._kubectl_base = "kubectl"
+        api = _CleanupApi()
+        with patch.object(check, "run_command") as rc, patch.object(check, "_exec") as ex:
+            check._cleanup("ns", "pod", "pvc", "sub", api, "v1", ns_created=True, pvc_created=True, pod_created=True)
+        assert [c for c in rc.call_args_list if "delete namespace ns" in c.args[0]]
+        ex.assert_not_called()
+        assert api.deleted == []
+        assert not [c for c in rc.call_args_list if "delete pod" in c.args[0]]
+
+    def test_reused_pod_and_pvc_survive(self, check):
+        check._kubectl_base = "kubectl"
+        api = _CleanupApi()
+        with patch.object(check, "run_command") as rc, patch.object(check, "_exec") as ex:
+            check._cleanup("ns", "pod", "pvc", "sub", api, "v1", ns_created=False, pvc_created=False, pod_created=False)
+        joined = " ".join(c.args[0] for c in rc.call_args_list)
+        assert "delete pod" not in joined
+        assert "delete pvc" not in joined
+        assert "delete namespace" not in joined
+        assert api.deleted == [("v1", None, "sub")]
+        ex.assert_called_once()
+        assert "rm -rf /data/sub" in ex.call_args.args[2]
+
+    def test_cleanup_threads_explicit_tenant_to_quota_delete(self, check):
+        check._kubectl_base = "kubectl"
+        api = _CleanupApi()
+        with patch.object(check, "run_command"), patch.object(check, "_exec"):
+            check._cleanup(
+                "ns",
+                "pod",
+                "pvc",
+                "sub",
+                api,
+                "v1",
+                tenant_id="tenant-a",
+                ns_created=False,
+                pvc_created=False,
+                pod_created=False,
+            )
+        assert api.deleted == [("v1", "tenant-a", "sub")]
+
+    def test_quota_is_dropped_before_its_directory(self, check):
+        check._kubectl_base = "kubectl"
+        order: list[str] = []
+        api = _CleanupApi()
+        api.delete_directory_quota = lambda req: order.append("quota")
+        with (
+            patch.object(check, "run_command"),
+            patch.object(check, "_exec", side_effect=lambda *a: order.append("rm")),
+        ):
+            check._cleanup("ns", "pod", "pvc", "sub", api, "v1", ns_created=False, pvc_created=False, pod_created=False)
+        assert order == ["quota", "rm"]
+
+    def test_already_deleted_quota_is_not_an_error(self, check):
+        check._kubectl_base = "kubectl"
+        api = _CleanupApi()
+        api.delete_directory_quota = Mock(side_effect=NotFoundError("gone"))
+        with patch.object(check, "run_command"), patch.object(check, "_exec") as ex:
+            check._cleanup("ns", "pod", "pvc", "sub", api, "v1", ns_created=False, pvc_created=False, pod_created=False)
+        ex.assert_called_once()
+
+    def test_own_pod_in_reused_pvc_is_removed(self, check):
+        check._kubectl_base = "kubectl"
+        with patch.object(check, "run_command") as rc, patch.object(check, "_exec"):
+            check._cleanup(
+                "ns", "pod", "pvc", "sub", _CleanupApi(), "v1", ns_created=False, pvc_created=False, pod_created=True
+            )
+        joined = " ".join(c.args[0] for c in rc.call_args_list)
+        assert "delete pod pod" in joined
+        assert "delete pvc" not in joined
+
+    def test_nothing_removed_before_a_subdir_was_created(self, check):
+        check._kubectl_base = "kubectl"
+        api = _CleanupApi()
+        with patch.object(check, "run_command"), patch.object(check, "_exec") as ex:
+            check._cleanup("ns", "pod", "pvc", "", api, "v1", ns_created=False, pvc_created=False, pod_created=True)
+        ex.assert_not_called()
+        assert api.deleted == []
+
+    def test_unresolved_volume_skips_the_quota_delete(self, check):
+        check._kubectl_base = "kubectl"
+        api = _CleanupApi()
+        with patch.object(check, "run_command"), patch.object(check, "_exec"):
+            check._cleanup("ns", "pod", "pvc", "sub", api, "", ns_created=False, pvc_created=False, pod_created=False)
+        assert api.deleted == []
+
+
+class TestCandidateSelection:
+    """Provider prefiltering for the directory-quota CRUD surface."""
+
+    def test_set_only_directory_quota_provider_is_skipped(self):
+        provider = Provider(
+            name="set-only",
+            volume_type="file",
+            tenant_id="tenant",
+            shim_kind="python",
+            api=object(),
+            expected_capabilities={CAP_DIRECTORY_QUOTA_SET: True},
+        )
+        check = StorageDirectoryQuotaEnforcementCheck(config={"manifest_path": "manifest.yaml"})
+        with (
+            patch("isvtest.validations.storage_quota_enforcement.load_provider_registry", return_value=[provider]),
+            patch("isvtest.validations.storage_quota_enforcement.is_k8s_available") as available,
+        ):
+            check.run()
+        assert check.passed
+        assert "full directory-quota CRUD" in check.message
+        assert CAP_DIRECTORY_QUOTA_LIST in check.message
+        available.assert_not_called()
+
+    def test_full_directory_quota_provider_reaches_k8s_availability_check(self):
+        provider = Provider(
+            name="full",
+            volume_type="file",
+            tenant_id="tenant",
+            shim_kind="python",
+            api=object(),
+            expected_capabilities={
+                CAP_DIRECTORY_QUOTA_SET: True,
+                CAP_DIRECTORY_QUOTA_GET: True,
+                CAP_DIRECTORY_QUOTA_LIST: True,
+                CAP_DIRECTORY_QUOTA_DELETE: True,
+            },
+        )
+        check = StorageDirectoryQuotaEnforcementCheck(
+            config={"manifest_path": "manifest.yaml", "storage_class": "shared-fs"}
+        )
+        with (
+            patch("isvtest.validations.storage_quota_enforcement.load_provider_registry", return_value=[provider]),
+            patch("isvtest.validations.storage_quota_enforcement.is_k8s_available", return_value=False) as available,
+        ):
+            check.run()
+        assert check.passed
+        assert "no reachable Kubernetes" in check.message
+        available.assert_called_once_with()
+
+
+class TestPodReuseConfig:
+    def test_pod_name_without_pvc_name_fails_loudly(self):
+        check = StorageDirectoryQuotaEnforcementCheck(config={"pod_name": "probe"})
+        check.run()
+        assert not check.passed
+        assert "pod_name requires pvc_name" in check.message

--- a/isvtest/tests/test_storage_quota_enforcement.py
+++ b/isvtest/tests/test_storage_quota_enforcement.py
@@ -19,23 +19,52 @@ Covers ``_await_hard`` read-back polling, reused PVC/pod cleanup, and
 ``pod_name`` without ``pvc_name`` config rejection.
 """
 
+from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
 import pytest
 
+from isvtest.core.runners import CommandResult
 from isvtest.core.storage import Provider
 from isvtest.core.storage_provider import (
     CAP_DIRECTORY_QUOTA_DELETE,
     CAP_DIRECTORY_QUOTA_GET,
     CAP_DIRECTORY_QUOTA_LIST,
     CAP_DIRECTORY_QUOTA_SET,
+    CAP_VOLUME_CREATE,
+    CAP_VOLUME_DELETE,
     DirectoryQuota,
+    MountSpec,
     NotFoundError,
     QuotaLimits,
+    Volume,
 )
 from isvtest.validations.storage_quota_enforcement import StorageDirectoryQuotaEnforcementCheck
 
 _WANT = 1 << 30
+_FULL_DIRECTORY_QUOTA_CAPS = (
+    CAP_DIRECTORY_QUOTA_SET,
+    CAP_DIRECTORY_QUOTA_GET,
+    CAP_DIRECTORY_QUOTA_LIST,
+    CAP_DIRECTORY_QUOTA_DELETE,
+)
+
+
+def _directory_quota_provider(
+    name: str = "full",
+    *,
+    api: object | None = None,
+    capability_states: dict[str, str] | None = None,
+) -> Provider:
+    return Provider(
+        name=name,
+        volume_type="file",
+        tenant_id="tenant",
+        shim_kind="python",
+        api=api or object(),
+        expected_capabilities={cap: True for cap in _FULL_DIRECTORY_QUOTA_CAPS},
+        capability_states=capability_states or {},
+    )
 
 
 class _Api:
@@ -238,19 +267,7 @@ class TestCandidateSelection:
         available.assert_not_called()
 
     def test_full_directory_quota_provider_reaches_k8s_availability_check(self):
-        provider = Provider(
-            name="full",
-            volume_type="file",
-            tenant_id="tenant",
-            shim_kind="python",
-            api=object(),
-            expected_capabilities={
-                CAP_DIRECTORY_QUOTA_SET: True,
-                CAP_DIRECTORY_QUOTA_GET: True,
-                CAP_DIRECTORY_QUOTA_LIST: True,
-                CAP_DIRECTORY_QUOTA_DELETE: True,
-            },
-        )
+        provider = _directory_quota_provider()
         check = StorageDirectoryQuotaEnforcementCheck(
             config={"manifest_path": "manifest.yaml", "storage_class": "shared-fs"}
         )
@@ -260,8 +277,131 @@ class TestCandidateSelection:
         ):
             check.run()
         assert check.passed
-        assert "no reachable Kubernetes" in check.message
+        assert any("no reachable Kubernetes" in result["message"] for result in check._subtest_results)
         available.assert_called_once_with()
+
+
+class TestAcquisitionRouting:
+    def test_csi_provider_uses_k8s_path_when_k8s_available(self):
+        provider = _directory_quota_provider(
+            capability_states={CAP_VOLUME_CREATE: "default", CAP_VOLUME_DELETE: "default"}
+        )
+        check = StorageDirectoryQuotaEnforcementCheck(
+            config={"manifest_path": "manifest.yaml", "storage_class": "shared-fs"}
+        )
+
+        with (
+            patch("isvtest.validations.storage_quota_enforcement.load_provider_registry", return_value=[provider]),
+            patch("isvtest.validations.storage_quota_enforcement.is_k8s_available", return_value=True),
+            patch("isvtest.validations.storage_quota_enforcement.get_kubectl_command", return_value=["kubectl"]),
+            patch("isvtest.validations.storage_quota_enforcement.get_kubectl_base_shell", return_value="kubectl"),
+            patch.object(check, "_exercise_provider_k8s", return_value=True) as k8s,
+            patch.object(check, "_exercise_provider_native", return_value=True) as native,
+        ):
+            check.run()
+
+        assert check.passed
+        k8s.assert_called_once_with(provider)
+        native.assert_not_called()
+
+    def test_native_provider_uses_native_path_when_k8s_unavailable(self):
+        provider = _directory_quota_provider(
+            capability_states={CAP_VOLUME_CREATE: "native", CAP_VOLUME_DELETE: "native"}
+        )
+        check = StorageDirectoryQuotaEnforcementCheck(config={"manifest_path": "manifest.yaml"})
+
+        with (
+            patch("isvtest.validations.storage_quota_enforcement.load_provider_registry", return_value=[provider]),
+            patch("isvtest.validations.storage_quota_enforcement.is_k8s_available", return_value=False),
+            patch.object(check, "_exercise_provider_native", return_value=True) as native,
+            patch.object(check, "_exercise_provider_k8s", return_value=True) as k8s,
+        ):
+            check.run()
+
+        assert check.passed
+        native.assert_called_once_with(provider)
+        k8s.assert_not_called()
+
+
+class _NativeApi:
+    def __init__(self, *, mount: MountSpec | None = MountSpec(fs_type="nfs", source="server:/export")):
+        self.mount = mount
+        self.created = []
+        self.deleted = []
+        self.deleted_quotas = []
+
+    def create_volume(self, req):
+        self.created.append(req)
+        return Volume(
+            tenant_id=req.tenant_id or "tenant",
+            id="vol-1",
+            size_bytes=req.size_bytes,
+            created_at=datetime.now(UTC),
+            type=req.volume_type,
+            state="available",
+            mount=self.mount,
+        )
+
+    def delete_volume(self, req):
+        self.deleted.append(req)
+
+    def delete_directory_quota(self, req):
+        self.deleted_quotas.append(req)
+
+
+class TestNativeLifecycle:
+    def test_native_path_creates_mounts_runs_and_deletes_volume(self):
+        api = _NativeApi()
+        provider = _directory_quota_provider(
+            api=api,
+            capability_states={CAP_VOLUME_CREATE: "native", CAP_VOLUME_DELETE: "native"},
+        )
+        check = StorageDirectoryQuotaEnforcementCheck()
+        check._volume_size = 123
+        check._ns_prefix = "isvtest-dq"
+        check._write_timeout = 30
+        check._create_hard = 64
+        check._enforce_hard = 32
+
+        with (
+            patch("isvtest.validations.storage_quota_enforcement.uuid.uuid4") as uuid4,
+            patch("isvtest.validations.storage_quota_enforcement.tempfile.mkdtemp", return_value="/tmp/isvtest-native"),
+            patch.object(check, "_mount_native_volume", return_value=True) as mount,
+            patch.object(check, "_exec_local", return_value=CommandResult(0, "", "", 0.0)) as exec_local,
+            patch.object(check, "run_command", return_value=CommandResult(0, "", "", 0.0)) as run_command,
+            patch.object(check, "_run_crud", return_value=True) as crud,
+            patch.object(check, "_run_enforcement", return_value=True) as enforcement,
+        ):
+            uuid4.return_value.hex = "abcdef123456"
+            assert check._exercise_provider_native(provider)
+
+        assert api.created[0].size_bytes == 123
+        assert api.created[0].tenant_id == "tenant"
+        assert api.created[0].name == "isvtest-dq-abcdef12"
+        mount.assert_called_once_with(MountSpec(fs_type="nfs", source="server:/export"), "/tmp/isvtest-native")
+        exec_local.assert_any_call("mkdir -p /tmp/isvtest-native/isvtest-dq-abcdef12")
+        crud.assert_called_once()
+        enforcement.assert_called_once()
+        assert api.deleted[0].volume_id == "vol-1"
+        assert api.deleted[0].tenant_id == "tenant"
+        run_command.assert_any_call("umount /tmp/isvtest-native")
+        run_command.assert_any_call("rmdir /tmp/isvtest-native")
+
+    def test_native_path_skips_when_created_volume_has_no_mount_spec(self):
+        api = _NativeApi(mount=None)
+        provider = _directory_quota_provider(
+            api=api,
+            capability_states={CAP_VOLUME_CREATE: "native", CAP_VOLUME_DELETE: "native"},
+        )
+        check = StorageDirectoryQuotaEnforcementCheck()
+        check._volume_size = 123
+        check._ns_prefix = "isvtest-dq"
+
+        assert check._exercise_provider_native(provider)
+
+        assert [result["skipped"] for result in check._subtest_results] == [True, True]
+        assert "returned no mount instructions" in check._subtest_results[0]["message"]
+        assert api.deleted[0].volume_id == "vol-1"
 
 
 class TestPodReuseConfig:

--- a/isvtest/tests/test_vast_shim.py
+++ b/isvtest/tests/test_vast_shim.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hermetic tests for the VAST storage provider shim."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from isvtest.core.storage_provider import (
+    DeleteUserQuotaRequest,
+    QuotaLimits,
+    SetUserQuotaRequest,
+    StorageApiError,
+    UserQuota,
+)
+
+_SHIM = (
+    Path(__file__).resolve().parents[2]
+    / "isvctl"
+    / "configs"
+    / "providers"
+    / "vast"
+    / "scripts"
+    / "storage"
+    / "vast"
+    / "api.py"
+)
+
+
+def _load_shim():
+    """Load the VAST shim by path, matching manifest-loader behavior."""
+    spec = importlib.util.spec_from_file_location("vast_api_under_test", _SHIM)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+vast = _load_shim()
+
+
+def _api():
+    """Build a VAST API instance without making backend calls."""
+    return vast.VastApi(endpoint="https://vast.invalid", token="token", tenant="tenant", storage_path="/exports/k8s")
+
+
+def test_http_endpoint_is_rejected_before_auth_headers_are_sent():
+    """Reject cleartext VMS endpoints during client construction."""
+    with pytest.raises(StorageApiError, match="https://"):
+        vast.VastApi(endpoint="http://vast.invalid", token="token", storage_path="/exports/k8s")
+
+
+def test_user_quota_set_sends_inode_limits_for_default_and_override():
+    """Write hard_limit_inodes wherever quota.user advertises inode support."""
+    api = _api()
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def _request(method: str, path: str, *, body=None, **_kwargs):
+        calls.append((method, path, body))
+        if method == "GET" and path == "/api/quotas/123/":
+            return {"id": 123, "is_user_quota": True}
+        return {"id": 123}
+
+    api._request = _request  # type: ignore[method-assign]
+    api.get_user_quota = lambda req: UserQuota(  # type: ignore[method-assign]
+        tenant_id=req.tenant_id or "", volume_id=req.volume_id, user=req.user
+    )
+
+    api.set_user_quota(
+        SetUserQuotaRequest(
+            UserQuota(tenant_id="tenant", volume_id="123", user=None, hard=QuotaLimits(bytes=4096, inodes=25))
+        )
+    )
+    api.set_user_quota(
+        SetUserQuotaRequest(
+            UserQuota(tenant_id="tenant", volume_id="123", user="1000", hard=QuotaLimits(bytes=8192, inodes=50))
+        )
+    )
+
+    default_body = calls[0][2]
+    override_body = calls[-1][2]
+    assert default_body == {
+        "is_user_quota": True,
+        "default_user_quota": {"hard_limit": 4096, "hard_limit_inodes": 25},
+    }
+    assert override_body is not None
+    assert override_body["hard_limit_inodes"] == 50
+
+
+def test_default_user_quota_delete_clears_inode_limit_too():
+    """Clear default-user byte and inode limits together."""
+    api = _api()
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def _request(method: str, path: str, *, body=None, **_kwargs):
+        calls.append((method, path, body))
+        return {}
+
+    api._request = _request  # type: ignore[method-assign]
+    api.delete_user_quota(DeleteUserQuotaRequest(tenant_id="tenant", volume_id="123", user=None))
+    assert calls == [
+        ("PATCH", "/api/quotas/123/", {"default_user_quota": {"hard_limit": None, "hard_limit_inodes": None}})
+    ]
+
+
+def test_http_errors_do_not_surface_raw_response_bodies(monkeypatch):
+    """Keep backend response bodies out of raised validation errors."""
+    api = _api()
+
+    def _boom(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            url="https://vast.invalid/api/quotas/",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=io.BytesIO(b'{"token":"secret-token"}'),
+        )
+
+    monkeypatch.setattr(vast.urllib.request, "urlopen", _boom)
+    with pytest.raises(StorageApiError) as excinfo:
+        api._request("GET", "/api/quotas/")
+    assert "HTTP 500 Internal Server Error" in str(excinfo.value)
+    assert "secret-token" not in str(excinfo.value)

--- a/isvtest/tests/test_weka_shim.py
+++ b/isvtest/tests/test_weka_shim.py
@@ -1,0 +1,504 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the WEKA ``weka/v2`` CSI volume model and its quota surfaces.
+
+Hermetic: loads ``weka/api.py`` by path (same as the manifest loader) and stubs
+``_request_envelope`` so quota REST calls assert the correct filesystem uid.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from isvtest.core.storage_provider import (
+    DeleteDirectoryQuotaRequest,
+    DeleteUserQuotaRequest,
+    DirectoryQuota,
+    GetUserQuotaRequest,
+    GetVolumeRequest,
+    ListDirectoryQuotasRequest,
+    ListUserQuotasRequest,
+    NotFoundError,
+    NotSupportedError,
+    QuotaLimits,
+    SetDirectoryQuotaRequest,
+    SetUserQuotaRequest,
+    UserQuota,
+    ValidationError,
+)
+
+_SHIM = (
+    Path(__file__).resolve().parents[2]
+    / "isvctl"
+    / "configs"
+    / "providers"
+    / "weka"
+    / "scripts"
+    / "storage"
+    / "weka"
+    / "api.py"
+)
+
+
+def _load_shim():
+    spec = importlib.util.spec_from_file_location("weka_api_under_test", _SHIM)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+weka = _load_shim()
+
+# Filesystem named by WEKA_FILESYSTEM (tenant-quota source).
+_SHARED_FS = {"name": "test_fs", "uid": "uid-shared", "status": "READY", "total_budget": 1000, "used_total": 10}
+# Filesystem the CSI driver minted for one PVC.
+_PVC_FS = {
+    "name": "csivol-pvc-abc",
+    "uid": "uid-pvc-abc",
+    "status": "READY",
+    "total_budget": 50 << 30,
+    "used_total": 1 << 20,
+}
+_PVC_HANDLE = "weka/v2/csivol-pvc-abc"
+
+
+def _make_api(
+    quotas: dict[str, list[dict[str, Any]]] | None = None,
+    storage_path: str | None = None,
+    user_quotas: dict[str, list[dict[str, Any]]] | None = None,
+):
+    """A WekaApi answering from canned REST responses, plus a call log.
+
+    Only ``_request_envelope`` is stubbed: ``_request`` is implemented on top
+    of it, so the unwrapping and pagination under test stay real. User-quota
+    rows are held per filesystem uid so a write is visible to the read-back.
+    """
+    api = weka.WekaApi(
+        endpoint="weka.invalid:14000",
+        username="u",
+        password="p",
+        organization="Root",
+        filesystem="test_fs",
+        storage_path=storage_path,
+        insecure_skip_verify=True,
+    )
+    quotas = quotas or {}
+    user_quotas = {uid: list(rows) for uid, rows in (user_quotas or {}).items()}
+    calls: list[tuple[str, str, Any, Any]] = []
+
+    def _envelope(method: str, path: str, *, body=None, params=None):
+        calls.append((method, path, body, params))
+        if path == "/api/v2/fileSystems":
+            return {"data": [_SHARED_FS, _PVC_FS]}
+        if m := re.fullmatch(r"/api/v2/fileSystems/([^/]+)/quota/user", path):
+            return _user_quota_response(user_quotas, m.group(1), method, params)
+        if m := re.fullmatch(r"/api/v2/fileSystems/([^/]+)/quota", path):
+            return {"data": list(quotas.get(m.group(1), []))}
+        if m := re.fullmatch(r"/api/v2/fileSystems/([^/]+)/resolvePath", path):
+            # Real inode ids are opaque and slash-free; keep that so the quota
+            # URL below stays a single path segment.
+            return {"data": {"inode_id": "inode-" + (params or {})["path"].strip("/").replace("/", "-")}}
+        if m := re.fullmatch(r"/api/v2/fileSystems/([^/]+)/quota/([^/]+)", path):
+            return {
+                "data": {
+                    "quota_id": "new-id",
+                    "inode_id": m.group(2),
+                    "hard_limit_bytes": (body or {}).get("hard_limit_bytes", 0),
+                }
+            }
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    api._request_envelope = _envelope  # type: ignore[method-assign]
+    return api, calls
+
+
+def _user_quota_response(store: dict[str, list[dict[str, Any]]], fs_uid: str, method: str, params):
+    """Serve /quota/user against ``store`` so writes round-trip into reads."""
+    rows = store.setdefault(fs_uid, [])
+    if method == "GET":
+        return {"data": list(rows)}
+    uid = int((params or {})["user_id"])
+    rows[:] = [row for row in rows if row["uid_or_gid"] != uid]
+    if method == "POST":
+        rows.append(
+            {
+                "uid_or_gid": uid,
+                "total_bytes": 0,
+                "hard_limit_bytes": int(params["hard_limit_bytes"]),
+                "soft_limit_bytes": int(params["soft_limit_bytes"]),
+            }
+        )
+    return {"data": {}}
+
+
+def _quota_writes(calls) -> list[tuple[str, str]]:
+    """(method, filesystem uid) for every call that mutates a quota."""
+    out = []
+    for method, path, _, _ in calls:
+        if method in ("PUT", "PATCH", "DELETE") and (
+            m := re.fullmatch(r"/api/v2/fileSystems/([^/]+)/quota/(?!user$).+", path)
+        ):
+            out.append((method, m.group(1)))
+    return out
+
+
+def _user_quota_calls(calls) -> list[tuple[str, str, Any]]:
+    """(method, filesystem uid, query params) for every /quota/user call."""
+    out = []
+    for method, path, _, params in calls:
+        if m := re.fullmatch(r"/api/v2/fileSystems/([^/]+)/quota/user", path):
+            out.append((method, m.group(1), params))
+    return out
+
+
+class TestFsNameFromVolumeId:
+    """Which volume ids name a filesystem, and which do not."""
+
+    @pytest.mark.parametrize(
+        "volume_id,expected",
+        [
+            ("weka/v2/csivol-pvc-abc", "csivol-pvc-abc"),
+            ("csivol-pvc-abc", "csivol-pvc-abc"),
+            ("/vols/pvc-1", ""),
+            ("", ""),
+        ],
+    )
+    def test_classification(self, volume_id, expected):
+        assert weka._fs_name_from_volume_id(volume_id) == expected
+
+
+class TestGetVolume:
+    def test_weka_v2_handle_resolves_to_its_filesystem(self):
+        """The PV handle the CSI driver writes must be answerable as a volume."""
+        api, _ = _make_api()
+        vol = api.get_volume(GetVolumeRequest(volume_id=_PVC_HANDLE))
+        assert vol.name == "csivol-pvc-abc"
+        assert vol.size_bytes == 50 << 30
+        assert vol.used_bytes == 1 << 20
+        assert vol.state == "available"
+        assert vol.csi is not None and vol.csi.volume_handle == _PVC_HANDLE
+
+    def test_volume_id_round_trips_into_quota_calls(self):
+        """get_volume().id must be usable as the volume_id for quota calls."""
+        api, calls = _make_api(quotas={"uid-pvc-abc": []})
+        vol = api.get_volume(GetVolumeRequest(volume_id=_PVC_HANDLE))
+        api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                DirectoryQuota(tenant_id="Root", volume_id=vol.id, path="sub", hard=QuotaLimits(bytes=1))
+            )
+        )
+        assert _quota_writes(calls) == [("PUT", "uid-pvc-abc")]
+
+    def test_unknown_volume_is_not_found(self):
+        api, _ = _make_api()
+        with pytest.raises(NotFoundError):
+            api.get_volume(GetVolumeRequest(volume_id="weka/v2/does-not-exist"))
+
+
+class TestListVolumes:
+    def test_returns_filesystems_as_weka_v2_volumes(self):
+        api, _ = _make_api()
+        volumes = api.list_volumes(weka.ListVolumesRequest()).volumes
+        assert {v.id for v in volumes} == {"weka/v2/test_fs", _PVC_HANDLE}
+        assert all(v.csi is not None and v.csi.volume_handle == v.id for v in volumes)
+
+    def test_filters_by_volume_id(self):
+        api, _ = _make_api()
+        volumes = api.list_volumes(weka.ListVolumesRequest(ids=(_PVC_HANDLE,))).volumes
+        assert [v.id for v in volumes] == [_PVC_HANDLE]
+
+
+class TestSetDirectoryQuotaTargetsTheRightFilesystem:
+    """Quota mutations must hit the volume's filesystem."""
+
+    def test_weka_v2_writes_to_the_pvc_filesystem_at_its_root(self):
+        api, calls = _make_api(quotas={"uid-pvc-abc": []})
+        api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                DirectoryQuota(
+                    tenant_id="Root", volume_id=_PVC_HANDLE, path="isvtest-dq", hard=QuotaLimits(bytes=1 << 30)
+                )
+            )
+        )
+        assert any(call[:2] == ("GET", "/api/v2/fileSystems/uid-pvc-abc/resolvePath") for call in calls)
+        assert _quota_writes(calls) == [("PUT", "uid-pvc-abc")]
+        assert not any("uid-shared" in path for _, path, _, _ in calls if "quota" in path)
+
+    def test_existing_quota_is_patched_not_recreated(self):
+        """An update must PATCH the record already on the PVC filesystem."""
+        existing = {"quota_id": "77", "inode_id": "77", "path": "/isvtest-dq", "hard_limit_bytes": 1}
+        api, calls = _make_api(quotas={"uid-pvc-abc": [existing]})
+        api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                DirectoryQuota(
+                    tenant_id="Root", volume_id=_PVC_HANDLE, path="isvtest-dq", hard=QuotaLimits(bytes=2 << 30)
+                )
+            )
+        )
+        assert _quota_writes(calls) == [("PATCH", "uid-pvc-abc")]
+
+    def test_returned_path_is_relative_to_the_volume(self):
+        api, _ = _make_api(quotas={"uid-pvc-abc": []})
+        got = api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                DirectoryQuota(
+                    tenant_id="Root", volume_id=_PVC_HANDLE, path="isvtest-dq", hard=QuotaLimits(bytes=1 << 30)
+                )
+            )
+        )
+        assert got.path == "isvtest-dq"
+        assert got.hard is not None and got.hard.bytes == 1 << 30
+
+
+class TestSetDirectoryQuotaRefusesTheVolumeRoot:
+    """Empty / ``/`` paths target the CSI capacity quota; reject them."""
+
+    @pytest.mark.parametrize("path", ["", "/", "///"])
+    def test_root_path_is_rejected(self, path):
+        api, calls = _make_api(quotas={"uid-pvc-abc": []})
+        with pytest.raises(ValidationError):
+            api.set_directory_quota(
+                SetDirectoryQuotaRequest(
+                    DirectoryQuota(tenant_id="Root", volume_id=_PVC_HANDLE, path=path, hard=QuotaLimits(bytes=1 << 30))
+                )
+            )
+        assert _quota_writes(calls) == []
+
+    def test_a_subdirectory_is_still_accepted(self):
+        api, calls = _make_api(quotas={"uid-pvc-abc": []})
+        api.set_directory_quota(
+            SetDirectoryQuotaRequest(
+                DirectoryQuota(tenant_id="Root", volume_id=_PVC_HANDLE, path="sub", hard=QuotaLimits(bytes=1 << 30))
+            )
+        )
+        assert _quota_writes(calls) == [("PUT", "uid-pvc-abc")]
+
+
+class TestListAndDelete:
+    def test_list_returns_quotas_under_the_pvc_filesystem_root(self):
+        api, _ = _make_api(
+            quotas={
+                "uid-pvc-abc": [
+                    {"quota_id": "1", "inode_id": "1", "path": "/isvtest-dq", "hard_limit_bytes": 8},
+                    {"quota_id": "2", "inode_id": "2", "path": "/", "hard_limit_bytes": 9},
+                ]
+            }
+        )
+        resp = api.list_directory_quotas(ListDirectoryQuotasRequest(tenant_id="Root", volume_id=_PVC_HANDLE))
+        # The filesystem root is the volume itself, not a quota under it.
+        assert [q.path for q in resp.directory_quotas] == ["isvtest-dq"]
+
+    def test_list_does_not_leak_another_filesystems_quotas(self):
+        other_quota = {"quota_id": "900", "inode_id": "900", "path": "/other", "hard_limit_bytes": 4096}
+        api, _ = _make_api(quotas={"uid-shared": [other_quota], "uid-pvc-abc": []})
+        resp = api.list_directory_quotas(ListDirectoryQuotasRequest(tenant_id="Root", volume_id=_PVC_HANDLE))
+        assert resp.directory_quotas == ()
+
+    def test_delete_targets_the_pvc_filesystem(self):
+        api, calls = _make_api(
+            quotas={"uid-pvc-abc": [{"quota_id": "1", "inode_id": "1", "path": "/isvtest-dq", "hard_limit_bytes": 8}]}
+        )
+        api.delete_directory_quota(
+            DeleteDirectoryQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, path="isvtest-dq")
+        )
+        assert _quota_writes(calls) == [("DELETE", "uid-pvc-abc")]
+
+    def test_delete_of_a_missing_quota_is_a_no_op(self):
+        api, calls = _make_api(quotas={"uid-pvc-abc": []})
+        api.delete_directory_quota(DeleteDirectoryQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, path="gone"))
+        assert _quota_writes(calls) == []
+
+
+class TestStoragePathScoping:
+    def test_does_not_hide_a_volumes_quotas(self):
+        api, _ = _make_api(
+            quotas={"uid-pvc-abc": [{"quota_id": "1", "inode_id": "1", "path": "/isvtest-dq", "hard_limit_bytes": 8}]},
+            storage_path="/vols",
+        )
+        resp = api.list_directory_quotas(ListDirectoryQuotasRequest(tenant_id="Root", volume_id=_PVC_HANDLE))
+        assert [q.path for q in resp.directory_quotas] == ["isvtest-dq"]
+
+
+class TestUserQuotaCrud:
+    """The WEKA 5.1.26 REST surface at /fileSystems/{uid}/quota/user."""
+
+    def test_list_returns_rows_from_the_volumes_filesystem(self):
+        api, calls = _make_api(
+            user_quotas={
+                "uid-pvc-abc": [{"uid_or_gid": 1000, "total_bytes": 512, "hard_limit_bytes": 1 << 20}],
+                "uid-shared": [{"uid_or_gid": 2000, "total_bytes": 1, "hard_limit_bytes": 1}],
+            }
+        )
+        quotas = api.list_user_quotas(ListUserQuotasRequest(tenant_id="Root", volume_id=_PVC_HANDLE)).user_quotas
+        assert [q.user for q in quotas] == ["1000"]
+        assert quotas[0].hard is not None and quotas[0].hard.bytes == 1 << 20
+        assert quotas[0].usage.bytes == 512
+        assert _user_quota_calls(calls) == [("GET", "uid-pvc-abc", None)]
+
+    def test_get_finds_the_uid_and_reports_a_miss_as_not_found(self):
+        api, _ = _make_api(user_quotas={"uid-pvc-abc": [{"uid_or_gid": 1000, "hard_limit_bytes": 4096}]})
+        got = api.get_user_quota(GetUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, user="1000"))
+        assert got.user == "1000"
+        assert got.hard is not None and got.hard.bytes == 4096
+        with pytest.raises(NotFoundError):
+            api.get_user_quota(GetUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, user="2000"))
+
+    def test_set_sends_the_limits_as_query_params_and_reads_back(self):
+        api, calls = _make_api(user_quotas={"uid-pvc-abc": []})
+        got = api.set_user_quota(
+            SetUserQuotaRequest(
+                UserQuota(tenant_id="Root", volume_id=_PVC_HANDLE, user="1000", hard=QuotaLimits(bytes=4096))
+            )
+        )
+        assert got.user == "1000"
+        assert got.hard is not None and got.hard.bytes == 4096
+        # Both limits go on every write: WEKA reads 0 as unlimited, so an
+        # explicit zero is how a limit gets cleared.
+        assert ("POST", "uid-pvc-abc", {"user_id": "1000", "hard_limit_bytes": "4096", "soft_limit_bytes": "0"}) in (
+            _user_quota_calls(calls)
+        )
+
+    def test_delete_addresses_the_uid_on_the_volumes_filesystem(self):
+        api, calls = _make_api(user_quotas={"uid-pvc-abc": [{"uid_or_gid": 1000, "hard_limit_bytes": 4096}]})
+        api.delete_user_quota(DeleteUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, user="1000"))
+        assert _user_quota_calls(calls) == [("DELETE", "uid-pvc-abc", {"user_id": "1000"})]
+        remaining = api.list_user_quotas(ListUserQuotasRequest(tenant_id="Root", volume_id=_PVC_HANDLE)).user_quotas
+        assert remaining == ()
+
+    def test_delete_of_missing_uid_is_a_no_op(self):
+        api, _ = _make_api()
+
+        def _missing(method: str, fs_uid: str, *, params=None):
+            raise NotFoundError("No quota for UID")
+
+        api._user_quota_request = _missing  # type: ignore[method-assign]
+        api.delete_user_quota(DeleteUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, user="1000"))
+
+    def test_list_follows_next_token(self):
+        api, calls = _make_api()
+        pages = [
+            {"data": [{"uid_or_gid": 1000, "total_bytes": 1, "hard_limit_bytes": 10}], "next_token": 3214121},
+            # The final page omits next_token entirely.
+            {"data": [{"uid_or_gid": 1001, "total_bytes": 2, "hard_limit_bytes": 20}]},
+        ]
+
+        def _paged(method: str, path: str, *, body=None, params=None):
+            if path == "/api/v2/fileSystems":
+                return {"data": [_SHARED_FS, _PVC_FS]}
+            calls.append((method, path, body, params))
+            return pages[1] if params else pages[0]
+
+        api._request_envelope = _paged  # type: ignore[method-assign]
+        quotas = api.list_user_quotas(ListUserQuotasRequest(tenant_id="Root", volume_id=_PVC_HANDLE)).user_quotas
+        assert [q.user for q in quotas] == ["1000", "1001"]
+        assert [params for _, _, params in _user_quota_calls(calls)] == [None, {"next_token": "3214121"}]
+
+
+class TestUserQuotaSemantics:
+    @pytest.mark.parametrize("hard_limit_bytes", [0, None])
+    def test_zero_or_absent_hard_limit_is_unlimited(self, hard_limit_bytes):
+        """WEKA reports an unlimited user as 0, not as a zero-byte allowance."""
+        api, _ = _make_api(
+            user_quotas={
+                "uid-pvc-abc": [{"uid_or_gid": 1000, "total_bytes": 512, "hard_limit_bytes": hard_limit_bytes}]
+            }
+        )
+        got = api.get_user_quota(GetUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, user="1000"))
+        assert got.hard is not None and got.hard.bytes is None
+        assert got.usage.bytes == 512
+
+    @pytest.mark.parametrize("user", ["alice", "", "10x"])
+    def test_a_non_numeric_subject_is_rejected(self, user):
+        """WEKA's user_id is numeric; usernames have no REST equivalent."""
+        api, calls = _make_api(user_quotas={"uid-pvc-abc": []})
+        with pytest.raises(ValidationError):
+            api.get_user_quota(GetUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE, user=user))
+        assert _user_quota_calls(calls) == []
+
+    def test_a_directory_backed_volume_is_refused(self):
+        """A filesystem-wide quota on a shared filesystem would bind every PVC on it."""
+        api, calls = _make_api(user_quotas={"uid-pvc-abc": []})
+        with pytest.raises(NotSupportedError):
+            api.list_user_quotas(ListUserQuotasRequest(tenant_id="Root", volume_id="DIR:0xf9a7:0"))
+        assert _user_quota_calls(calls) == []
+
+
+class TestUserQuotaRefusesTheDefaultUserSlot:
+    """WEKA addresses one uid per call, so user=None has no backing endpoint."""
+
+    def test_the_qualifier_is_advertised_false(self):
+        api, _ = _make_api()
+        caps = weka.new_implementation(core=api._core, impl=api).properties().capabilities()
+        assert caps.quota().user().default_user_slot() is False
+        assert caps.quota().user().set().is_supported()
+
+    def test_get_set_and_delete_all_refuse(self):
+        api, calls = _make_api(user_quotas={"uid-pvc-abc": []})
+        with pytest.raises(NotSupportedError):
+            api.get_user_quota(GetUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE))
+        with pytest.raises(NotSupportedError):
+            api.set_user_quota(
+                SetUserQuotaRequest(
+                    UserQuota(tenant_id="Root", volume_id=_PVC_HANDLE, user=None, hard=QuotaLimits(bytes=4096))
+                )
+            )
+        with pytest.raises(NotSupportedError):
+            api.delete_user_quota(DeleteUserQuotaRequest(tenant_id="Root", volume_id=_PVC_HANDLE))
+        # Refusal must not reach the backend and write a per-uid row.
+        assert _user_quota_calls(calls) == []
+
+
+class TestUnknownRouteIsACapabilityGap:
+    """An older cluster answers the route with 404; that is not a missing quota."""
+
+    def test_plain_404_maps_to_not_found(self, monkeypatch):
+        api, _ = _make_api()
+
+        def _missing(*_args, **_kwargs):
+            raise weka.urllib.error.HTTPError(
+                url="https://weka.invalid/api/v2/fileSystems/fs/quota/user",
+                code=404,
+                msg="Not Found",
+                hdrs={},
+                fp=io.BytesIO(b"No quota for UID"),
+            )
+
+        monkeypatch.setattr(weka.urllib.request, "urlopen", _missing)
+        with pytest.raises(NotFoundError):
+            api._raw_request("DELETE", "/api/v2/fileSystems/fs/quota/user", base_url="https://weka.invalid", auth=False)
+
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ('{"message":"Route GET - /api/v2/fileSystems/x/quota/user does not exist"}', True),
+            ('{"message":"uid: \'x\' not found"}', False),
+            ("", False),
+        ],
+    )
+    def test_route_message_classification(self, message, expected):
+        assert weka._is_unknown_route(message) is expected
+
+    def test_the_required_release_is_named(self):
+        with pytest.raises(NotSupportedError, match=r"5\.1\.26"):
+            with weka._user_quota_route():
+                raise NotSupportedError("route not implemented on this cluster release")

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -111,6 +111,11 @@ def find_files() -> list[Path]:
         if rel.parts and rel.parts[0] == ".github":
             continue
 
+        # Vendored third-party source keeps its upstream content/license; it
+        # must not receive NVIDIA SPDX headers.
+        if "vendor" in rel.parts:
+            continue
+
         ext = rel.suffix
 
         if ext in (".py", ".sh", ".tf", ".yaml", ".yml"):


### PR DESCRIPTION
## Summary

Adds the **storage provider API validation** surface to the suite: a
provider-shim framework, a v1alpha2 provider manifest + discovery, two new
validation checks, reference shims for **VAST** and **WEKA** (plus a `my-isv`
scaffold), and in-cluster runbooks with example runs.

This lands the machinery for the storage acceptance requirements
**N-019 … N-031** (see [Related issues](#related-issues)). Checks ship
**unreleased** — exercise them with `ISVTEST_INCLUDE_UNRELEASED=1` until the
release commit onboards them.

---

## New validation checks

Two checks under the `storage_provider_api` group in
`isvctl/configs/suites/storage.yaml`:

### `StorageProviderApiCheck`
Loads the provider manifest, imports the provider's Python shim in-process,
and probes the declared management-API surfaces. Subtests:

| Subtest | Requirement | Issue |
| ------- | ----------- | ----- |
| `manifest-consistency[<provider>]` | manifest ↔ shim contract | — |
| `api-authentication[<provider>]` | N-019 API authentication | [#506](https://github.com/NVIDIA/ai-cloud-validation/issues/506) |
| `volume-provisioning[<provider>]` | N-020 Volume Provisioning API (CSI `list_volumes` fallback when the CSI driver owns lifecycle) | [#507](https://github.com/NVIDIA/ai-cloud-validation/issues/507) |
| `tenant-quota[<provider>]` | N-021 Tenant-level quota exists | [#508](https://github.com/NVIDIA/ai-cloud-validation/issues/508) |

The shim also backs list/get quota and multi-tenant scoping used by
N-022 ([#509](https://github.com/NVIDIA/ai-cloud-validation/issues/509)),
N-023 ([#510](https://github.com/NVIDIA/ai-cloud-validation/issues/510)) and
N-025 ([#512](https://github.com/NVIDIA/ai-cloud-validation/issues/512)).

### `StorageDirectoryQuotaEnforcementCheck`
End-to-end directory-quota lifecycle **and** enforcement against a real
mounted RWX PVC (vs. the sentinel-id probes above). Subtests:

| Subtest | Requirement | Issue |
| ------- | ----------- | ----- |
| `directory-quota-crud[<provider>]` | N-031 Quota CRUD via API; N-027 per-directory quota exists | [#518](https://github.com/NVIDIA/ai-cloud-validation/issues/518), [#514](https://github.com/NVIDIA/ai-cloud-validation/issues/514) |
| `directory-quota-enforcement[<provider>]` | N-028 hard quota enforcement (directory); N-024 usage reflects consumption | [#515](https://github.com/NVIDIA/ai-cloud-validation/issues/515), [#511](https://github.com/NVIDIA/ai-cloud-validation/issues/511) |

User-quota surfaces (set/get/list/delete) back N-026 per-user quota
([#513](https://github.com/NVIDIA/ai-cloud-validation/issues/513)) and N-029
hard user-quota enforcement
([#516](https://github.com/NVIDIA/ai-cloud-validation/issues/516)); these are
covered by the shim contract + hermetic unit tests today.

> **Not yet covered:** N-030 soft quota with grace period
> ([#517](https://github.com/NVIDIA/ai-cloud-validation/issues/517)) — the
> shims are byte-hard-limit only; soft/grace semantics are deferred.

---

## Storage provider shim framework

- `isvtest/src/isvtest/core/storage_provider/` — `StorageApi` ABC, value
  types, capability model, loader, and mock/hermetic test support.
- v1alpha2 **provider manifest** (`storage-provider-manifest.yaml`) declaring
  identity + hierarchical capabilities (`native | default | none`) as a
  contract cross-checked against the shim's `properties()`.
- Manifest → step adapter (`providers/shared/storage_manifest_to_steps.py`)
  that drives the k8s suite via `storage-k8s.yaml`.
- JSON schema at `isvctl/schemas/storage-provider-manifest.schema.json`.

## Reference shims

| Provider | Shim | Notes |
| -------- | ---- | ----- |
| VAST | `providers/vast/scripts/storage/vast/api.py` | VMS REST; directory + user quota; NFS |
| WEKA | `providers/weka/scripts/storage/weka/api.py` | WEKA REST `/api/v2`; directory + user quota (5.1.26+); wekafs |
| my-isv | `providers/my-isv/scripts/storage/api.py` | copy-me scaffold with `DEMO_MODE` |

## Docs & runbooks

- `docs/guides/vast-in-cluster-storage-validation.md`
- `docs/guides/weka-in-cluster-storage-validation.md`
- Provider READMEs + `storage-acceptance-requirements` matrix updates
- Hermetic tests: `test_storage_provider.py`, `test_storage_quota_enforcement.py`,
  `test_vast_shim.py`, `test_weka_shim.py`

---

## Running the checks

Management APIs (VAST VMS, WEKA REST) are frequently reachable only from
inside the cluster network, so the guides use an in-cluster runner Pod plus a
reusable probe PVC/pod and minimal RBAC.

Shared pytest filter and overlays for both providers:

```bash
-k "StorageProviderApi or StorageDirectoryQuotaEnforcement"
```

```yaml
# k8s-capability.yaml — capability must be exactly "kubernetes" (not "k8s")
commands:
  kubernetes:
    phases: ["setup", "test", "teardown"]
tests:
  capability: kubernetes
```

```yaml
# quota-reuse.yaml — MUST be under storage_provider_api (not k8s_storage)
tests:
  validations:
    storage_provider_api:
      checks:
        StorageDirectoryQuotaEnforcementCheck:
          pvc_namespace: isvtest-quota
          pvc_name: quota-probe
          pod_name: quota-probe
```

Shared prerequisites (probe PVC/pod + RBAC granting the runner SA
`pods/exec` in the probe namespace and cluster-scoped `get` on
PersistentVolumes) are in each guide.

### VAST — example run

```bash
# Env: VAST_ENDPOINT, VAST_TOKEN, VAST_STORAGE_PATH (== StorageClass root_export),
#      K8S_CSI_SHARED_FS_SC=<vast-rwx-sc>, ISVTEST_INCLUDE_UNRELEASED=1
uv run python .cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py \
  --manifest isvctl/configs/providers/vast/config/storage-provider-manifest.yaml

ISVTEST_INCLUDE_UNRELEASED=1 \
  uv run isvctl test run \
    -f isvctl/configs/providers/vast/config/storage-k8s.yaml \
    -f k8s-capability.yaml \
    -f quota-reuse.yaml \
    -- -v -s -k "StorageProviderApi or StorageDirectoryQuotaEnforcement"
```

Success: `StorageProviderApiCheck` PASSED (`volume-provisioning` SKIPPED via
CSI `list_volumes` fallback, `tenant-quota` `hard_limit_bytes > 0`) and
`StorageDirectoryQuotaEnforcementCheck` PASSED.

### WEKA — example run

```bash
# Env: WEKA_ENDPOINTS, WEKA_USERNAME/WEKA_PASSWORD (tenant-admin), WEKA_ORGANIZATION,
#      WEKA_FILESYSTEM=<existing fs>, K8S_CSI_SHARED_FS_SC=<weka-rwx-sc>,
#      ISVTEST_INCLUDE_UNRELEASED=1
uv run python .cursor/skills/storage-api-stub-authoring/scripts/probe_shim.py \
  --manifest isvctl/configs/providers/weka/config/storage-provider-manifest.yaml

ISVTEST_INCLUDE_UNRELEASED=1 \
  uv run isvctl test run \
    -f isvctl/configs/providers/weka/config/storage-k8s.yaml \
    -f k8s-capability.yaml \
    -f quota-reuse.yaml \
    -- -v -s -k "StorageProviderApi or StorageDirectoryQuotaEnforcement"
```

Success pattern matches VAST. WEKA login body field is `org` (not
`organization`); use an account with directory-quota rights, not a CSI-only user.

---

## Validation evidence

Both checks were run in-cluster against live VAST and WEKA backends and passed
end-to-end (`isvctl exit code: 0`), including the isolated `probe_shim`
preflight (auth OK, ≥1 volume via `list_volumes`, `hard_limit_bytes > 0`) and
the directory-quota CRUD + write-enforcement subtests. Full setup and expected
output are in the two guides above.

---

## Test plan

- [x] `make lint` / `make test` green
- [x] VAST: `probe_shim` + `isvctl` filter → both checks pass in-cluster
- [x] WEKA: `probe_shim` + `isvctl` filter → both checks pass in-cluster

---

## Related issues

Storage acceptance requirements N-019 … N-031:

- [#506 — N-019: API authentication](https://github.com/NVIDIA/ai-cloud-validation/issues/506)
- [#507 — N-020: Volume Provisioning API](https://github.com/NVIDIA/ai-cloud-validation/issues/507)
- [#508 — N-021: Tenant-level quota exists](https://github.com/NVIDIA/ai-cloud-validation/issues/508)
- [#509 — N-022: List quotas](https://github.com/NVIDIA/ai-cloud-validation/issues/509)
- [#510 — N-023: Get quota by ID](https://github.com/NVIDIA/ai-cloud-validation/issues/510)
- [#511 — N-024: Quota reflects consumed capacity](https://github.com/NVIDIA/ai-cloud-validation/issues/511)
- [#512 — N-025: Multi-tenant isolation](https://github.com/NVIDIA/ai-cloud-validation/issues/512)
- [#513 — N-026: Per-user quota exists](https://github.com/NVIDIA/ai-cloud-validation/issues/513)
- [#514 — N-027: Per-directory (project) quota exists](https://github.com/NVIDIA/ai-cloud-validation/issues/514)
- [#515 — N-028: Hard quota enforcement, directory](https://github.com/NVIDIA/ai-cloud-validation/issues/515)
- [#516 — N-029: Hard quota enforcement, user](https://github.com/NVIDIA/ai-cloud-validation/issues/516)
- [#517 — N-030: Soft quota with grace period](https://github.com/NVIDIA/ai-cloud-validation/issues/517) *(not yet covered)*
- [#518 — N-031: Quota CRUD via API](https://github.com/NVIDIA/ai-cloud-validation/issues/518)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added storage-provider support with manifest-based configuration, capability detection, tenant quotas, volume inventory, and provider health checks.
  * Added validation for storage APIs, CSI-backed volumes, directory quotas, and quota enforcement.
  * Added integrations and validation configurations for AWS FSx for Lustre, VAST, WEKA, and My ISV environments.
  * Added Kubernetes in-cluster configuration and storage test workflows.

* **Documentation**
  * Added comprehensive setup, configuration, troubleshooting, and implementation guidance.

* **Bug Fixes**
  * Improved capability-based suite filtering and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->