### PR TITLE
test(breakfix): implement BFX01-04 cordon validation

### DIFF
--- a/isvctl/configs/providers/my-isv/scripts/breakfix/cordon_node.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/cordon_node.py
@@ -2,36 +2,323 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Cordon a Kubernetes node (BFX01-04) - my-isv template."""
+"""Exercise Kubernetes node cordoning semantics for BFX01-04."""
 
 from __future__ import annotations
 
 import argparse
+import json
+import os
+import shlex
+import subprocess
 import sys
-from pathlib import Path
+import time
+import uuid
+from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _stub import base_result, demo_or_not_implemented, finish
+DEFAULT_IMAGE = "registry.k8s.io/pause:3.10"
+
+
+class CordonTestError(RuntimeError):
+    """Raised when the cordon workflow cannot prove the required behavior."""
+
+
+def _kubectl_command() -> list[str]:
+    """Return the configured kubectl-compatible command prefix."""
+    configured = os.environ.get("KUBECTL", "kubectl")
+    try:
+        command = shlex.split(configured)
+    except ValueError as exc:
+        raise CordonTestError(f"Invalid KUBECTL value: {exc}") from exc
+    if not command:
+        raise CordonTestError("KUBECTL must not be blank")
+    return command
+
+
+def _run(
+    kubectl: list[str],
+    *args: str,
+    input_text: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run kubectl and raise a concise error when the command fails."""
+    try:
+        completed = subprocess.run(
+            [*kubectl, *args],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise CordonTestError(f"Unable to run {' '.join(kubectl)}: {exc}") from exc
+    if check and completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        detail = detail[-500:] if detail else "command failed without output"
+        raise CordonTestError(f"kubectl {' '.join(args)} failed: {detail}")
+    return completed
+
+
+def _json_output(completed: subprocess.CompletedProcess[str], resource: str) -> dict[str, Any]:
+    """Parse one kubectl JSON object."""
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise CordonTestError(f"kubectl returned invalid JSON for {resource}") from exc
+    if not isinstance(payload, dict):
+        raise CordonTestError(f"kubectl returned a non-object for {resource}")
+    return payload
+
+
+def _node_is_ready(node: dict[str, Any]) -> bool:
+    """Return whether a node is Ready, schedulable, and available for the test."""
+    conditions = node.get("status", {}).get("conditions", [])
+    ready = any(item.get("type") == "Ready" and item.get("status") == "True" for item in conditions)
+    return ready and not node.get("spec", {}).get("unschedulable", False)
+
+
+def _select_node(kubectl: list[str], requested_node: str | None) -> tuple[str, str, list[dict[str, str]]]:
+    """Select a schedulable Ready node and return its identity and required tolerations."""
+    payload = _json_output(_run(kubectl, "get", "nodes", "-o", "json"), "node list")
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise CordonTestError("kubectl node list is missing items")
+
+    candidates = [node for node in items if isinstance(node, dict) and _node_is_ready(node)]
+    if requested_node:
+        candidates = [node for node in candidates if node.get("metadata", {}).get("name") == requested_node]
+        if not candidates:
+            raise CordonTestError(f"Requested node {requested_node!r} is not Ready and schedulable")
+    if not candidates:
+        raise CordonTestError("No Ready, schedulable node is available for the cordon test")
+
+    node = candidates[0]
+    metadata = node.get("metadata", {})
+    name = metadata.get("name")
+    hostname = metadata.get("labels", {}).get("kubernetes.io/hostname")
+    if not isinstance(name, str) or not name:
+        raise CordonTestError("Selected node is missing metadata.name")
+    if not isinstance(hostname, str) or not hostname:
+        raise CordonTestError(f"Node {name!r} is missing the kubernetes.io/hostname label")
+    tolerations = []
+    for taint in node.get("spec", {}).get("taints", []):
+        key = taint.get("key")
+        effect = taint.get("effect")
+        if not isinstance(key, str) or effect not in {"NoSchedule", "NoExecute"}:
+            continue
+        if key == "node.kubernetes.io/unschedulable":
+            continue
+        tolerations.append(
+            {
+                "key": key,
+                "operator": "Equal",
+                "value": str(taint.get("value", "")),
+                "effect": effect,
+            }
+        )
+    return name, hostname, tolerations
+
+
+def _pod_manifest(
+    name: str,
+    namespace: str,
+    hostname: str,
+    image: str,
+    tolerations: list[dict[str, str]],
+) -> str:
+    """Build a minimal long-running pod constrained to one node hostname."""
+    return json.dumps(
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": name,
+                "namespace": namespace,
+                "labels": {
+                    "app.kubernetes.io/managed-by": "isvtest",
+                    "isvtest.nvidia.com/purpose": "bfx01-04",
+                },
+            },
+            "spec": {
+                "restartPolicy": "Never",
+                "nodeSelector": {"kubernetes.io/hostname": hostname},
+                "tolerations": tolerations,
+                "containers": [{"name": "probe", "image": image}],
+            },
+        }
+    )
+
+
+def _get_pod(kubectl: list[str], namespace: str, name: str) -> dict[str, Any]:
+    """Return one pod as a JSON object."""
+    completed = _run(kubectl, "get", "pod", name, "-n", namespace, "-o", "json")
+    return _json_output(completed, f"pod {namespace}/{name}")
+
+
+def _pod_is_ready_on_node(pod: dict[str, Any], node_name: str) -> bool:
+    """Return whether a pod is still Ready and bound to the expected node."""
+    if pod.get("spec", {}).get("nodeName") != node_name or pod.get("status", {}).get("phase") != "Running":
+        return False
+    conditions = pod.get("status", {}).get("conditions", [])
+    return any(item.get("type") == "Ready" and item.get("status") == "True" for item in conditions)
+
+
+def _pod_is_unschedulable(pod: dict[str, Any]) -> bool:
+    """Return whether the scheduler explicitly reported the pod unschedulable."""
+    if pod.get("spec", {}).get("nodeName"):
+        return False
+    conditions = pod.get("status", {}).get("conditions", [])
+    return any(
+        item.get("type") == "PodScheduled" and item.get("status") == "False" and item.get("reason") == "Unschedulable"
+        for item in conditions
+    )
+
+
+def _wait_for_unschedulable(
+    kubectl: list[str],
+    namespace: str,
+    name: str,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+) -> bool:
+    """Poll until Kubernetes reports that the new probe cannot be scheduled."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        if _pod_is_unschedulable(_get_pod(kubectl, namespace, name)):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(poll_interval_seconds)
+
+
+def _cleanup(kubectl: list[str], namespace: str, pod_names: list[str], node_name: str | None) -> list[str]:
+    """Delete probe pods and restore node schedulability, returning any errors."""
+    errors: list[str] = []
+    for pod_name in pod_names:
+        try:
+            completed = _run(
+                kubectl,
+                "delete",
+                "pod",
+                pod_name,
+                "-n",
+                namespace,
+                "--ignore-not-found=true",
+                "--wait=false",
+                check=False,
+            )
+        except CordonTestError as exc:
+            errors.append(f"delete pod {namespace}/{pod_name}: {exc}")
+            continue
+        if completed.returncode != 0:
+            errors.append(f"delete pod {namespace}/{pod_name}: {(completed.stderr or completed.stdout).strip()}")
+    if node_name:
+        try:
+            completed = _run(kubectl, "uncordon", node_name, check=False)
+        except CordonTestError as exc:
+            errors.append(f"uncordon node {node_name}: {exc}")
+        else:
+            if completed.returncode != 0:
+                errors.append(f"uncordon node {node_name}: {(completed.stderr or completed.stdout).strip()}")
+    return errors
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description="Cordon a node and verify Kubernetes scheduling behavior")
+    parser.add_argument("--region", default="", help="Accepted for provider config compatibility")
+    parser.add_argument("--node", help="Specific Ready, schedulable node to test")
+    parser.add_argument("--namespace", default="default", help="Namespace for temporary probe pods")
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Container image for temporary probe pods")
+    parser.add_argument("--timeout-seconds", type=float, default=120, help="Timeout for each scheduling assertion")
+    parser.add_argument("--poll-interval-seconds", type=float, default=2, help="Pending-pod polling interval")
+    return parser
 
 
 def main() -> int:
-    """Emit the cordon-node template result (BFX01-04)."""
-    parser = argparse.ArgumentParser(description="Cordon node (template)")
-    parser.add_argument("--region", default="", help="Cloud region")
-    _ = parser.parse_args()
+    """Run the reversible cordon test and emit its provider-neutral JSON result."""
+    args = _parser().parse_args()
+    operation: dict[str, Any] = {
+        "cordoned": False,
+        "new_workloads_blocked": False,
+        "existing_workloads_running": False,
+    }
+    result: dict[str, Any] = {"success": False, "platform": "my-isv", "test_name": "cordon_node"}
+    kubectl: list[str] = []
+    created_pods: list[str] = []
+    cordoned_node: str | None = None
 
-    result = demo_or_not_implemented(
-        {
-            **base_result("cordon_node"),
-            "operation": {
-                "cordoned": True,
-                "new_workloads_blocked": True,
-                "existing_workloads_running": True,
-            },
-        },
-        hint="cordon node breakfix API",
-    )
-    return finish(result)
+    try:
+        if args.timeout_seconds <= 0 or args.poll_interval_seconds <= 0:
+            raise CordonTestError("Timeout and poll interval must be greater than zero")
+        kubectl = _kubectl_command()
+        node_name, hostname, tolerations = _select_node(kubectl, args.node)
+        operation["node_id"] = node_name
+        suffix = uuid.uuid4().hex[:8]
+        existing_pod = f"isvtest-bfx-existing-{suffix}"
+        blocked_pod = f"isvtest-bfx-blocked-{suffix}"
+
+        _run(
+            kubectl,
+            "create",
+            "-f",
+            "-",
+            input_text=_pod_manifest(existing_pod, args.namespace, hostname, args.image, tolerations),
+        )
+        created_pods.append(existing_pod)
+        _run(
+            kubectl,
+            "wait",
+            "--for=condition=Ready",
+            f"pod/{existing_pod}",
+            "-n",
+            args.namespace,
+            f"--timeout={args.timeout_seconds:g}s",
+        )
+
+        _run(kubectl, "cordon", node_name)
+        cordoned_node = node_name
+        node = _json_output(_run(kubectl, "get", "node", node_name, "-o", "json"), f"node {node_name}")
+        operation["cordoned"] = node.get("spec", {}).get("unschedulable") is True
+        if not operation["cordoned"]:
+            raise CordonTestError(f"Node {node_name!r} was not marked unschedulable")
+
+        operation["existing_workloads_running"] = _pod_is_ready_on_node(
+            _get_pod(kubectl, args.namespace, existing_pod), node_name
+        )
+        if not operation["existing_workloads_running"]:
+            raise CordonTestError("Existing probe pod did not remain Ready on the cordoned node")
+
+        _run(
+            kubectl,
+            "create",
+            "-f",
+            "-",
+            input_text=_pod_manifest(blocked_pod, args.namespace, hostname, args.image, tolerations),
+        )
+        created_pods.append(blocked_pod)
+        operation["new_workloads_blocked"] = _wait_for_unschedulable(
+            kubectl,
+            args.namespace,
+            blocked_pod,
+            args.timeout_seconds,
+            args.poll_interval_seconds,
+        )
+        if not operation["new_workloads_blocked"]:
+            raise CordonTestError("New probe pod was not confirmed unschedulable on the cordoned node")
+        result["success"] = True
+    except CordonTestError as exc:
+        result["error"] = str(exc)
+    finally:
+        cleanup_errors = _cleanup(kubectl, args.namespace, created_pods, cordoned_node) if kubectl else []
+        if cleanup_errors:
+            result["success"] = False
+            result["cleanup_errors"] = cleanup_errors
+            result.setdefault("error", "Cordon test cleanup failed")
+
+    result["operation"] = operation
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
 
 
 if __name__ == "__main__":

--- a/isvctl/tests/test_my_isv_cordon_node.py
+++ b/isvctl/tests/test_my_isv_cordon_node.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the my-isv BFX01-04 Kubernetes cordon script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+CORDON_SCRIPT = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "breakfix" / "cordon_node.py"
+
+
+def _load_script() -> ModuleType:
+    """Load the cordon provider script as a module for direct testing."""
+    spec = importlib.util.spec_from_file_location("test_my_isv_cordon_node_script", CORDON_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(
+    args: tuple[str, ...], *, payload: dict[str, Any] | None = None, error: str = ""
+) -> subprocess.CompletedProcess[str]:
+    """Build a completed kubectl command with optional JSON output."""
+    return subprocess.CompletedProcess(
+        args=["kubectl", *args],
+        returncode=1 if error else 0,
+        stdout=json.dumps(payload) if payload is not None else "",
+        stderr=error,
+    )
+
+
+def _node(*, unschedulable: bool = False) -> dict[str, Any]:
+    """Return one Ready, untainted fake node."""
+    return {
+        "metadata": {"name": "worker-1", "labels": {"kubernetes.io/hostname": "worker-1-host"}},
+        "spec": {"unschedulable": unschedulable},
+        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+    }
+
+
+def test_node_taints_are_tolerated_without_bypassing_cordon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Probe pods tolerate the selected GPU taint but never the cordon taint."""
+    module = _load_script()
+    node = _node()
+    node["spec"]["taints"] = [
+        {"key": "nvidia.com/gpu", "value": "present", "effect": "NoSchedule"},
+        {"key": "node.kubernetes.io/unschedulable", "effect": "NoSchedule"},
+    ]
+    monkeypatch.setattr(
+        module,
+        "_run",
+        lambda kubectl, *args, **kwargs: _completed(args, payload={"items": [node]}),
+    )
+
+    name, hostname, tolerations = module._select_node(["kubectl"], None)
+
+    assert (name, hostname) == ("worker-1", "worker-1-host")
+    assert tolerations == [{"key": "nvidia.com/gpu", "operator": "Equal", "value": "present", "effect": "NoSchedule"}]
+
+
+def _running_pod() -> dict[str, Any]:
+    """Return a Ready pod bound to the selected node."""
+    return {
+        "spec": {"nodeName": "worker-1"},
+        "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}]},
+    }
+
+
+def _unschedulable_pod() -> dict[str, Any]:
+    """Return an unbound pod rejected by the scheduler."""
+    return {
+        "spec": {},
+        "status": {
+            "phase": "Pending",
+            "conditions": [{"type": "PodScheduled", "status": "False", "reason": "Unschedulable"}],
+        },
+    }
+
+
+def test_cordon_workflow_proves_all_three_requirements_and_restores_node(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A successful run verifies cordon, old work, and blocked new work before cleanup."""
+    module = _load_script()
+    calls: list[tuple[str, ...]] = []
+    pod_gets = iter([_running_pod(), _unschedulable_pod()])
+
+    def fake_run(kubectl: list[str], *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Return deterministic Kubernetes state for the happy path."""
+        calls.append(args)
+        if args[:4] == ("get", "nodes", "-o", "json"):
+            return _completed(args, payload={"items": [_node()]})
+        if args[:3] == ("get", "node", "worker-1"):
+            return _completed(args, payload=_node(unschedulable=True))
+        if args[:2] == ("get", "pod"):
+            return _completed(args, payload=next(pod_gets))
+        return _completed(args)
+
+    monkeypatch.setattr(module, "_run", fake_run)
+    monkeypatch.setattr(module.uuid, "uuid4", lambda: type("Uuid", (), {"hex": "deadbeefcafebabe"})())
+    monkeypatch.setattr(sys, "argv", ["cordon_node.py", "--timeout-seconds", "1"])
+
+    assert module.main() == 0
+    result = json.loads(capsys.readouterr().out)
+
+    assert result["success"] is True
+    assert result["operation"] == {
+        "cordoned": True,
+        "new_workloads_blocked": True,
+        "existing_workloads_running": True,
+        "node_id": "worker-1",
+    }
+    assert ("cordon", "worker-1") in calls
+    assert calls[-1] == ("uncordon", "worker-1")
+    assert [call[:3] for call in calls].count(("delete", "pod", "isvtest-bfx-existing-deadbeef")) == 1
+    assert [call[:3] for call in calls].count(("delete", "pod", "isvtest-bfx-blocked-deadbeef")) == 1
+
+
+def test_existing_pod_failure_still_uncordons_and_reports_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failed continuation check restores schedulability and emits structured failure."""
+    module = _load_script()
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(kubectl: list[str], *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Make the existing pod disappear from the selected node after cordon."""
+        calls.append(args)
+        if args[:4] == ("get", "nodes", "-o", "json"):
+            return _completed(args, payload={"items": [_node()]})
+        if args[:3] == ("get", "node", "worker-1"):
+            return _completed(args, payload=_node(unschedulable=True))
+        if args[:2] == ("get", "pod"):
+            return _completed(args, payload={"spec": {}, "status": {"phase": "Pending"}})
+        return _completed(args)
+
+    monkeypatch.setattr(module, "_run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["cordon_node.py", "--timeout-seconds", "1"])
+
+    assert module.main() == 1
+    result = json.loads(capsys.readouterr().out)
+
+    assert result["success"] is False
+    assert "did not remain Ready" in result["error"]
+    assert result["operation"]["existing_workloads_running"] is False
+    assert calls[-1] == ("uncordon", "worker-1")
+
+
+def test_uncordon_failure_cannot_report_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A node left cordoned is a failed test even when all assertions passed."""
+    module = _load_script()
+    pod_gets = iter([_running_pod(), _unschedulable_pod()])
+
+    def fake_run(kubectl: list[str], *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Pass the workflow but reject the final uncordon."""
+        if args[:4] == ("get", "nodes", "-o", "json"):
+            return _completed(args, payload={"items": [_node()]})
+        if args[:3] == ("get", "node", "worker-1"):
+            return _completed(args, payload=_node(unschedulable=True))
+        if args[:2] == ("get", "pod"):
+            return _completed(args, payload=next(pod_gets))
+        if args == ("uncordon", "worker-1"):
+            return _completed(args, error="forbidden")
+        return _completed(args)
+
+    monkeypatch.setattr(module, "_run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["cordon_node.py", "--timeout-seconds", "1"])
+
+    assert module.main() == 1
+    result = json.loads(capsys.readouterr().out)
+
+    assert result["success"] is False
+    assert result["error"] == "Cordon test cleanup failed"
+    assert result["cleanup_errors"] == ["uncordon node worker-1: forbidden"]
+
+
+def test_requested_precordoned_node_is_rejected_without_uncordoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The workflow never takes ownership of or restores a node cordoned by someone else."""
+    module = _load_script()
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(kubectl: list[str], *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Return only a pre-cordoned requested node."""
+        calls.append(args)
+        return _completed(args, payload={"items": [_node(unschedulable=True)]})
+
+    monkeypatch.setattr(module, "_run", fake_run)
+
+    with pytest.raises(module.CordonTestError, match="not Ready and schedulable"):
+        module._select_node(["kubectl"], "worker-1")
+    assert all(call[0] != "uncordon" for call in calls)


### PR DESCRIPTION
## Summary

- replace the `my-isv` BFX01-04 placeholder with a real, reversible Kubernetes cordon workflow
- prove that the selected node becomes unschedulable, an existing probe remains running, and a new node-targeted probe is rejected by the scheduler
- always remove probe pods and uncordon the node, treating cleanup failures as test failures
- support configured kubectl-compatible commands, optional node/namespace/image selection, and pre-existing GPU-node taints without tolerating the cordon itself
- add unit coverage for success, failure cleanup, pre-cordoned nodes, uncordon failure, and taint handling

## Why

PR #562 introduces the BFX01-04 validation contract but leaves the provider script as a dummy-success scaffold. This implements the actual Kubernetes behavior required by #209.

This PR is stacked on #562 because the break-fix validation and provider wiring do not exist on `main` yet.

## Impact

Providers using the `my-isv` Kubernetes configuration now get evidence-backed BFX01-04 results instead of a placeholder. The workflow requires permission to create/delete pods and cordon/uncordon nodes.

## Validation

- live run against an isolated k3s v1.35.0 cluster: all three operation fields returned `true`
- independently verified the node was Ready and schedulable afterward, with no BFX probe pods remaining
- focused tests: `18 passed`
- full `make test`: `1505 passed`, `58 passed`, `1323 passed` with `175 deselected`, and `124 passed`
- pre-commit checks passed for both changed files

Closes #209


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functional Kubernetes node cordoning validation.
  - Automatically selects or accepts a target node and verifies workloads before and after cordoning.
  - Supports configurable commands, namespace, image, node, timeout, and polling interval.
  - Provides structured results and reports cleanup failures.

- **Bug Fixes**
  - Ensures temporary resources are removed and nodes are restored after execution.

- **Tests**
  - Added coverage for GPU taints, existing workloads, already-cordoned nodes, successful cleanup, and cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->