### PR TITLE
test(breakfix): validate GB300 NVSwitch firmware inspection (BFX03-02)

### DIFF
--- a/isvctl/configs/providers/gb300/config/bare_metal.yaml
+++ b/isvctl/configs/providers/gb300/config/bare_metal.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Direct GB300 NVSwitch firmware validation.
+#
+# This provider runs on a GB300 BCM head where Bright Cluster Manager and
+# cm-nvfwupd are installed.  It reads existing NVSwitch inventory and executes
+# only `nvfwupd show_version -j`; it never performs a firmware update.
+#
+# Prerequisites:
+#   - passwordless sudo for the read-only cmsh and nvfwupd commands
+#   - tests.settings.gb300_rack set to a rack prefix (for example, rack-a), or
+#     tests.settings.gb300_switch_hosts set to comma-separated NVSwitch names
+#   - tests.settings.gb300_switch_limit controls the number inspected (1-8)
+#
+# Usage:
+#   uv run isvctl test run \
+#     -f isvctl/configs/providers/gb300/config/bare_metal.yaml \
+#     --set tests.settings.gb300_rack=rack-a \
+#     -- -k NvSwitchFirmwareCheck
+
+import:
+  - ../../../suites/bare_metal.yaml
+
+version: "1.0"
+
+commands:
+  bare_metal:
+    phases: ["test"]
+    steps:
+      - name: query_switch_firmware
+        phase: test
+        continue_on_failure: true
+        command: "python ../scripts/breakfix/query_switch_firmware.py"
+        args:
+          - "--rack={{ gb300_rack | default('', true) }}"
+          - "--switch-hosts={{ gb300_switch_hosts | default('', true) }}"
+          - "--limit={{ gb300_switch_limit | default(1, true) }}"
+        # Discovery is bounded at 30 seconds and each of the at most eight
+        # serial tray queries is bounded at 120 seconds. Keep one minute for
+        # result normalization so the provider can always emit failure JSON.
+        timeout: 1050
+
+tests:
+  cluster_name: "gb300-direct-firmware-validation"
+  description: "Inspect GB300 NVSwitch tray firmware directly with nvfwupd"
+
+  settings:
+    region: ""
+    instance_type: ""
+    teardown_flag: ""
+    gb300_rack: ""
+    gb300_switch_hosts: ""
+    gb300_switch_limit: 1

--- a/isvctl/configs/providers/gb300/scripts/breakfix/query_switch_firmware.py
+++ b/isvctl/configs/providers/gb300/scripts/breakfix/query_switch_firmware.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inspect GB300 NVSwitch tray firmware with read-only ``nvfwupd`` (BFX03-02).
+
+The script is intended to run on a GB300 BCM head. It discovers dedicated
+``nvswitch`` devices through read-only ``cmsh`` inventory and invokes only
+``nvfwupd show_version -j`` against the selected tray BMCs. Credentials remain
+inside the privileged subprocess and are never included in the JSON result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+_HOST_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+MAX_SWITCH_LIMIT = 8
+_NVFWUPD_PATH = "/cm/local/apps/cm-nvfwupd/nvfwupd"
+_SERVER_TYPE = "gb200switch"
+_MODULE_SETUP = """\
+export MODULEPATH=/cm/local/modulefiles:/cm/shared/modulefiles
+source /cm/local/apps/environment-modules/current/init/bash
+module load shared cmsh cm-nvfwupd >/dev/null 2>&1
+"""
+_DISCOVER_SCRIPT = (
+    _MODULE_SETUP
+    + """\
+exec cmsh-lazy-load -c 'device; list -t switch -f hostname:64,category:32,status:32'
+"""
+)
+_QUERY_SCRIPT = (
+    _MODULE_SETUP
+    + f"""\
+switch_host="$1"
+bmc_creds=$(cmsh-lazy-load -c "device; use $switch_host; get ip; accesssettings; get username; get password")
+set -- $bmc_creds
+if [ "$#" -lt 3 ]; then
+    exit 20
+fi
+bmc_ip="$1"
+bmc_user="$2"
+bmc_pass="$3"
+exec {_NVFWUPD_PATH} \\
+    -t ip="$bmc_ip" user="$bmc_user" password="$bmc_pass" servertype={_SERVER_TYPE} \\
+    show_version -j
+"""
+)
+
+
+class InspectionError(RuntimeError):
+    """Raised when direct NVSwitch firmware evidence cannot be obtained."""
+
+
+class ProviderArgumentParser(argparse.ArgumentParser):
+    """Raise provider errors instead of exiting without a JSON result."""
+
+    def error(self, message: str) -> None:
+        """Convert invalid arguments into the provider failure path."""
+        raise InspectionError(f"Invalid arguments: {message}")
+
+
+def _emit(result: dict[str, Any]) -> int:
+    """Print the provider-neutral JSON result and return its exit status."""
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("success") else 1
+
+
+def _run_privileged(script: str, *args: str, timeout: int) -> subprocess.CompletedProcess[str]:
+    """Run one fixed read-only helper as root without exposing BMC credentials."""
+    return subprocess.run(
+        ["sudo", "-n", "bash", "-s", "--", *args],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _validate_host(host: str) -> str:
+    """Reject values that cannot be safely used as BCM device names."""
+    value = host.strip()
+    if not _HOST_RE.fullmatch(value):
+        raise InspectionError("invalid NVSwitch hostname")
+    return value
+
+
+def _discover_switches(rack: str) -> list[str]:
+    """Return dedicated NVSwitch hostnames from BCM's read-only inventory."""
+    completed = _run_privileged(_DISCOVER_SCRIPT, timeout=30)
+    if completed.returncode != 0:
+        raise InspectionError("unable to read NVSwitch inventory from BCM")
+
+    rack_prefix = rack.strip().lower()
+    switches: list[str] = []
+    for line in completed.stdout.splitlines():
+        fields = line.split()
+        if len(fields) < 2 or "nvswitch" not in fields[1].lower():
+            continue
+        host = _validate_host(fields[0])
+        if rack_prefix and not host.lower().startswith(f"{rack_prefix}-"):
+            continue
+        if host not in switches:
+            switches.append(host)
+    return switches
+
+
+def _query_tray(host: str) -> dict[str, Any]:
+    """Run ``nvfwupd show_version -j`` against one dedicated switch tray."""
+    completed = _run_privileged(_QUERY_SCRIPT, _validate_host(host), timeout=120)
+    if completed.returncode != 0:
+        raise InspectionError("nvfwupd show_version failed")
+    try:
+        inventory = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise InspectionError("nvfwupd returned invalid JSON") from exc
+    if not isinstance(inventory, dict) or str(inventory.get("Error Code", 0)) != "0":
+        raise InspectionError("nvfwupd returned a firmware inventory error")
+
+    devices = inventory.get("Firmware Devices")
+    if not isinstance(devices, list) or not devices:
+        raise InspectionError("nvfwupd returned no firmware devices")
+
+    versions: dict[str, str] = {}
+    incomplete_inventory = False
+    for device in devices:
+        if not isinstance(device, dict):
+            raise InspectionError("nvfwupd returned a malformed firmware device")
+        raw_name = device.get("AP Name")
+        raw_version = device.get("Sys Version")
+        if not isinstance(raw_name, str):
+            raise InspectionError("nvfwupd returned a firmware device without a name")
+        name = raw_name.strip()
+        if not name:
+            raise InspectionError("nvfwupd returned a firmware device without a name")
+        if raw_version is not None and not isinstance(raw_version, str):
+            raise InspectionError("nvfwupd returned a malformed firmware version")
+        version = raw_version.strip() if raw_version is not None else ""
+        if not version:
+            incomplete_inventory = True
+        versions[name] = version
+
+    primary_version = (
+        "" if incomplete_inventory else versions.get("BMC") or versions.get("ASIC") or next(iter(versions.values()))
+    )
+    return {
+        "tray_id": host,
+        "firmware_version": primary_version,
+        "firmware_versions": versions,
+    }
+
+
+def _configured_switches(cli_switches: Sequence[str]) -> list[str]:
+    """Normalize configured switch targets while preserving their order."""
+    configured = list(cli_switches)
+    switches: list[str] = []
+    for candidate in configured:
+        if not candidate.strip():
+            continue
+        host = _validate_host(candidate)
+        if host not in switches:
+            switches.append(host)
+    return switches
+
+
+def _bounded_limit(value: str) -> int:
+    """Parse a positive tray limit bounded by the executor timeout."""
+    parsed = int(value)
+    if not 1 <= parsed <= MAX_SWITCH_LIMIT:
+        raise argparse.ArgumentTypeError(f"must be between 1 and {MAX_SWITCH_LIMIT}")
+    return parsed
+
+
+def main() -> int:
+    """Inspect selected GB300 NVSwitch trays and emit BFX03-02 evidence."""
+    parser = ProviderArgumentParser(description="Inspect GB300 NVSwitch tray firmware with nvfwupd")
+    parser.add_argument("--rack", default="", help="BCM rack hostname prefix")
+    parser.add_argument("--switch-host", action="append", default=[], help="NVSwitch hostname; repeat as needed")
+    parser.add_argument("--switch-hosts", default="", help="Comma-separated NVSwitch hostnames")
+    parser.add_argument(
+        "--limit",
+        type=_bounded_limit,
+        default=1,
+        help=f"Maximum number of trays to inspect, 1-{MAX_SWITCH_LIMIT} (default: 1)",
+    )
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "gb300",
+        "source": "nvfwupd show_version -j",
+        "trays": [],
+    }
+    try:
+        args = parser.parse_args()
+        switches = _configured_switches([*args.switch_host, *args.switch_hosts.split(",")])
+        if not switches:
+            switches = _discover_switches(args.rack)
+        if not switches:
+            raise InspectionError("no NVSwitch trays discovered on the GB300 system")
+        result["trays"] = [_query_tray(host) for host in switches[: args.limit]]
+    except (InspectionError, subprocess.TimeoutExpired) as exc:
+        result["error_type"] = "firmware_inspection"
+        result["error"] = str(exc) if isinstance(exc, InspectionError) else "NVSwitch firmware inspection timed out"
+        return _emit(result)
+
+    result["success"] = True
+    return _emit(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/tests/providers/gb300/test_gb300_provider.py
+++ b/isvctl/tests/providers/gb300/test_gb300_provider.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for direct GB300 NVSwitch tray firmware inspection."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+from isvtest.validations.breakfix import NvSwitchFirmwareCheck
+
+from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.orchestrator.context import Context
+from isvctl.orchestrator.step_executor import StepExecutor
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
+GB300_ROOT = ISVCTL_ROOT / "configs" / "providers" / "gb300"
+SCRIPT_PATH = GB300_ROOT / "scripts" / "breakfix" / "query_switch_firmware.py"
+CONFIG_PATH = GB300_ROOT / "config" / "bare_metal.yaml"
+
+COMPLETE_INVENTORY = {
+    "Error Code": 0,
+    "Firmware Devices": [
+        {"AP Name": "ASIC", "Sys Version": "1.0.0"},
+        {"AP Name": "BIOS", "Sys Version": "2.0.0"},
+        {"AP Name": "BMC", "Sys Version": "3.0.0"},
+        {"AP Name": "CPLD1", "Sys Version": "4.0.0"},
+        {"AP Name": "CPLD2", "Sys Version": "5.0.0"},
+        {"AP Name": "CPLD3", "Sys Version": "6.0.0"},
+        {"AP Name": "EROT", "Sys Version": "7.0.0"},
+        {"AP Name": "FPGA", "Sys Version": "8.0.0"},
+        {"AP Name": "SSD", "Sys Version": "9.0.0"},
+    ],
+}
+
+
+def _load_script() -> ModuleType:
+    """Load the provider script as an isolated module."""
+    spec = importlib.util.spec_from_file_location("test_gb300_switch_firmware", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(stdout: str, *, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess[str]:
+    """Build a subprocess result for privileged-helper mocks."""
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+def test_config_wires_only_read_only_firmware_query() -> None:
+    """The GB300 provider binds BFX03-02 to the direct query script."""
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    steps = config["commands"]["bare_metal"]["steps"]
+
+    assert steps == [
+        {
+            "name": "query_switch_firmware",
+            "phase": "test",
+            "continue_on_failure": True,
+            "command": "python ../scripts/breakfix/query_switch_firmware.py",
+            "args": [
+                "--rack={{ gb300_rack | default('', true) }}",
+                "--switch-hosts={{ gb300_switch_hosts | default('', true) }}",
+                "--limit={{ gb300_switch_limit | default(1, true) }}",
+            ],
+            "timeout": 1050,
+        }
+    ]
+    assert config["tests"]["settings"]["gb300_rack"] == ""
+    assert config["tests"]["settings"]["gb300_switch_hosts"] == ""
+    assert config["tests"]["settings"]["gb300_switch_limit"] == 1
+
+
+def test_configured_firmware_targets_render_from_test_settings() -> None:
+    """GB300 targets and limits are regular YAML settings, not environment inputs."""
+    merged = merge_yaml_files(
+        [CONFIG_PATH],
+        set_values=[
+            "tests.settings.gb300_rack=rack-a",
+            "tests.settings.gb300_switch_hosts=rack-a-nvsw-01,rack-a-nvsw-02",
+            "tests.settings.gb300_switch_limit=2",
+        ],
+    )
+    config = RunConfig.model_validate(merged)
+    step = config.commands["bare_metal"].steps[0]
+
+    assert StepExecutor()._render_args(step.args, Context(config)) == [
+        "--rack=rack-a",
+        "--switch-hosts=rack-a-nvsw-01,rack-a-nvsw-02",
+        "--limit=2",
+    ]
+
+
+def test_discovers_dedicated_nvswitches_in_requested_rack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BCM compute and other-rack devices never become firmware targets."""
+    module = _load_script()
+    inventory = """\
+rack-a-compute-01 compute [ UP ]
+rack-a-nvsw-01 nvswitch [ UP ]
+rack-a-nvsw-02 nvswitch [ UP ]
+rack-b-nvsw-01 nvswitch [ UP ]
+"""
+    monkeypatch.setattr(module, "_run_privileged", lambda *args, **kwargs: _completed(inventory))
+
+    assert module._discover_switches("rack-a") == ["rack-a-nvsw-01", "rack-a-nvsw-02"]
+
+
+def test_queries_complete_nvfwupd_inventory_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A representative complete switch response produces BFX03-02 evidence."""
+    module = _load_script()
+    observed: dict[str, Any] = {}
+
+    def fake_run(script: str, *args: str, timeout: int) -> subprocess.CompletedProcess[str]:
+        """Record the helper invocation before returning representative inventory."""
+        observed.update(script=script, args=args, timeout=timeout)
+        return _completed(json.dumps(COMPLETE_INVENTORY))
+
+    monkeypatch.setattr(module, "_run_privileged", fake_run)
+
+    tray = module._query_tray("rack-a-nvsw-01")
+
+    assert tray["tray_id"] == "rack-a-nvsw-01"
+    assert tray["firmware_version"] == "3.0.0"
+    assert tray["firmware_versions"]["ASIC"] == "1.0.0"
+    assert tray["firmware_versions"]["CPLD3"] == "6.0.0"
+    assert observed["args"] == ("rack-a-nvsw-01",)
+    assert observed["timeout"] == 120
+    assert "show_version -j" in observed["script"]
+    assert all(token not in observed["script"] for token in ("update_fw", "update_firmware", "activate_fw"))
+
+
+def test_main_passes_with_direct_gb300_tray_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """One inspected GB300 NVSwitch tray satisfies the suite's minimum."""
+    module = _load_script()
+    monkeypatch.setattr(module, "_discover_switches", lambda rack: ["rack-a-nvsw-01"])
+    monkeypatch.setattr(
+        module,
+        "_query_tray",
+        lambda host: {
+            "tray_id": host,
+            "firmware_version": "3.0.0",
+            "firmware_versions": {"BMC": "3.0.0", "ASIC": "1.0.0"},
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["query_switch_firmware.py", "--rack", "rack-a"])
+
+    assert module.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "platform": "gb300",
+        "source": "nvfwupd show_version -j",
+        "success": True,
+        "trays": [
+            {
+                "tray_id": "rack-a-nvsw-01",
+                "firmware_version": "3.0.0",
+                "firmware_versions": {"BMC": "3.0.0", "ASIC": "1.0.0"},
+            }
+        ],
+    }
+
+    check = NvSwitchFirmwareCheck(config={"step_output": payload})
+    check.run()
+    assert check.passed
+    assert "1 NV switch tray(s)" in check.message
+
+
+def test_assumed_gb300_without_switch_inventory_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Applicable GB300 hardware cannot skip or pass without tray evidence."""
+    module = _load_script()
+    monkeypatch.setattr(module, "_discover_switches", lambda rack: [])
+    monkeypatch.setattr(sys, "argv", ["query_switch_firmware.py", "--rack", "rack-a"])
+
+    assert module.main() == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["trays"] == []
+    assert payload["error_type"] == "firmware_inspection"
+    assert "no NVSwitch trays discovered" in payload["error"]
+    assert "skipped" not in payload
+
+
+@pytest.mark.parametrize("limit", ["0", "9"])
+def test_invalid_switch_limit_emits_failure_json(
+    limit: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Out-of-range limits must preserve the provider JSON contract."""
+    module = _load_script()
+    monkeypatch.setattr(sys, "argv", ["query_switch_firmware.py", f"--limit={limit}"])
+    monkeypatch.setattr(
+        module,
+        "_discover_switches",
+        lambda rack: pytest.fail("discovery must not run when parsing fails"),
+    )
+
+    assert module.main() == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert captured.err == ""
+    assert payload["success"] is False
+    assert payload["trays"] == []
+    assert "must be between 1 and 8" in payload["error"]
+
+
+def test_comma_separated_switch_settings_bypass_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Explicit YAML-rendered targets are normalized without BCM discovery."""
+    module = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["query_switch_firmware.py", "--switch-hosts=rack-a-nvsw-01,rack-a-nvsw-02", "--limit=2"],
+    )
+    monkeypatch.setattr(
+        module,
+        "_discover_switches",
+        lambda rack: pytest.fail("explicit switch hosts must bypass discovery"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_query_tray",
+        lambda host: {"tray_id": host, "firmware_version": "1.0", "firmware_versions": {"BMC": "1.0"}},
+    )
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert [tray["tray_id"] for tray in payload["trays"]] == ["rack-a-nvsw-01", "rack-a-nvsw-02"]
+
+
+def test_incomplete_nvfwupd_device_preserves_failing_tray_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing component version retains the tray identity but cannot PASS."""
+    module = _load_script()
+    incomplete = {
+        "Error Code": 0,
+        "Firmware Devices": [
+            {"AP Name": "BMC", "Sys Version": "3.0.0"},
+            {"AP Name": "ASIC", "Sys Version": ""},
+        ],
+    }
+    monkeypatch.setattr(
+        module,
+        "_run_privileged",
+        lambda *args, **kwargs: _completed(json.dumps(incomplete)),
+    )
+
+    tray = module._query_tray("rack-a-nvsw-01")
+
+    assert tray == {
+        "tray_id": "rack-a-nvsw-01",
+        "firmware_version": "",
+        "firmware_versions": {"BMC": "3.0.0", "ASIC": ""},
+    }
+    check = NvSwitchFirmwareCheck(config={"step_output": {"success": True, "trays": [tray]}})
+    check.run()
+    assert not check.passed
+    assert "missing firmware_version" in check.message
+
+
+def test_nvfwupd_device_without_a_name_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unnamed component cannot be represented in the component inventory."""
+    module = _load_script()
+    malformed = {"Error Code": 0, "Firmware Devices": [{"AP Name": "", "Sys Version": "1.2.3"}]}
+    monkeypatch.setattr(
+        module,
+        "_run_privileged",
+        lambda *args, **kwargs: _completed(json.dumps(malformed)),
+    )
+
+    with pytest.raises(module.InspectionError, match="without a name"):
+        module._query_tray("rack-a-nvsw-01")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("AP Name", 1, "without a name"),
+        ("Sys Version", 1, "malformed firmware version"),
+    ],
+)
+def test_non_string_nvfwupd_fields_are_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: int,
+    message: str,
+) -> None:
+    """Numeric inventory fields cannot be coerced into firmware evidence."""
+    module = _load_script()
+    device = {"AP Name": "BMC", "Sys Version": "1.2.3"}
+    device[field] = value
+    malformed = {"Error Code": 0, "Firmware Devices": [device]}
+    monkeypatch.setattr(
+        module,
+        "_run_privileged",
+        lambda *args, **kwargs: _completed(json.dumps(malformed)),
+    )
+
+    with pytest.raises(module.InspectionError, match=message):
+        module._query_tray("rack-a-nvsw-01")
+
+
+def test_privileged_failure_does_not_leak_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """BMC credentials or raw command diagnostics never enter provider JSON."""
+    module = _load_script()
+    monkeypatch.setattr(module, "_discover_switches", lambda rack: ["rack-a-nvsw-01"])
+    monkeypatch.setattr(
+        module,
+        "_run_privileged",
+        lambda *args, **kwargs: _completed("", returncode=1, stderr="password=do-not-print"),
+    )
+    monkeypatch.setattr(sys, "argv", ["query_switch_firmware.py", "--rack", "rack-a"])
+
+    assert module.main() == 1
+
+    output = capsys.readouterr().out
+    assert "do-not-print" not in output
+    assert "password=" not in output

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -17,6 +17,7 @@ from isvtest.validations.breakfix import (
     HostReplacementCheck,
     MaintenanceEventsCheck,
     NodeHealthAgentCheck,
+    NvSwitchFirmwareCheck,
     PlannedMaintenanceNotificationCheck,
     RepairHistoryCheck,
     RetirementNoticesCheck,
@@ -144,6 +145,42 @@ class TestOperationChecks:
         check = _run(ReturnNodeMaintenanceCheck, step_output)
         assert check.passed
         assert "maintenance_mode=hw" in check.message
+
+
+class TestNvSwitchFirmwareCheck:
+    """Cover BFX03-02 firmware evidence for every returned switch tray."""
+
+    def test_fails_when_no_trays_are_returned(self) -> None:
+        """An applicable GB300 system cannot pass without NVSwitch tray evidence."""
+        check = _run(NvSwitchFirmwareCheck, {"success": True, "trays": []})
+        assert not check.passed
+        assert "Expected at least 1 NV switch tray(s), got 0" in check.message
+
+    def test_passes_when_every_tray_has_firmware(self) -> None:
+        """Every discovered NVSwitch tray must report a non-empty version."""
+        step_output = {
+            "success": True,
+            "trays": [
+                {"tray_id": "switch-1", "firmware_version": "1.2.3"},
+                {"tray_id": "switch-2", "firmware_version": "2.0.0"},
+            ],
+        }
+        check = _run(NvSwitchFirmwareCheck, step_output)
+        assert check.passed
+        assert "2 NV switch tray(s)" in check.message
+
+    def test_fails_when_any_tray_has_no_firmware(self) -> None:
+        """One missing version keeps partial inventory from passing BFX03-02."""
+        step_output = {
+            "success": True,
+            "trays": [
+                {"tray_id": "switch-1", "firmware_version": "1.2.3"},
+                {"tray_id": "switch-2", "firmware_version": ""},
+            ],
+        }
+        check = _run(NvSwitchFirmwareCheck, step_output)
+        assert not check.passed
+        assert "1 switch tray(s) missing firmware_version" in check.message
 
 
 class TestNodeHealthAgentCheck:


### PR DESCRIPTION
## Summary

- add read-only GB300 NVSwitch firmware inspection for BFX03-02
- discover dedicated NVSwitch devices from provider inventory
- execute only the firmware version inspection operation
- normalize tray and component firmware evidence for provider-neutral validation
- keep credentials and raw command diagnostics out of provider output

## Safety

The implementation performs inventory reads and firmware version inspection only. It contains no firmware update, activation, or cluster-state mutation operation.

## Validation

- focused provider and break-fix tests passed
- provider configurations and suite wiring validate
- full unit and demo suites passed
- read-only validation on an applicable GB300 environment returned complete NVSwitch tray firmware evidence and produced PASS

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only NVSwitch firmware validation for GB300 bare-metal environments.
  * Added support for rack filtering, explicit switch hosts, and configurable inspection limits.
  * Added structured JSON results for successful checks, incomplete firmware data, invalid settings, and inspection failures.
  * Added configuration guidance and prerequisites for enabling the firmware check.

* **Tests**
  * Added coverage for firmware discovery, validation outcomes, configuration rendering, limits, malformed data, and safe error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->