### PR TITLE
ci: repin dsx GitHub Actions after org transfer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
           fetch-depth: 0 # Full history for secret scanning
 
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
           # Lob's key pattern is `test_` + 35 chars, so its verifier reports every
           # 40-character pytest function name as a verified secret. Nothing here uses
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run CodeQL Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@55d1e0af17fb4431edaca19fbd5c78fecd29d18a
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/codeql-scan@55d1e0af17fb4431edaca19fbd5c78fecd29d18a
         with:
           languages: python
           build-mode: none
@@ -146,7 +146,7 @@ jobs:
   #       uses: actions/checkout@v6
 
   #     - name: Run Trivy Scan
-  #       uses: NVIDIA/dsx-github-actions/.github/actions/trivy-scan@495fc76167e3d265f817c1fdc00b7b9275436418
+  #       uses: dsx-ai-factory/dsx-github-actions/.github/actions/trivy-scan@495fc76167e3d265f817c1fdc00b7b9275436418
   #       with:
   #         scan-type: fs
   #         scan-ref: .


### PR DESCRIPTION
## Summary

- repin all `NVIDIA/dsx-github-actions` references to `dsx-ai-factory/dsx-github-actions`
- preserve each action path and immutable commit SHA
- update the commented workflow reference for consistency

## Tracking

- NvBug: https://nvbugspro.nvidia.com/bug/6528755

## Validation

- `uvx pre-commit run -a`
- `git diff --check`
- confirmed no exact `NVIDIA/dsx-github-actions` references remain

## Merge timing

Keep this PR as a draft and merge it only after the repository transfer to `dsx-ai-factory/dsx-github-actions` is complete and the new location is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security and code analysis workflows to use the maintained shared action source.
  * Existing workflow versions and configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->