### PR TITLE
fix(security): remove unsupported SEC04 source-CIDR check

### DIFF
--- a/docs/requirements/test-requirements-matrix.adoc
+++ b/docs/requirements/test-requirements-matrix.adoc
@@ -1698,7 +1698,7 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | [[SEC04-01]]SEC04-01
 | Data Services
 | SDS Controller
-| Verify least-privilege access policies (resource-based, user-based, network-based)
+| Verify least-privilege access policies (resource-based and user-based)
 | SEC04
 | offtake
 | full

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -2844,7 +2844,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/296[#296]
 |
 | M5
 |
-| Verify least-privilege access policies (resource-based, user-based, network-based)
+| Verify least-privilege access policies (resource-based and user-based)
 | published
 |
 

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2555,7 +2555,7 @@ domains:
                 status: pending
           - description: Storage Security
             tests:
-              - summary: Verify least-privilege access policies (resource-based, user-based, network-based)
+              - summary: Verify least-privilege access policies (resource-based and user-based)
                 labels:
                   - iam
                   - min_req

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -38,7 +38,7 @@
 #  10. KMS Options             - Verify provider- and customer-managed keys (SEC09-02)
 #  11. Centralized KMS         - Verify encrypted resources resolve to KMS (SEC09-03)
 #  12. Customer Managed Key    - Verify customer-managed key encryption (SEC09-04)
-#  13. Least Privilege         - Verify scoped user/resource/network policies (SEC04-01/02)
+#  13. Least Privilege         - Verify scoped user/resource policies (SEC04-01/02)
 #  14. Audit Logging           - Verify management-event logging and retention (SEC08-01/02)
 #  15. SA Credential Auth      - Verify IAM user + long-lived access key auth
 #  16. OIDC User Auth          - Probe configured OIDC-protected platform endpoint (SEC01-01)
@@ -175,8 +175,8 @@ commands:
       # Test 12: Least-Privilege Policy + Minimal Role Enforcement (SEC04-01/02)
       # Self-contained: provisions a temporary IAM user, two tagged buckets, and a minimal
       # VPC/subnet/security-group/instance fixture for EC2 DryRun probes. It attaches one
-      # inline policy scoped by identity, resource, and aws:SourceIp, then verifies the
-      # allowed S3 ListBucket path plus denied out-of-scope compute/storage/network API
+      # inline policy scoped by identity and resource, then verifies the allowed S3
+      # ListBucket path plus denied out-of-scope compute/storage/network API
       # probes. Cleans up the user, access key, inline policy, buckets, object, and EC2
       # fixture in a finally block.
       #

--- a/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
@@ -21,13 +21,11 @@ This AWS reference is self-contained. It provisions a temporary IAM user
 inline policy to the user, mints an access key, then probes the policy as
 that user.
 
-The inline policy exercises the three least-privilege dimensions named by
+The inline policy exercises the two least-privilege dimensions named by
 SEC04-01:
 
 * user-based: only the temporary user receives the inline grant.
 * resource-based: only the tagged allowed bucket ARN is granted.
-* network-based: the grant includes an ``aws:SourceIp`` condition for the
-  caller's public CIDR.
 
 SEC04-02 is checked from the same minimal identity by verifying out-of-scope
 compute, storage, and network APIs are denied. Mutating EC2 probes use
@@ -41,13 +39,10 @@ rather than fabricate a pass.
 """
 
 import argparse
-import ipaddress
 import json
 import os
 import sys
 import time
-import urllib.error
-import urllib.request
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -63,7 +58,6 @@ TEST_NAME = "least_privilege_test"
 TEST_USER_PREFIX = "isv-sec04-test-"
 INLINE_POLICY_NAME = "isv-sec04-least-privilege"
 DENIED_OBJECT_KEY = "sec04-denied-probe-object"
-CALLER_IP_URL = "https://checkip.amazonaws.com/"
 PROBE_CIDR = "10.96.0.0/24"
 
 SKIPPABLE_SETUP_ERRORS = frozenset({"AccessDenied", "UnauthorizedOperation"})
@@ -90,23 +84,6 @@ def _skipped_result(reason: str) -> dict[str, Any]:
         "skip_reason": reason,
         "tests": {},
     }
-
-
-def _detect_source_cidr() -> str:
-    """Return the caller's public IP address as an IPv4/IPv6 host CIDR."""
-    try:
-        with urllib.request.urlopen(CALLER_IP_URL, timeout=5) as response:
-            ip_address = response.read().decode("utf-8").strip()
-    except (OSError, urllib.error.URLError) as exc:
-        msg = f"cannot determine caller public IP for source condition: {exc}"
-        raise RuntimeError(msg) from exc
-    try:
-        parsed_ip = ipaddress.ip_address(ip_address)
-    except ValueError as exc:
-        msg = f"unexpected caller public IP response: {ip_address!r}"
-        raise RuntimeError(msg) from exc
-    prefix_len = 32 if parsed_ip.version == 4 else 128
-    return f"{parsed_ip}/{prefix_len}"
 
 
 def _create_bucket(s3: Any, bucket: str, region: str, buckets_created: list[str]) -> None:
@@ -233,71 +210,30 @@ def _get_amazon_linux_ami(ec2: Any) -> str:
     return images[0]["ImageId"]
 
 
-def _policy_document(allowed_bucket: str, source_cidr: str) -> str:
+def _policy_document(allowed_bucket: str) -> str:
     """Return the minimal inline policy attached only to the temporary user."""
     return json.dumps(
         {
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Sid": "AllowListOnlyTaggedBucketFromCallerCidr",
+                    "Sid": "AllowListOnlyTaggedBucket",
                     "Effect": "Allow",
                     "Action": "s3:ListBucket",
                     "Resource": f"arn:aws:s3:::{allowed_bucket}",
-                    "Condition": {"IpAddress": {"aws:SourceIp": source_cidr}},
                 }
             ],
         }
     )
 
 
-def _policy_has_source_cidr_condition(policy_document: str, allowed_bucket: str, source_cidr: str) -> bool:
-    """Return True when the S3 allow statement is scoped to the expected SourceIp CIDR."""
-    expected_resource = f"arn:aws:s3:::{allowed_bucket}"
-    try:
-        document = json.loads(policy_document)
-    except json.JSONDecodeError:
-        return False
-
-    statements = document.get("Statement", [])
-    if isinstance(statements, dict):
-        statements = [statements]
-    if not isinstance(statements, list):
-        return False
-
-    for statement in statements:
-        if not isinstance(statement, dict):
-            continue
-        actions = statement.get("Action", [])
-        if isinstance(actions, str):
-            actions = [actions]
-        resources = statement.get("Resource", [])
-        if isinstance(resources, str):
-            resources = [resources]
-        source_ips = statement.get("Condition", {}).get("IpAddress", {}).get("aws:SourceIp", [])
-        if isinstance(source_ips, str):
-            source_ips = [source_ips]
-        if (
-            statement.get("Effect") == "Allow"
-            and "s3:ListBucket" in actions
-            and expected_resource in resources
-            and source_cidr in source_ips
-        ):
-            return True
-    return False
-
-
-def _policy_dimension_scope_results(
+def _policy_resource_scope_result(
     *,
     allowed_result: dict[str, Any],
     denied_resource_result: dict[str, Any],
-    policy_document: str,
-    allowed_bucket: str,
-    source_cidr: str,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Build resource- and network-scope SEC04 result entries from concrete evidence."""
+) -> dict[str, Any]:
+    """Build the resource-scope SEC04 result entry from concrete evidence."""
     allowed_passed = bool(allowed_result.get("passed"))
-    source_condition_matches = _policy_has_source_cidr_condition(policy_document, allowed_bucket, source_cidr)
     resource_passed = allowed_passed and bool(denied_resource_result.get("passed"))
     resource_result: dict[str, Any] = {
         "passed": resource_passed,
@@ -311,21 +247,7 @@ def _policy_dimension_scope_results(
             resource_result["error"] = denied_resource_result.get("error") or (
                 f"unscoped-resource probe returned {denied_resource_result.get('code', 'unknown')}"
             )
-    network_passed = allowed_passed and source_condition_matches
-    network_result: dict[str, Any] = {
-        "passed": network_passed,
-        "message": (
-            "minimal policy "
-            f"{'contains' if source_condition_matches else 'does not contain'} the expected source CIDR condition"
-        ),
-    }
-    if not network_passed:
-        network_result["error"] = (
-            "allowed scoped-resource action did not succeed"
-            if not allowed_passed
-            else "minimal policy is missing the expected source CIDR condition"
-        )
-    return resource_result, network_result
+    return resource_result
 
 
 def _cleanup_buckets(s3: Any, buckets: list[str]) -> list[str]:
@@ -485,19 +407,8 @@ def main() -> int:
     """Provision the SEC04 fixture, run positive and negative probes, emit JSON."""
     parser = argparse.ArgumentParser(description="Least-privilege policy and minimal-role enforcement test")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
-    parser.add_argument(
-        "--source-cidr",
-        default=os.environ.get("SEC04_ALLOWED_SOURCE_CIDR", ""),
-        help="Allowed source CIDR. Defaults to the caller public host CIDR.",
-    )
     args = parser.parse_args()
     region = args.region
-
-    try:
-        source_cidr = args.source_cidr.strip() or _detect_source_cidr()
-    except RuntimeError as exc:
-        print(json.dumps(_skipped_result(str(exc)), indent=2))
-        return 0
 
     iam = boto3.client("iam", region_name=region)
     ec2 = boto3.client("ec2", region_name=region)
@@ -523,11 +434,9 @@ def main() -> int:
         "test_name": TEST_NAME,
         "test_identity": username,
         "allowed_resource": allowed_bucket,
-        "allowed_source_cidr": source_cidr,
         "tests": {
             "policy_dimensions_user_based": {"passed": False},
             "policy_dimensions_resource_based": {"passed": False},
-            "policy_dimensions_network_based": {"passed": False},
             "policy_dimensions_allowed_action_succeeds": {"passed": False},
             "out_of_scope_compute_denied": {"passed": False},
             "out_of_scope_storage_denied": {"passed": False},
@@ -554,7 +463,7 @@ def main() -> int:
                 sg_id=probe_sg_id,
                 name=username,
             )
-            policy_document = _policy_document(allowed_bucket, source_cidr)
+            policy_document = _policy_document(allowed_bucket)
             iam.put_user_policy(
                 UserName=username,
                 PolicyName=INLINE_POLICY_NAME,
@@ -584,12 +493,9 @@ def main() -> int:
                 "storage_list_unscoped_resource_denied",
                 lambda: clients["s3"].list_objects_v2(Bucket=denied_bucket, MaxKeys=1),
             )
-            resource_scope_result, network_scope_result = _policy_dimension_scope_results(
+            resource_scope_result = _policy_resource_scope_result(
                 allowed_result=allowed_result,
                 denied_resource_result=denied_resource_result,
-                policy_document=policy_document,
-                allowed_bucket=allowed_bucket,
-                source_cidr=source_cidr,
             )
             user_based_passed = allowed_passed and username in caller_arn
             result["tests"]["policy_dimensions_user_based"] = {
@@ -607,7 +513,6 @@ def main() -> int:
                     else "temporary principal identity did not match the minted access key"
                 )
             result["tests"]["policy_dimensions_resource_based"] = resource_scope_result
-            result["tests"]["policy_dimensions_network_based"] = network_scope_result
 
             compute_probes = [
                 _expect_denied(

--- a/isvctl/configs/providers/my-isv/scripts/security/least_privilege_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/least_privilege_test.py
@@ -27,11 +27,9 @@ Required JSON output fields:
     "test_name": "least_privilege_test",
     "test_identity": "<temporary principal id>",
     "allowed_resource": "<resource allowed by the minimal policy>",
-    "allowed_source_cidr": "<network source constraint>",
     "tests": {
       "policy_dimensions_user_based":              {"passed": true},
       "policy_dimensions_resource_based":          {"passed": true},
-      "policy_dimensions_network_based":           {"passed": true},
       "policy_dimensions_allowed_action_succeeds": {"passed": true},
       "out_of_scope_compute_denied":               {"passed": true},
       "out_of_scope_storage_denied":               {"passed": true},
@@ -64,11 +62,9 @@ def main() -> int:
         "test_name": "least_privilege_test",
         "test_identity": "",
         "allowed_resource": "",
-        "allowed_source_cidr": "",
         "tests": {
             "policy_dimensions_user_based": {"passed": False},
             "policy_dimensions_resource_based": {"passed": False},
-            "policy_dimensions_network_based": {"passed": False},
             "policy_dimensions_allowed_action_succeeds": {"passed": False},
             "out_of_scope_compute_denied": {"passed": False},
             "out_of_scope_storage_denied": {"passed": False},
@@ -85,7 +81,6 @@ def main() -> int:
     #       principal,
     #       allowed_action="list/read metadata",
     #       allowed_resource=resource.id,
-    #       allowed_source_cidr=current_runner_cidr,
     #   )
     #   assert principal.can_perform_allowed_action(resource)
     #   assert principal.cannot_use_compute_actions_outside_policy()
@@ -99,11 +94,9 @@ def main() -> int:
     if DEMO_MODE:
         result["test_identity"] = "demo-sec04-principal"
         result["allowed_resource"] = "demo-sec04-resource"
-        result["allowed_source_cidr"] = "203.0.113.10/32"
         result["tests"] = {
             "policy_dimensions_user_based": {"passed": True, "message": "demo: policy attached to one principal"},
             "policy_dimensions_resource_based": {"passed": True, "message": "demo: policy scoped to one resource"},
-            "policy_dimensions_network_based": {"passed": True, "message": "demo: policy scoped to one source CIDR"},
             "policy_dimensions_allowed_action_succeeds": {"passed": True, "message": "demo: in-scope action allowed"},
             "out_of_scope_compute_denied": {"passed": True, "message": "demo: compute operations denied"},
             "out_of_scope_storage_denied": {"passed": True, "message": "demo: storage operations denied"},

--- a/isvctl/tests/providers/aws/test_aws_security_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_security_scripts.py
@@ -983,78 +983,32 @@ def test_audit_logging_main_emits_structured_skip(
     assert "audit_log_trail_arn" not in payload
 
 
-class FakeIpResponse:
-    """Context manager returned by fake URL open calls."""
-
-    def __init__(self, body: str) -> None:
-        """Store the fake response body."""
-        self.body = body
-
-    def __enter__(self) -> FakeIpResponse:
-        """Return this fake response."""
-        return self
-
-    def __exit__(self, *_args: Any) -> None:
-        """Close the fake response."""
-
-    def read(self) -> bytes:
-        """Return the configured response body."""
-        return self.body.encode("utf-8")
-
-
-@pytest.mark.parametrize(
-    ("raw_ip", "expected_cidr"),
-    [
-        ("203.0.113.10\n", "203.0.113.10/32"),
-        ("2001:db8::1\n", "2001:db8::1/128"),
-    ],
-)
-def test_least_privilege_detect_source_cidr_handles_ipv4_and_ipv6(
-    monkeypatch: pytest.MonkeyPatch,
-    raw_ip: str,
-    expected_cidr: str,
-) -> None:
-    """Source CIDR detection normalizes IPv4 and IPv6 host addresses."""
+def test_least_privilege_resource_scope_requires_denied_bucket() -> None:
+    """SEC04 resource scope requires allowed-resource and denied-resource evidence."""
     module = _load_security_script("least_privilege_test.py")
+    policy_document = json.loads(module._policy_document("allowed-bucket"))
 
-    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *_args, **_kwargs: FakeIpResponse(raw_ip))
-
-    assert module._detect_source_cidr() == expected_cidr
-
-
-def test_least_privilege_dimension_results_require_denied_bucket_and_source_cidr() -> None:
-    """SEC04 dimension flags require denied-resource evidence and the SourceIp policy condition."""
-    module = _load_security_script("least_privilege_test.py")
-    policy_document = module._policy_document("allowed-bucket", "2001:db8::1/128")
-
-    resource_result, network_result = module._policy_dimension_scope_results(
+    resource_result = module._policy_resource_scope_result(
         allowed_result={"passed": True},
         denied_resource_result={
             "name": "storage_list_unscoped_resource_denied",
             "passed": True,
             "code": "AccessDenied",
         },
-        policy_document=policy_document,
-        allowed_bucket="allowed-bucket",
-        source_cidr="2001:db8::1/128",
     )
 
+    assert policy_document["Statement"][0]["Resource"] == "arn:aws:s3:::allowed-bucket"
+    assert "Condition" not in policy_document["Statement"][0]
     assert resource_result["passed"] is True
     assert resource_result["probes"][0]["code"] == "AccessDenied"
-    assert network_result["passed"] is True
 
-    failed_resource_result, failed_network_result = module._policy_dimension_scope_results(
+    failed_resource_result = module._policy_resource_scope_result(
         allowed_result={"passed": True},
         denied_resource_result={"name": "storage_list_unscoped_resource_denied", "passed": False, "error": "allowed"},
-        policy_document=policy_document,
-        allowed_bucket="allowed-bucket",
-        source_cidr="203.0.113.10/32",
     )
 
     assert failed_resource_result["passed"] is False
-    assert failed_network_result["passed"] is False
     assert failed_resource_result["error"]
-    assert failed_network_result["error"]
 
 
 class _FakeSec04PropagationClient:

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -843,10 +843,10 @@ class ShortLivedCredentialsCheck(BaseValidation):
 class LeastPrivilegePolicyCheck(BaseValidation):
     """Validate least-privilege policy dimensions are enforced (SEC04-01).
 
-    Verifies the provider probe exercised user-scoped, resource-scoped, and
-    network-scoped access policy constraints. The probe may emit a structured
-    top-level skip when it cannot provision the temporary identity needed for
-    the check.
+    Verifies the provider probe exercised user-scoped and resource-scoped
+    access policy constraints and that the allowed action succeeds. The probe
+    may emit a structured top-level skip when it cannot provision the
+    temporary identity needed for the check.
 
     Config:
         step_output: The step output to check
@@ -854,14 +854,12 @@ class LeastPrivilegePolicyCheck(BaseValidation):
     Step output:
         test_identity: Required non-empty identity used for the policy probe
         allowed_resource: Required non-empty resource identifier that should be allowed
-        allowed_source_cidr: Required non-empty source CIDR used for network-scope enforcement
         tests: dict with policy_dimensions_user_based,
                policy_dimensions_resource_based,
-               policy_dimensions_network_based,
                policy_dimensions_allowed_action_succeeds
     """
 
-    description: ClassVar[str] = "Check least-privilege access policies are user, resource, and network scoped"
+    description: ClassVar[str] = "Check least-privilege access policies are user and resource scoped"
 
     def run(self) -> None:
         """Validate required least-privilege policy-dimension results from step output."""
@@ -872,13 +870,12 @@ class LeastPrivilegePolicyCheck(BaseValidation):
         required = [
             "policy_dimensions_user_based",
             "policy_dimensions_resource_based",
-            "policy_dimensions_network_based",
             "policy_dimensions_allowed_action_succeeds",
         ]
         if not check_required_tests(self, required, "Least-privilege policy tests failed"):
             return
 
-        for field in ("test_identity", "allowed_resource", "allowed_source_cidr"):
+        for field in ("test_identity", "allowed_resource"):
             value = step_output.get(field)
             if not isinstance(value, str) or not value.strip():
                 self.set_failed(f"Least-privilege policy output missing non-empty '{field}'")

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -31,6 +31,7 @@ from isvtest.validations.security import (
     CustomerManagedKeyCheck,
     InsecureProtocolsCheck,
     KmsEncryptionOptionCheck,
+    LeastPrivilegePolicyCheck,
     MfaEnforcedCheck,
     MutualTlsCheck,
     OidcUserAuthCheck,
@@ -847,6 +848,74 @@ def test_short_lived_credentials_check_skips_when_step_marks_skipped() -> None:
 
     with pytest.raises(pytest.skip.Exception, match="GetSessionToken not available"):
         ShortLivedCredentialsCheck(config={"step_output": step_output}).execute()
+
+
+LEAST_PRIVILEGE_REQUIRED_TESTS = {
+    "policy_dimensions_user_based": {"passed": True},
+    "policy_dimensions_resource_based": {"passed": True},
+    "policy_dimensions_allowed_action_succeeds": {"passed": True},
+}
+
+
+def _least_privilege_step_output(**overrides: Any) -> dict[str, Any]:
+    """Return valid SEC04-01 output without the removed source-CIDR evidence."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "security",
+        "test_name": "least_privilege_test",
+        "test_identity": "sec04-test-principal",
+        "allowed_resource": "sec04-test-resource",
+        "tests": deepcopy(LEAST_PRIVILEGE_REQUIRED_TESTS),
+    }
+    output.update(overrides)
+    return output
+
+
+class TestLeastPrivilegePolicyCheck:
+    """Tests for SEC04-01 least-privilege policy validation."""
+
+    def test_passes_without_source_cidr_dimension(self) -> None:
+        """Source-IP/CIDR is not part of the originating SEC04-01 requirement."""
+        result = LeastPrivilegePolicyCheck(config={"step_output": _least_privilege_step_output()}).execute()
+
+        assert result["passed"] is True
+
+    def test_ignores_legacy_source_cidr_evidence(self) -> None:
+        """Legacy provider output cannot reintroduce the removed CIDR subtest."""
+        tests = deepcopy(LEAST_PRIVILEGE_REQUIRED_TESTS)
+        tests["policy_dimensions_network_based"] = {
+            "passed": False,
+            "error": "source-IP identity binding is unavailable",
+        }
+        result = LeastPrivilegePolicyCheck(
+            config={
+                "step_output": _least_privilege_step_output(
+                    allowed_source_cidr="",
+                    tests=tests,
+                )
+            }
+        ).execute()
+
+        assert result["passed"] is True
+
+    def test_fails_when_required_dimension_is_missing(self) -> None:
+        """User, resource, and allowed-action evidence remain mandatory."""
+        tests = deepcopy(LEAST_PRIVILEGE_REQUIRED_TESTS)
+        tests.pop("policy_dimensions_resource_based")
+        result = LeastPrivilegePolicyCheck(config={"step_output": _least_privilege_step_output(tests=tests)}).execute()
+
+        assert result["passed"] is False
+        assert "policy_dimensions_resource_based" in result["error"]
+
+    @pytest.mark.parametrize("field", ["test_identity", "allowed_resource"])
+    def test_fails_when_required_identity_or_resource_is_empty(self, field: str) -> None:
+        """The remaining identity and resource evidence must be non-empty."""
+        result = LeastPrivilegePolicyCheck(
+            config={"step_output": _least_privilege_step_output(**{field: ""})}
+        ).execute()
+
+        assert result["passed"] is False
+        assert field in result["error"]
 
 
 TENANT_ISOLATION_REQUIRED_TESTS = {


### PR DESCRIPTION
## Summary

- remove the source-IP/CIDR dimension from `LeastPrivilegePolicyCheck`
- align the AWS reference probe and `my-isv` provider contract with the originating SEC04 requirement
- keep user scope, resource scope, allowed-action success, and SEC04-02 out-of-scope API denial checks intact
- update the canonical and generated test-plan wording

## Why

The originating SEC04 requirement does not require identities to be bound to a source IP or CIDR. Requiring `allowed_source_cidr` and `policy_dimensions_network_based` therefore added an unsupported provider-specific constraint and incorrectly failed platforms without identity-level source-IP binding.

With the invalid dimension removed, the supplied run-377 evidence satisfies all four applicable run-level criteria.

Fixes #579

## Validation

- `uv run pytest isvtest/tests/test_security.py -q` (84 passed)
- `uv run pytest isvctl/tests/providers/aws/test_aws_security_scripts.py -q` (140 passed)
- focused `my-isv` SEC04 orchestration (both checks passed)
- `make demo-test` (all 9 living-example suites passed)
- `make plan`
- `make reqcheck`
- `.venv/bin/pre-commit run --all-files`

## Evidence boundary

The AWS reference path is covered by unit tests and the provider-independent path by the `my-isv` demo orchestration. No live AWS resources were created for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updated Security Validation**
  - Least-privilege checks now evaluate user-based and resource-based access controls.
  - Network-based policy enforcement and source-network requirements are no longer required.
  - Storage security checks continue to verify allowed actions and denied-resource evidence.

- **Documentation**
  - Updated security test plans, configuration guidance, and policy examples to reflect the revised validation scope.

- **Tests**
  - Added coverage for resource scoping, missing policy evidence, and compatibility with legacy network-related results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->