### PR TITLE
docs: add out-of-band hotfix release process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,16 @@ on:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
 
+# Least privilege for every job that does not declare its own block. Without
+# this the token inherits the repository default, which is write. packages:read
+# is required because the container image below is private and the runner
+# authenticates to ghcr with this token. Jobs that need more (the security
+# scans) declare their own permissions, which replace these rather than add
+# to them.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   pre-commit:
     name: Pre-commit Checks
@@ -183,9 +193,14 @@ jobs:
       - security-codeql-scan
       # - security-trivy-scan  # Disabled - see comment above (Trivy supply chain compromise)
     steps:
+      # The expression is evaluated into env rather than inlined into the
+      # script, keeping "no ${{ }} inside a run: block" true across every
+      # workflow - an invariant a reviewer can grep for.
       - name: Check Pipeline Status
+        env:
+          PIPELINE_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+          if [[ "$PIPELINE_FAILED" == "true" ]]; then
             echo "One or more jobs on the pipeline failed! Check the logs for details."
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - "releases/**"
       - "pull-request/[0-9]+"
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,15 +17,34 @@ jobs:
     environment: release
     steps:
       # fetch-depth: 0 so existing tags are visible to the guards below.
+      # persist-credentials: false so no write-capable token is left behind in
+      # .git/config while later steps run scripts from the checked-out ref. The
+      # tag is created through the API in the final step, which is the only step
+      # that needs a credential.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Normalize version
+      # inputs.version is untrusted - it arrives as a free-form string from
+      # whoever dispatched the run. It is passed through env rather than a
+      # ${{ }} expression because expressions are substituted into the script
+      # before bash parses it, so a crafted value would execute as code. It is
+      # validated here, before any other step consumes it. The pattern matches
+      # the repository's tag naming rule (with semver's no-leading-zeros
+      # restriction), so a version accepted here cannot be rejected later.
+      - name: Normalize and validate version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+            # The rejected value is deliberately not echoed: it is untrusted and
+            # could inject workflow commands. It is visible in the run's inputs.
+            echo "::error::Invalid version input. Expected X.Y.Z or X.Y.Z-rcN, without a leading 'v'."
+            exit 1
+          fi
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       # Releases come from main, or from a maintenance branch for out-of-band
@@ -43,16 +62,18 @@ jobs:
           esac
 
       - name: Verify tag does not already exist
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
-          TAG="v${{ steps.version.outputs.value }}"
+          TAG="v$VERSION"
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             echo "::error::$TAG already exists at $(git rev-parse --short "$TAG^{commit}")." \
-                 "Tags cannot be deleted - pick the next version."
+                 "Tags are never deleted - pick the next version."
             exit 1
           fi
 
       # Informational: lets the dispatcher confirm they are tagging what they
-      # think before the (irreversible) push.
+      # think before the (irreversible) tag creation.
       - name: Show base tag
         run: |
           BASE=$(git describe --tags --abbrev=0 --match "v*" HEAD 2>/dev/null || echo "none")
@@ -60,9 +81,18 @@ jobs:
           echo "Nearest ancestor tag: $BASE"
 
       - name: Verify version matches pyproject.toml
-        run: python3 scripts/bump-version.py --check "${{ steps.version.outputs.value }}"
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: python3 scripts/bump-version.py --check "$VERSION"
 
-      - name: Create and push tag
+      - name: Create tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.value }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
-          git tag "v${{ steps.version.outputs.value }}"
-          git push origin "v${{ steps.version.outputs.value }}"
+          gh api --method POST "repos/$REPO/git/refs" \
+            -f ref="refs/tags/v$VERSION" \
+            -f sha="$SHA" > /dev/null
+          echo "Created tag v$VERSION at $SHA"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
+      # fetch-depth: 0 so existing tags are visible to the guards below.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Normalize version
         id: version
@@ -24,6 +27,37 @@ jobs:
           VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Releases come from main, or from a maintenance branch for out-of-band
+      # patches (see CONTRIBUTING.md "Out-of-Band Releases"). Anything else is
+      # a mis-dispatch, and tags are never deleted.
+      - name: Verify dispatch ref is releasable
+        run: |
+          case "$GITHUB_REF" in
+            refs/heads/main | refs/heads/releases/*) ;;
+            *)
+              echo "::error::Refusing to tag from '$GITHUB_REF'." \
+                   "Dispatch from 'main' or a 'releases/X.Y.x' branch."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify tag does not already exist
+        run: |
+          TAG="v${{ steps.version.outputs.value }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::$TAG already exists at $(git rev-parse --short "$TAG^{commit}")." \
+                 "Tags cannot be deleted - pick the next version."
+            exit 1
+          fi
+
+      # Informational: lets the dispatcher confirm they are tagging what they
+      # think before the (irreversible) push.
+      - name: Show base tag
+        run: |
+          BASE=$(git describe --tags --abbrev=0 --match "v*" HEAD 2>/dev/null || echo "none")
+          echo "Tagging $(git rev-parse --short HEAD) on $GITHUB_REF"
+          echo "Nearest ancestor tag: $BASE"
 
       - name: Verify version matches pyproject.toml
         run: python3 scripts/bump-version.py --check "${{ steps.version.outputs.value }}"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,11 +10,13 @@ on:
 
 permissions:
   contents: write
+  checks: read # to confirm CI passed on the commit being tagged
 
 jobs:
   tag:
     runs-on: ubuntu-latest
     environment: release
+    timeout-minutes: 10
     steps:
       # fetch-depth: 0 so existing tags are visible to the guards below.
       # persist-credentials: false so no write-capable token is left behind in
@@ -84,6 +86,39 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
         run: python3 scripts/bump-version.py --check "$VERSION"
+
+      # A tag is permanent, and merges are squashed - so the commit being tagged
+      # is a new SHA that no pull request ever tested. Require CI to have passed
+      # on this exact commit. This also catches a release branch cut from an
+      # older tag, which carries that tag's workflow config and may not run CI
+      # on pushes to itself at all (see CONTRIBUTING.md "Out-of-Band Releases").
+      - name: Verify CI passed on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          STATE=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "Pipeline Status")]
+                  | sort_by(.started_at) | last // {}
+                  | "\(.status // "none"):\(.conclusion // "none")"')
+          case "$STATE" in
+            completed:success)
+              echo "Pipeline Status passed for $SHA"
+              ;;
+            none:none)
+              echo "::error::No Pipeline Status check found for $SHA." \
+                   "If this is a release branch, add 'releases/**' to the push" \
+                   "triggers in .github/workflows/ci.yaml on the branch, push," \
+                   "and re-run once CI completes."
+              exit 1
+              ;;
+            *)
+              echo "::error::Pipeline Status for $SHA is '$STATE', not a success." \
+                   "Refusing to tag an untested commit."
+              exit 1
+              ;;
+          esac
 
       - name: Create tag
         env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -51,11 +51,29 @@ jobs:
 
       # Releases come from main, or from a maintenance branch for out-of-band
       # patches (see CONTRIBUTING.md "Out-of-Band Releases"). Anything else is
-      # a mis-dispatch, and tags are never deleted.
+      # a mis-dispatch, and tags are never deleted. A maintenance branch must
+      # also be tagged on its own line: releases/0.7.x cuts 0.7.z and nothing
+      # else, so a wrong-branch dispatch cannot mint a permanent tag that
+      # belongs to a different minor.
       - name: Verify dispatch ref is releasable
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
           case "$GITHUB_REF" in
-            refs/heads/main | refs/heads/releases/*) ;;
+            refs/heads/main) ;;
+            refs/heads/releases/*)
+              if [[ ! "$GITHUB_REF" =~ ^refs/heads/releases/((0|[1-9][0-9]*)\.(0|[1-9][0-9]*))\.x$ ]]; then
+                echo "::error::Maintenance branches must be named 'releases/X.Y.x'," \
+                     "not '$GITHUB_REF'."
+                exit 1
+              fi
+              LINE="${BASH_REMATCH[1]}"
+              if [[ "$VERSION" != "$LINE".* ]]; then
+                echo "::error::$GITHUB_REF releases the $LINE line, but $VERSION is not on it." \
+                     "Dispatch from the branch that owns this version."
+                exit 1
+              fi
+              ;;
             *)
               echo "::error::Refusing to tag from '$GITHUB_REF'." \
                    "Dispatch from 'main' or a 'releases/X.Y.x' branch."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,9 @@ forwarded env vars → optional isvreporter upload.
   feature PRs. To exercise an unreleased check end-to-end against a config,
   run with `ISVTEST_INCLUDE_UNRELEASED=1` (the orchestrator otherwise logs
   `Skipping unreleased validation '<Name>'` and the new check is a no-op).
+  On a `releases/X.Y.x` maintenance branch this manifest is regenerated from
+  that branch's own catalog, so it legitimately differs from `main`'s - do not
+  "reconcile" it by copying `main`'s version.
 
 ## Directory Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,7 +345,9 @@ After bumping, open a PR, review, and merge. Then the repo maintainers will crea
 
 The workflow tags whichever branch it is dispatched from, and only `main` or a
 `releases/**` branch is accepted. It will not re-cut an existing tag - tags are
-never deleted, so a mistake means burning that version.
+never deleted, so a mistake means burning that version - and it refuses to tag a
+commit that CI has not passed on. Since merges are squashed, that commit is a new
+one no pull request tested, so wait for its CI to finish before dispatching.
 
 ### Out-of-Band Releases
 
@@ -371,6 +373,9 @@ Conventions:
   section, not the version bump.
 - `make bump-patch` derives the version from the nearest ancestor tag, so it
   increments the release branch's own line.
+- Workflows run from the branch they are on, so a branch cut from an older tag
+  carries that tag's CI config. Add `releases/**` to the `push` triggers in
+  `.github/workflows/ci.yaml` on the branch, or its tip is never tested.
 - `released_tests.json` is regenerated from the release branch's catalog, so a
   cherry-picked validation ships there while staying unreleased on `main` until
   the next `main` bump. Run the bump on the branch; never cherry-pick it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,9 @@ The project follows [semver](https://semver.org/) but is still pre-1.0
   flagging to downstream consumers.
 - **Patch** (`X.Y.Z` -> `X.Y.(Z+1)`) - a decent batch of fixes/features/chores
   that has accumulated on `main` and is worth cutting, or an urgent fix that
-  needs to ship on its own.
+  needs to ship on its own. An urgent fix for an older minor is cut from a
+  maintenance branch instead of `main` (see [Out-of-Band
+  Releases](#out-of-band-releases)).
 
 External operators only run the **released** tests - the set pinned by
 `isvtest/src/isvtest/released_tests.json` at each tag - so every tag has a
@@ -340,6 +342,40 @@ After bumping, open a PR, review, and merge. Then the repo maintainers will crea
 1. Go to **Actions** > **Create version tag** in GitHub
 2. Enter the version (e.g. `1.0.0`, without leading `v`)
 3. The workflow verifies all `pyproject.toml` files match, then creates and pushes `v1.0.0`
+
+The workflow tags whichever branch it is dispatched from, and only `main` or a
+`releases/**` branch is accepted. It will not re-cut an existing tag - tags are
+never deleted, so a mistake means burning that version.
+
+### Out-of-Band Releases
+
+To patch an older minor without shipping everything that has landed on `main`
+since, cut a maintenance branch named `releases/<minor>.x` from the tag being
+patched, and tag from there.
+
+```bash
+git switch -c releases/<minor>.x v<tag>     # once per minor, from the tag
+git switch -c <topic> releases/<minor>.x    # then cherry-pick and bump
+git cherry-pick -x <sha>
+make bump-patch
+```
+
+Open the PR against the release branch, then dispatch **Create version tag**
+with that branch selected.
+
+Conventions:
+
+- Fixes land on `main` first and are cherry-picked onto the release branch,
+  never the reverse.
+- The release branch is not merged back. Forward-port only the CHANGELOG
+  section, not the version bump.
+- `make bump-patch` derives the version from the nearest ancestor tag, so it
+  increments the release branch's own line.
+- `released_tests.json` is regenerated from the release branch's catalog, so a
+  cherry-picked validation ships there while staying unreleased on `main` until
+  the next `main` bump. Run the bump on the branch; never cherry-pick it.
+- Confirm the version is free first - a bump can reach `main` without a tag
+  ever being cut, which burns the number.
 
 ## Project Structure
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -271,7 +271,10 @@ def refresh_released_tests(new_version: str) -> None:
 def check(expected: str) -> None:
     """Verify all pyproject.toml files already have the expected version."""
     if not SEMVER_RE.match(expected):
-        print(f"error: '{expected}' is not valid semver (expected X.Y.Z)", file=sys.stderr)
+        print(
+            f"error: '{expected}' is not valid semver (expected X.Y.Z, optionally with a prerelease such as X.Y.Z-rc1)",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     ok = True

--- a/scripts/changelog-prompt.md
+++ b/scripts/changelog-prompt.md
@@ -18,15 +18,23 @@ NVIDIA AI Cloud Validation Suite repository.
 ## Goal
 
 For every release version that is not yet documented in `CHANGELOG.md`,
-add a complete `## [X.Y.Z] - YYYY-MM-DD` section, in descending version
-order, immediately above the first existing `## [X.Y.Z]` heading (or at
-the end of the file if no version sections exist yet). A version is
-considered a release if either:
+add a complete `## [X.Y.Z] - YYYY-MM-DD` section. Sections are kept in
+**descending semver order**, so insert each one immediately above the
+first existing `## [X.Y.Z]` heading whose version is lower than it (or at
+the end of the file if there is no such heading). For a release cut from
+`main` this is the top of the list; for an out-of-band patch release it
+usually is not — a `0.7.3` section belongs below `0.10.0`, not above it.
+A version is considered a release if either:
 
 1. There is a git tag of the form `vX.Y.Z`, OR
-2. The `version` field of the root `pyproject.toml` is newer than every
-   git tag — this is a **pending release** that has been bumped but is
-   not yet tagged (typically run as part of `make bump-*`).
+2. The `version` field of the root `pyproject.toml` is newer than the
+   **nearest ancestor tag** (`git describe --tags --abbrev=0 --match "v*"`)
+   — this is a **pending release** that has been bumped but is not yet
+   tagged (typically run as part of `make bump-*`). Compare against the
+   ancestor tag rather than against every tag in the repo: on a
+   `releases/X.Y.x` maintenance branch the pending `0.7.3` is older than
+   the newest tag on `main`, and comparing globally would miss it
+   entirely. See CONTRIBUTING.md, "Out-of-Band Releases".
 
 Do not modify the file header, the "How to update this file" block, or
 any version section that already has content.
@@ -36,15 +44,21 @@ any version section that already has content.
 1. Read `CHANGELOG.md` and list every `## [X.Y.Z]` heading already present.
 2. Run `git tag --sort=-v:refname` to list all release tags. Any tag of the
    form `vX.Y.Z` whose version is **not** already a heading in the file is
-   missing. Also read the root `pyproject.toml` — if its `version = "X.Y.Z"`
-   is newer than every git tag and not already a heading, treat it as a
-   pending release.
+   missing. Also run `git describe --tags --abbrev=0 --match "v*"` to get the
+   nearest ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
+   `version = "X.Y.Z"` is newer than that ancestor tag and not already a
+   heading, treat it as a pending release.
 3. For each missing version, in chronological order (oldest first):
-   - For a **tagged release**, the commit range is `<prev_tag>..<tag>`
-     (`git log --pretty='%H %s' <prev_tag>..<tag>`).
-   - For a **pending release**, the commit range is `<latest_tag>..HEAD`
-     (`git log --pretty='%H %s' <latest_tag>..HEAD`). Skip the bump
-     commit itself (`chore: update package versions to X.Y.Z`).
+   - For a **tagged release**, the commit range is `<prev_tag>..<tag>`, where
+     `<prev_tag>` is the tag the release was cut from — use
+     `git describe --tags --abbrev=0 --match "v*" <tag>^` rather than
+     "the previous tag by version number", so a patch cut from a maintenance
+     branch is diffed against its own base and not against an unrelated tag
+     on `main` (`git log --pretty='%H %s' <prev_tag>..<tag>`).
+   - For a **pending release**, the commit range is `<ancestor_tag>..HEAD`
+     (`git log --pretty='%H %s' <ancestor_tag>..HEAD`), using the nearest
+     ancestor tag from step 2. Skip the bump commit itself
+     (`chore: update package versions to X.Y.Z`).
    - Each commit subject ends with the PR number in parentheses, e.g.
      `(#425)`. Fetch the PR for richer context from
      `https://github.com/NVIDIA/ai-cloud-validation/pull/<N>` (use the


### PR DESCRIPTION
Releases are tagged on `main`, so we can only ship "main as it stands" — there
was no way to cut a patch off an older minor. That matters here because the tag
is the release: `released_tests.json` is pinned at it, so moving an operator
forward to get a fix also changes their validation set.

Documents maintenance branches (`releases/<minor>.x`, cut on demand, main-first
cherry-picks, never merged back) and closes the gaps that path hits:

- `ci.yaml` — run on pushes to `releases/**`, so the tagged commit has been through CI
- `tag.yml` — only dispatch from `main` or `releases/**`, and refuse to re-cut an existing tag
- `changelog-prompt.md` — resolve the pending release against the nearest ancestor tag and
  insert sections in descending semver order; off `main` the old rules produced nothing

Docs only, plus two workflow guards. No behavior change to the normal release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release automation now supports maintenance-branch pushes and safer release creation.
  * Release tagging validates semantic versions, prevents duplicate tags, and verifies required checks.
  * Workflow permissions, runtime limits, and status reporting are more secure and reliable.
  * Version checks now clearly accept prerelease versions.

* **Documentation**
  * Expanded guidance for urgent, out-of-band, and maintenance-branch releases.
  * Updated changelog instructions for version ordering, branch-specific histories, and pending releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->