### PR TITLE
fix: backport runtime and SEC04 fixes to 0.7.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,20 @@ on:
   push:
     branches:
       - main
+      - "releases/**"
       - "pull-request/[0-9]+"
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
+
+# Least privilege for every job that does not declare its own block. Without
+# this the token inherits the repository default, which is write. packages:read
+# is required because the container image below is private and the runner
+# authenticates to ghcr with this token. Jobs that need more (the security
+# scans) declare their own permissions, which replace these rather than add
+# to them.
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   pre-commit:
@@ -178,9 +189,14 @@ jobs:
       - security-codeql-scan
       # - security-trivy-scan  # Disabled - see comment above (Trivy supply chain compromise)
     steps:
+      # The expression is evaluated into env rather than inlined into the
+      # script, keeping "no ${{ }} inside a run: block" true across every
+      # workflow - an invariant a reviewer can grep for.
       - name: Check Pipeline Status
+        env:
+          PIPELINE_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+          if [[ "$PIPELINE_FAILED" == "true" ]]; then
             echo "One or more jobs on the pipeline failed! Check the logs for details."
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0 # Full history for secret scanning
 
       - name: Run TruffleHog Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
           extra-args: "--results=verified,unknown --only-verified"
           post-pr-comment: "true"
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run CodeQL Scan
-        uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@55d1e0af17fb4431edaca19fbd5c78fecd29d18a
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/codeql-scan@55d1e0af17fb4431edaca19fbd5c78fecd29d18a
         with:
           languages: python
           build-mode: none
@@ -153,7 +153,7 @@ jobs:
   #       uses: actions/checkout@v6
 
   #     - name: Run Trivy Scan
-  #       uses: NVIDIA/dsx-github-actions/.github/actions/trivy-scan@495fc76167e3d265f817c1fdc00b7b9275436418
+  #       uses: dsx-ai-factory/dsx-github-actions/.github/actions/trivy-scan@495fc76167e3d265f817c1fdc00b7b9275436418
   #       with:
   #         scan-type: fs
   #         scan-ref: .

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,25 +10,142 @@ on:
 
 permissions:
   contents: write
+  checks: read # to confirm CI passed on the commit being tagged
 
 jobs:
   tag:
     runs-on: ubuntu-latest
     environment: release
+    timeout-minutes: 10
     steps:
+      # fetch-depth: 0 so existing tags are visible to the guards below.
+      # persist-credentials: false so no write-capable token is left behind in
+      # .git/config while later steps run scripts from the checked-out ref. The
+      # tag is created through the API in the final step, which is the only step
+      # that needs a credential.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Normalize version
+      # inputs.version is untrusted - it arrives as a free-form string from
+      # whoever dispatched the run. It is passed through env rather than a
+      # ${{ }} expression because expressions are substituted into the script
+      # before bash parses it, so a crafted value would execute as code. It is
+      # validated here, before any other step consumes it. The pattern matches
+      # the repository's tag naming rule (with semver's no-leading-zeros
+      # restriction), so a version accepted here cannot be rejected later.
+      - name: Normalize and validate version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+            # The rejected value is deliberately not echoed: it is untrusted and
+            # could inject workflow commands. It is visible in the run's inputs.
+            echo "::error::Invalid version input. Expected X.Y.Z or X.Y.Z-rcN, without a leading 'v'."
+            exit 1
+          fi
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Verify version matches pyproject.toml
-        run: python3 scripts/bump-version.py --check "${{ steps.version.outputs.value }}"
-
-      - name: Create and push tag
+      # Releases come from main, or from a maintenance branch for out-of-band
+      # patches (see CONTRIBUTING.md "Out-of-Band Releases"). Anything else is
+      # a mis-dispatch, and tags are never deleted. A maintenance branch must
+      # also be tagged on its own line: releases/0.7.x cuts 0.7.z and nothing
+      # else, so a wrong-branch dispatch cannot mint a permanent tag that
+      # belongs to a different minor.
+      - name: Verify dispatch ref is releasable
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
-          git tag "v${{ steps.version.outputs.value }}"
-          git push origin "v${{ steps.version.outputs.value }}"
+          case "$GITHUB_REF" in
+            refs/heads/main) ;;
+            refs/heads/releases/*)
+              if [[ ! "$GITHUB_REF" =~ ^refs/heads/releases/((0|[1-9][0-9]*)\.(0|[1-9][0-9]*))\.x$ ]]; then
+                echo "::error::Maintenance branches must be named 'releases/X.Y.x'," \
+                     "not '$GITHUB_REF'."
+                exit 1
+              fi
+              LINE="${BASH_REMATCH[1]}"
+              if [[ "$VERSION" != "$LINE".* ]]; then
+                echo "::error::$GITHUB_REF releases the $LINE line, but $VERSION is not on it." \
+                     "Dispatch from the branch that owns this version."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Refusing to tag from '$GITHUB_REF'." \
+                   "Dispatch from 'main' or a 'releases/X.Y.x' branch."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify tag does not already exist
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::$TAG already exists at $(git rev-parse --short "$TAG^{commit}")." \
+                 "Tags are never deleted - pick the next version."
+            exit 1
+          fi
+
+      # Informational: lets the dispatcher confirm they are tagging what they
+      # think before the (irreversible) tag creation.
+      - name: Show base tag
+        run: |
+          BASE=$(git describe --tags --abbrev=0 --match "v*" HEAD 2>/dev/null || echo "none")
+          echo "Tagging $(git rev-parse --short HEAD) on $GITHUB_REF"
+          echo "Nearest ancestor tag: $BASE"
+
+      - name: Verify version matches pyproject.toml
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: python3 scripts/bump-version.py --check "$VERSION"
+
+      # A tag is permanent, and merges are squashed - so the commit being tagged
+      # is a new SHA that no pull request ever tested. Require CI to have passed
+      # on this exact commit. This also catches a release branch cut from an
+      # older tag, which carries that tag's workflow config and may not run CI
+      # on pushes to itself at all (see CONTRIBUTING.md "Out-of-Band Releases").
+      - name: Verify CI passed on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          STATE=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+            --jq '[.check_runs[] | select(.name == "Pipeline Status")]
+                  | sort_by(.started_at) | last // {}
+                  | "\(.status // "none"):\(.conclusion // "none")"')
+          case "$STATE" in
+            completed:success)
+              echo "Pipeline Status passed for $SHA"
+              ;;
+            none:none)
+              echo "::error::No Pipeline Status check found for $SHA." \
+                   "If this is a release branch, add 'releases/**' to the push" \
+                   "triggers in .github/workflows/ci.yaml on the branch, push," \
+                   "and re-run once CI completes."
+              exit 1
+              ;;
+            *)
+              echo "::error::Pipeline Status for $SHA is '$STATE', not a success." \
+                   "Refusing to tag an untested commit."
+              exit 1
+              ;;
+          esac
+
+      - name: Create tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.value }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          gh api --method POST "repos/$REPO/git/refs" \
+            -f ref="refs/tags/v$VERSION" \
+            -f sha="$SHA" > /dev/null
+          echo "Created tag v$VERSION at $SHA"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,9 @@ forwarded env vars → optional isvreporter upload.
   feature PRs. To exercise an unreleased check end-to-end against a config,
   run with `ISVTEST_INCLUDE_UNRELEASED=1` (the orchestrator otherwise logs
   `Skipping unreleased validation '<Name>'` and the new check is a no-op).
+  On a `releases/X.Y.x` maintenance branch this manifest is regenerated from
+  that branch's own catalog, so it legitimately differs from `main`'s - do not
+  "reconcile" it by copying `main`'s version.
 
 ## Directory Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,9 @@ The project follows [semver](https://semver.org/) but is still pre-1.0
   flagging to downstream consumers.
 - **Patch** (`X.Y.Z` -> `X.Y.(Z+1)`) - a decent batch of fixes/features/chores
   that has accumulated on `main` and is worth cutting, or an urgent fix that
-  needs to ship on its own.
+  needs to ship on its own. An urgent fix for an older minor is cut from a
+  maintenance branch instead of `main` (see [Out-of-Band
+  Releases](#out-of-band-releases)).
 
 External operators only run the **released** tests - the set pinned by
 `isvtest/src/isvtest/released_tests.json` at each tag - so every tag has a
@@ -340,6 +342,45 @@ After bumping, open a PR, review, and merge. Then the repo maintainers will crea
 1. Go to **Actions** > **Create version tag** in GitHub
 2. Enter the version (e.g. `1.0.0`, without leading `v`)
 3. The workflow verifies all `pyproject.toml` files match, then creates and pushes `v1.0.0`
+
+The workflow tags whichever branch it is dispatched from, and only `main` or a
+`releases/**` branch is accepted. It will not re-cut an existing tag - tags are
+never deleted, so a mistake means burning that version - and it refuses to tag a
+commit that CI has not passed on. Since merges are squashed, that commit is a new
+one no pull request tested, so wait for its CI to finish before dispatching.
+
+### Out-of-Band Releases
+
+To patch an older minor without shipping everything that has landed on `main`
+since, cut a maintenance branch named `releases/<minor>.x` from the tag being
+patched, and tag from there.
+
+```bash
+git switch -c releases/<minor>.x v<tag>     # once per minor, from the tag
+git switch -c <topic> releases/<minor>.x    # then cherry-pick and bump
+git cherry-pick -x <sha>
+make bump-patch
+```
+
+Open the PR against the release branch, then dispatch **Create version tag**
+with that branch selected.
+
+Conventions:
+
+- Fixes land on `main` first and are cherry-picked onto the release branch,
+  never the reverse.
+- The release branch is not merged back. Forward-port only the CHANGELOG
+  section, not the version bump.
+- `make bump-patch` derives the version from the nearest ancestor tag, so it
+  increments the release branch's own line.
+- Workflows run from the branch they are on, so a branch cut from an older tag
+  carries that tag's CI config. Add `releases/**` to the `push` triggers in
+  `.github/workflows/ci.yaml` on the branch, or its tip is never tested.
+- `released_tests.json` is regenerated from the release branch's catalog, so a
+  cherry-picked validation ships there while staying unreleased on `main` until
+  the next `main` bump. Run the bump on the branch; never cherry-pick it.
+- Confirm the version is free first - a bump can reach `main` without a tag
+  ever being cut, which burns the number.
 
 ## Project Structure
 

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -2649,7 +2649,7 @@ a| icon:exclamation-circle[role=red] https://github.com/NVIDIA/ISV-NCP-Validatio
 |
 | M5
 |
-| Verify least-privilege access policies (resource-based, user-based, network-based)
+| Verify least-privilege access policies (resource-based and user-based)
 | pending
 |
 

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2037,7 +2037,7 @@ domains:
                 status: pending
           - description: Storage Security
             tests:
-              - summary: Verify least-privilege access policies (resource-based, user-based, network-based)
+              - summary: Verify least-privilege access policies (resource-based and user-based)
                 labels:
                   - min_req
                 priority: P1

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -37,7 +37,7 @@
 #   9. KMS Options             - Verify provider- and customer-managed keys (SEC09-02)
 #  10. Centralized KMS         - Verify encrypted resources resolve to KMS (SEC09-03)
 #  11. Customer Managed Key    - Verify customer-managed key encryption (SEC09-04)
-#  12. Least Privilege         - Verify scoped user/resource/network policies (SEC04-01/02)
+#  12. Least Privilege         - Verify scoped user/resource policies (SEC04-01/02)
 #  13. Audit Logging           - Verify management-event logging and retention (SEC08-01/02)
 #  14. SA Credential Auth      - Verify IAM user + long-lived access key auth
 #  15. OIDC User Auth          - Probe configured OIDC-protected platform endpoint (SEC01-01)
@@ -154,8 +154,8 @@ commands:
       # Test 12: Least-Privilege Policy + Minimal Role Enforcement (SEC04-01/02)
       # Self-contained: provisions a temporary IAM user, two tagged buckets, and a minimal
       # VPC/subnet/security-group/instance fixture for EC2 DryRun probes. It attaches one
-      # inline policy scoped by identity, resource, and aws:SourceIp, then verifies the
-      # allowed S3 ListBucket path plus denied out-of-scope compute/storage/network API
+      # inline policy scoped by identity and resource, then verifies the allowed S3
+      # ListBucket path plus denied out-of-scope compute/storage/network API
       # probes. Cleans up the user, access key, inline policy, buckets, object, and EC2
       # fixture in a finally block.
       #

--- a/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/least_privilege_test.py
@@ -21,13 +21,11 @@ This AWS reference is self-contained. It provisions a temporary IAM user
 inline policy to the user, mints an access key, then probes the policy as
 that user.
 
-The inline policy exercises the three least-privilege dimensions named by
+The inline policy exercises the two least-privilege dimensions named by
 SEC04-01:
 
 * user-based: only the temporary user receives the inline grant.
 * resource-based: only the tagged allowed bucket ARN is granted.
-* network-based: the grant includes an ``aws:SourceIp`` condition for the
-  caller's public CIDR.
 
 SEC04-02 is checked from the same minimal identity by verifying out-of-scope
 compute, storage, and network APIs are denied. Mutating EC2 probes use
@@ -41,13 +39,10 @@ rather than fabricate a pass.
 """
 
 import argparse
-import ipaddress
 import json
 import os
 import sys
 import time
-import urllib.error
-import urllib.request
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -63,11 +58,17 @@ TEST_NAME = "least_privilege_test"
 TEST_USER_PREFIX = "isv-sec04-test-"
 INLINE_POLICY_NAME = "isv-sec04-least-privilege"
 DENIED_OBJECT_KEY = "sec04-denied-probe-object"
-CALLER_IP_URL = "https://checkip.amazonaws.com/"
 PROBE_CIDR = "10.96.0.0/24"
 
 SKIPPABLE_SETUP_ERRORS = frozenset({"AccessDenied", "UnauthorizedOperation"})
 DENY_CODES = frozenset({"AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "Forbidden"})
+# A freshly minted access key is not accepted by every service endpoint at
+# once; until it propagates, EC2 returns AuthFailure and S3 returns
+# InvalidAccessKeyId. These are credential-propagation races, not deny results,
+# so the probes must wait them out instead of misclassifying them as failures.
+CREDENTIAL_PROPAGATION_CODES = frozenset(
+    {"InvalidClientTokenId", "AuthFailure", "InvalidAccessKeyId", "SignatureDoesNotMatch"}
+)
 DRY_RUN_ALLOWED_CODE = "DryRunOperation"
 IAM_PROPAGATION_MAX_ATTEMPTS = 8
 IAM_PROPAGATION_BACKOFF_CAP = 8
@@ -83,23 +84,6 @@ def _skipped_result(reason: str) -> dict[str, Any]:
         "skip_reason": reason,
         "tests": {},
     }
-
-
-def _detect_source_cidr() -> str:
-    """Return the caller's public IP address as an IPv4/IPv6 host CIDR."""
-    try:
-        with urllib.request.urlopen(CALLER_IP_URL, timeout=5) as response:
-            ip_address = response.read().decode("utf-8").strip()
-    except (OSError, urllib.error.URLError) as exc:
-        msg = f"cannot determine caller public IP for source condition: {exc}"
-        raise RuntimeError(msg) from exc
-    try:
-        parsed_ip = ipaddress.ip_address(ip_address)
-    except ValueError as exc:
-        msg = f"unexpected caller public IP response: {ip_address!r}"
-        raise RuntimeError(msg) from exc
-    prefix_len = 32 if parsed_ip.version == 4 else 128
-    return f"{parsed_ip}/{prefix_len}"
 
 
 def _create_bucket(s3: Any, bucket: str, region: str, buckets_created: list[str]) -> None:
@@ -226,84 +210,44 @@ def _get_amazon_linux_ami(ec2: Any) -> str:
     return images[0]["ImageId"]
 
 
-def _policy_document(allowed_bucket: str, source_cidr: str) -> str:
+def _policy_document(allowed_bucket: str) -> str:
     """Return the minimal inline policy attached only to the temporary user."""
     return json.dumps(
         {
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Sid": "AllowListOnlyTaggedBucketFromCallerCidr",
+                    "Sid": "AllowListOnlyTaggedBucket",
                     "Effect": "Allow",
                     "Action": "s3:ListBucket",
                     "Resource": f"arn:aws:s3:::{allowed_bucket}",
-                    "Condition": {"IpAddress": {"aws:SourceIp": source_cidr}},
                 }
             ],
         }
     )
 
 
-def _policy_has_source_cidr_condition(policy_document: str, allowed_bucket: str, source_cidr: str) -> bool:
-    """Return True when the S3 allow statement is scoped to the expected SourceIp CIDR."""
-    expected_resource = f"arn:aws:s3:::{allowed_bucket}"
-    try:
-        document = json.loads(policy_document)
-    except json.JSONDecodeError:
-        return False
-
-    statements = document.get("Statement", [])
-    if isinstance(statements, dict):
-        statements = [statements]
-    if not isinstance(statements, list):
-        return False
-
-    for statement in statements:
-        if not isinstance(statement, dict):
-            continue
-        actions = statement.get("Action", [])
-        if isinstance(actions, str):
-            actions = [actions]
-        resources = statement.get("Resource", [])
-        if isinstance(resources, str):
-            resources = [resources]
-        source_ips = statement.get("Condition", {}).get("IpAddress", {}).get("aws:SourceIp", [])
-        if isinstance(source_ips, str):
-            source_ips = [source_ips]
-        if (
-            statement.get("Effect") == "Allow"
-            and "s3:ListBucket" in actions
-            and expected_resource in resources
-            and source_cidr in source_ips
-        ):
-            return True
-    return False
-
-
-def _policy_dimension_scope_results(
+def _policy_resource_scope_result(
     *,
     allowed_result: dict[str, Any],
     denied_resource_result: dict[str, Any],
-    policy_document: str,
-    allowed_bucket: str,
-    source_cidr: str,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Build resource- and network-scope SEC04 result entries from concrete evidence."""
+) -> dict[str, Any]:
+    """Build the resource-scope SEC04 result entry from concrete evidence."""
     allowed_passed = bool(allowed_result.get("passed"))
-    source_condition_matches = _policy_has_source_cidr_condition(policy_document, allowed_bucket, source_cidr)
-    resource_result = {
-        "passed": allowed_passed and bool(denied_resource_result.get("passed")),
+    resource_passed = allowed_passed and bool(denied_resource_result.get("passed"))
+    resource_result: dict[str, Any] = {
+        "passed": resource_passed,
         "message": "allowed scoped resource and denied unscoped resource",
         "probes": [denied_resource_result],
     }
-    network_result = {
-        "passed": allowed_passed and source_condition_matches,
-        "message": (
-            "minimal policy "
-            f"{'contains' if source_condition_matches else 'does not contain'} the expected source CIDR condition"
-        ),
-    }
-    return resource_result, network_result
+    if not resource_passed:
+        if not allowed_passed:
+            resource_result["error"] = "allowed scoped-resource action did not succeed"
+        else:
+            resource_result["error"] = denied_resource_result.get("error") or (
+                f"unscoped-resource probe returned {denied_resource_result.get('code', 'unknown')}"
+            )
+    return resource_result
 
 
 def _cleanup_buckets(s3: Any, buckets: list[str]) -> list[str]:
@@ -357,18 +301,41 @@ def _cleanup_test_user(
     return errors
 
 
-def _wait_for_iam_propagation(sts: Any) -> None:
-    """Block until the temporary access key is visible to STS."""
-    for attempt in range(IAM_PROPAGATION_MAX_ATTEMPTS):
-        try:
-            sts.get_caller_identity()
-            return
-        except ClientError as exc:
-            code = exc.response.get("Error", {}).get("Code", "")
-            if code == "InvalidClientTokenId" and attempt < IAM_PROPAGATION_MAX_ATTEMPTS - 1:
+def _service_accepts_credentials(probe: Callable[[], Any]) -> bool:
+    """Return True once a probe authenticates (any non-propagation response).
+
+    A deny (``AccessDenied``/``UnauthorizedOperation``) or ``DryRunOperation``
+    still proves the endpoint accepted the key; only credential-propagation
+    codes mean the key is not usable yet.
+    """
+    try:
+        probe()
+    except ClientError as exc:
+        return exc.response.get("Error", {}).get("Code", "") not in CREDENTIAL_PROPAGATION_CODES
+    return True
+
+
+def _wait_for_iam_propagation(clients: dict[str, Any], allowed_bucket: str) -> None:
+    """Block until STS, EC2, and S3 all accept the temporary access key.
+
+    STS visibility does not guarantee the EC2/S3 endpoints accept the key yet;
+    until they do they return AuthFailure/InvalidAccessKeyId, which the deny
+    probes would otherwise misclassify as authorization failures.
+    """
+    probes: tuple[tuple[str, Callable[[], Any]], ...] = (
+        ("sts", lambda: clients["sts"].get_caller_identity()),
+        ("ec2", lambda: clients["ec2"].describe_regions(DryRun=True)),
+        ("s3", lambda: clients["s3"].list_objects_v2(Bucket=allowed_bucket, MaxKeys=1)),
+    )
+    for service, probe in probes:
+        for attempt in range(IAM_PROPAGATION_MAX_ATTEMPTS):
+            if _service_accepts_credentials(probe):
+                break
+            if attempt < IAM_PROPAGATION_MAX_ATTEMPTS - 1:
                 time.sleep(min(2 ** (attempt + 1), IAM_PROPAGATION_BACKOFF_CAP))
-                continue
-            raise
+        else:
+            msg = f"temporary credentials did not propagate to {service} before timeout"
+            raise RuntimeError(msg)
 
 
 def _probe_allowed_bucket(s3_user: Any, allowed_bucket: str) -> dict[str, Any]:
@@ -440,19 +407,8 @@ def main() -> int:
     """Provision the SEC04 fixture, run positive and negative probes, emit JSON."""
     parser = argparse.ArgumentParser(description="Least-privilege policy and minimal-role enforcement test")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
-    parser.add_argument(
-        "--source-cidr",
-        default=os.environ.get("SEC04_ALLOWED_SOURCE_CIDR", ""),
-        help="Allowed source CIDR. Defaults to the caller public host CIDR.",
-    )
     args = parser.parse_args()
     region = args.region
-
-    try:
-        source_cidr = args.source_cidr.strip() or _detect_source_cidr()
-    except RuntimeError as exc:
-        print(json.dumps(_skipped_result(str(exc)), indent=2))
-        return 0
 
     iam = boto3.client("iam", region_name=region)
     ec2 = boto3.client("ec2", region_name=region)
@@ -478,11 +434,9 @@ def main() -> int:
         "test_name": TEST_NAME,
         "test_identity": username,
         "allowed_resource": allowed_bucket,
-        "allowed_source_cidr": source_cidr,
         "tests": {
             "policy_dimensions_user_based": {"passed": False},
             "policy_dimensions_resource_based": {"passed": False},
-            "policy_dimensions_network_based": {"passed": False},
             "policy_dimensions_allowed_action_succeeds": {"passed": False},
             "out_of_scope_compute_denied": {"passed": False},
             "out_of_scope_storage_denied": {"passed": False},
@@ -509,7 +463,7 @@ def main() -> int:
                 sg_id=probe_sg_id,
                 name=username,
             )
-            policy_document = _policy_document(allowed_bucket, source_cidr)
+            policy_document = _policy_document(allowed_bucket)
             iam.put_user_policy(
                 UserName=username,
                 PolicyName=INLINE_POLICY_NAME,
@@ -528,7 +482,7 @@ def main() -> int:
                 raise RuntimeError(msg)
 
             clients = _build_user_clients(access_key_id, secret_key, region)
-            _wait_for_iam_propagation(clients["sts"])
+            _wait_for_iam_propagation(clients, allowed_bucket)
             caller = clients["sts"].get_caller_identity()
             caller_arn = caller.get("Arn", "")
 
@@ -539,19 +493,26 @@ def main() -> int:
                 "storage_list_unscoped_resource_denied",
                 lambda: clients["s3"].list_objects_v2(Bucket=denied_bucket, MaxKeys=1),
             )
-            resource_scope_result, network_scope_result = _policy_dimension_scope_results(
+            resource_scope_result = _policy_resource_scope_result(
                 allowed_result=allowed_result,
                 denied_resource_result=denied_resource_result,
-                policy_document=policy_document,
-                allowed_bucket=allowed_bucket,
-                source_cidr=source_cidr,
             )
+            user_based_passed = allowed_passed and username in caller_arn
             result["tests"]["policy_dimensions_user_based"] = {
-                "passed": allowed_passed and username in caller_arn,
-                "message": "temporary principal identity verified",
+                "passed": user_based_passed,
+                "message": (
+                    "temporary principal identity verified"
+                    if user_based_passed
+                    else "temporary principal identity check failed"
+                ),
             }
+            if not user_based_passed:
+                result["tests"]["policy_dimensions_user_based"]["error"] = (
+                    "allowed scoped-resource action did not succeed"
+                    if not allowed_passed
+                    else "temporary principal identity did not match the minted access key"
+                )
             result["tests"]["policy_dimensions_resource_based"] = resource_scope_result
-            result["tests"]["policy_dimensions_network_based"] = network_scope_result
 
             compute_probes = [
                 _expect_denied(

--- a/isvctl/configs/providers/my-isv/scripts/security/least_privilege_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/least_privilege_test.py
@@ -27,11 +27,9 @@ Required JSON output fields:
     "test_name": "least_privilege_test",
     "test_identity": "<temporary principal id>",
     "allowed_resource": "<resource allowed by the minimal policy>",
-    "allowed_source_cidr": "<network source constraint>",
     "tests": {
       "policy_dimensions_user_based":              {"passed": true},
       "policy_dimensions_resource_based":          {"passed": true},
-      "policy_dimensions_network_based":           {"passed": true},
       "policy_dimensions_allowed_action_succeeds": {"passed": true},
       "out_of_scope_compute_denied":               {"passed": true},
       "out_of_scope_storage_denied":               {"passed": true},
@@ -64,11 +62,9 @@ def main() -> int:
         "test_name": "least_privilege_test",
         "test_identity": "",
         "allowed_resource": "",
-        "allowed_source_cidr": "",
         "tests": {
             "policy_dimensions_user_based": {"passed": False},
             "policy_dimensions_resource_based": {"passed": False},
-            "policy_dimensions_network_based": {"passed": False},
             "policy_dimensions_allowed_action_succeeds": {"passed": False},
             "out_of_scope_compute_denied": {"passed": False},
             "out_of_scope_storage_denied": {"passed": False},
@@ -85,7 +81,6 @@ def main() -> int:
     #       principal,
     #       allowed_action="list/read metadata",
     #       allowed_resource=resource.id,
-    #       allowed_source_cidr=current_runner_cidr,
     #   )
     #   assert principal.can_perform_allowed_action(resource)
     #   assert principal.cannot_use_compute_actions_outside_policy()
@@ -99,11 +94,9 @@ def main() -> int:
     if DEMO_MODE:
         result["test_identity"] = "demo-sec04-principal"
         result["allowed_resource"] = "demo-sec04-resource"
-        result["allowed_source_cidr"] = "203.0.113.10/32"
         result["tests"] = {
             "policy_dimensions_user_based": {"passed": True, "message": "demo: policy attached to one principal"},
             "policy_dimensions_resource_based": {"passed": True, "message": "demo: policy scoped to one resource"},
-            "policy_dimensions_network_based": {"passed": True, "message": "demo: policy scoped to one source CIDR"},
             "policy_dimensions_allowed_action_succeeds": {"passed": True, "message": "demo: in-scope action allowed"},
             "out_of_scope_compute_denied": {"passed": True, "message": "demo: compute operations denied"},
             "out_of_scope_storage_denied": {"passed": True, "message": "demo: storage operations denied"},

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -983,76 +983,32 @@ def test_audit_logging_main_emits_structured_skip(
     assert "audit_log_trail_arn" not in payload
 
 
-class FakeIpResponse:
-    """Context manager returned by fake URL open calls."""
-
-    def __init__(self, body: str) -> None:
-        """Store the fake response body."""
-        self.body = body
-
-    def __enter__(self) -> FakeIpResponse:
-        """Return this fake response."""
-        return self
-
-    def __exit__(self, *_args: Any) -> None:
-        """Close the fake response."""
-
-    def read(self) -> bytes:
-        """Return the configured response body."""
-        return self.body.encode("utf-8")
-
-
-@pytest.mark.parametrize(
-    ("raw_ip", "expected_cidr"),
-    [
-        ("203.0.113.10\n", "203.0.113.10/32"),
-        ("2001:db8::1\n", "2001:db8::1/128"),
-    ],
-)
-def test_least_privilege_detect_source_cidr_handles_ipv4_and_ipv6(
-    monkeypatch: pytest.MonkeyPatch,
-    raw_ip: str,
-    expected_cidr: str,
-) -> None:
-    """Source CIDR detection normalizes IPv4 and IPv6 host addresses."""
+def test_least_privilege_resource_scope_requires_denied_bucket() -> None:
+    """SEC04 resource scope requires allowed-resource and denied-resource evidence."""
     module = _load_security_script("least_privilege_test.py")
+    policy_document = json.loads(module._policy_document("allowed-bucket"))
 
-    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *_args, **_kwargs: FakeIpResponse(raw_ip))
-
-    assert module._detect_source_cidr() == expected_cidr
-
-
-def test_least_privilege_dimension_results_require_denied_bucket_and_source_cidr() -> None:
-    """SEC04 dimension flags require denied-resource evidence and the SourceIp policy condition."""
-    module = _load_security_script("least_privilege_test.py")
-    policy_document = module._policy_document("allowed-bucket", "2001:db8::1/128")
-
-    resource_result, network_result = module._policy_dimension_scope_results(
+    resource_result = module._policy_resource_scope_result(
         allowed_result={"passed": True},
         denied_resource_result={
             "name": "storage_list_unscoped_resource_denied",
             "passed": True,
             "code": "AccessDenied",
         },
-        policy_document=policy_document,
-        allowed_bucket="allowed-bucket",
-        source_cidr="2001:db8::1/128",
     )
 
+    assert policy_document["Statement"][0]["Resource"] == "arn:aws:s3:::allowed-bucket"
+    assert "Condition" not in policy_document["Statement"][0]
     assert resource_result["passed"] is True
     assert resource_result["probes"][0]["code"] == "AccessDenied"
-    assert network_result["passed"] is True
 
-    failed_resource_result, failed_network_result = module._policy_dimension_scope_results(
+    failed_resource_result = module._policy_resource_scope_result(
         allowed_result={"passed": True},
         denied_resource_result={"name": "storage_list_unscoped_resource_denied", "passed": False, "error": "allowed"},
-        policy_document=policy_document,
-        allowed_bucket="allowed-bucket",
-        source_cidr="203.0.113.10/32",
     )
 
     assert failed_resource_result["passed"] is False
-    assert failed_network_result["passed"] is False
+    assert failed_resource_result["error"]
 
 
 class FakeIamTags:

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -1924,20 +1924,74 @@ class EthernetCheck(BaseValidation):
 
 
 class ContainerRuntimeCheck(BaseValidation):
-    """Container runtime and NVIDIA Docker check.
+    """GPU-capable container runtime check.
 
-    Checks Docker and NVIDIA container runtime are available and working.
+    Verifies that the host has a container runtime capable of running GPU
+    workloads. Accepts any GPU-capable runtime, not just Docker, by probing
+    in order from highest-level to lowest-level:
+
+      Level 1 — Docker:      docker present + GPU container runs nvidia-smi.
+      Level 2 — nerdctl:     containerd-backed CLI present + GPU container runs.
+      Level 3 — containerd:  containerd present + nvidia-container-runtime
+                             installed as the OCI hook. The GPU operator's
+                             presence is the proof of capability.
+      Level 4 — runc:        runc present + nvidia-container-runtime installed.
+      Level 5 — crun:        crun (alternative OCI runtime) + nvidia-container-runtime.
+
+    On systems running containerd without Docker (e.g. standard k8s nodes),
+    level 3 passes when nvidia-container-runtime is installed, which is the
+    standard GPU operator deployment. Overlapping coverage from
+    K8sNvidiaSmiCheck and K8sGpuPodAccessCheck confirms GPU workloads run.
 
     Config:
         host, key_file, user: SSH connection details
         ngc_api_key: NGC API key for registry access (optional)
     """
 
-    description: ClassVar[str] = "Tests container runtime and NVIDIA Docker support"
+    description: ClassVar[str] = "Tests GPU-capable container runtime support"
     timeout: ClassVar[int] = 300
     labels: ClassVar[tuple[str, ...]] = ("ssh", "gpu", "workload", "slow", "bare_metal", "vm")
 
+    _GPU_IMAGE: ClassVar[str] = "nvcr.io/nvidia/cuda:13.0.0-base-ubuntu24.04"
+
+    def _check_cmd(self, ssh: object, cmd: str) -> str:
+        """Run cmd via SSH and return stdout."""
+        _, stdout, _ = run_ssh_command(ssh, cmd)
+        return stdout
+
+    def _is_present(self, ssh: object, binary: str) -> tuple[bool, str]:
+        """Return (found, version_string) for a binary."""
+        out = self._check_cmd(ssh, f"{binary} --version 2>/dev/null || echo '__not_found__'")
+        found = "__not_found__" not in out and out.strip()
+        return bool(found), out.strip()
+
+    def _gpu_operator_installed(self, ssh: object) -> bool:
+        """Return True when nvidia-container-runtime is installed and configured as an OCI hook.
+
+        Checks both binary presence and containerd integration: verifies the
+        runtime binary exists and is referenced in the containerd configuration
+        or registered as a containerd plugin.
+        """
+        # Step 1: binary must exist.
+        out = self._check_cmd(ssh, "nvidia-container-runtime --version 2>/dev/null || echo '__not_found__'")
+        if "__not_found__" in out or not out.strip():
+            return False
+        # Step 2: verify containerd is configured to use it as an OCI runtime.
+        config_out = self._check_cmd(
+            ssh,
+            "grep -rl 'nvidia' /etc/containerd/ 2>/dev/null | head -1 || "
+            "ctr plugins ls 2>/dev/null | grep -i nvidia | head -1 || "
+            "echo '__not_configured__'",
+        )
+        return "__not_configured__" not in config_out and config_out.strip() != ""
+
+    def _run_gpu_container(self, ssh: object, run_cmd: str) -> bool:
+        """Return True when a GPU container runs nvidia-smi successfully."""
+        out = self._check_cmd(ssh, run_cmd + " 2>&1 || echo '__gpu_run_failed__'")
+        return "__gpu_run_failed__" not in out and "NVIDIA-SMI" in out
+
     def run(self) -> None:
+        """Detect the available GPU-capable container runtime and validate GPU support."""
         try:
             import paramiko  # noqa: F401
         except ImportError:
@@ -1957,42 +2011,124 @@ class ContainerRuntimeCheck(BaseValidation):
         try:
             ssh = get_ssh_client(host, user, key_path)
 
-            # Check Docker
-            _, stdout, _ = run_ssh_command(ssh, "docker --version 2>/dev/null || echo 'not_found'")
-            docker_ok = "not_found" not in stdout and "Docker" in stdout
-            self.report_subtest("docker", docker_ok, stdout.strip() if docker_ok else "Docker not installed")
+            rt_name: str | None = None
+            login_cmd_tmpl: str | None = None
 
-            if not docker_ok:
-                self.set_failed("Docker not available")
+            # ── Level 1: Docker ──────────────────────────────────────────────
+            docker_ok, docker_ver = self._is_present(ssh, "docker")
+            if docker_ok and rt_name is None:
+                gpu_ok = self._run_gpu_container(ssh, f"docker run --rm --gpus all {self._GPU_IMAGE} nvidia-smi")
+                if gpu_ok:
+                    self.report_subtest("container_runtime", True, f"docker {docker_ver}")
+                    self.report_subtest("gpu_container", True, "GPU container ran via docker")
+                    rt_name = "docker"
+                    login_cmd_tmpl = "printf '%s' '{key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
+                else:
+                    self.log.info("docker GPU container failed; falling back to next level")
+
+            # ── Level 2: nerdctl (containerd-backed CLI) ─────────────────────
+            if rt_name is None:
+                nerdctl_ok, nerdctl_ver = self._is_present(ssh, "nerdctl")
+                if nerdctl_ok:
+                    gpu_ok = self._run_gpu_container(ssh, f"nerdctl run --rm --gpus all {self._GPU_IMAGE} nvidia-smi")
+                    if gpu_ok:
+                        self.report_subtest("container_runtime", True, f"nerdctl {nerdctl_ver}")
+                        self.report_subtest("gpu_container", True, "GPU container ran via nerdctl")
+                        rt_name = "nerdctl"
+                        login_cmd_tmpl = (
+                            "printf '%s' '{key}' | nerdctl login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
+                        )
+                    else:
+                        self.log.info("nerdctl GPU container failed; falling back to containerd level")
+
+            # ── Level 3: containerd + nvidia-container-runtime ───────────────
+            containerd_ok, ct_ver = False, ""
+            if rt_name is None:
+                containerd_ok, ct_ver = self._is_present(ssh, "containerd")
+            if rt_name is None and containerd_ok:
+                gpu_op = self._gpu_operator_installed(ssh)
+                self.report_subtest(
+                    "container_runtime",
+                    gpu_op,
+                    f"containerd {ct_ver} with nvidia-container-runtime"
+                    if gpu_op
+                    else f"containerd {ct_ver} found but nvidia-container-runtime not installed",
+                )
+                if not gpu_op:
+                    self.set_failed("containerd present but nvidia-container-runtime not installed")
+                    ssh.close()
+                    return
+                # GPU operator presence is the proof of capability at this level.
+                # containerd + nvidia-container-runtime is sufficient proof of GPU capability.
+                self.report_subtest(
+                    "gpu_container",
+                    True,
+                    "GPU capability proven by containerd + nvidia-container-runtime "
+                    "(overlapping: K8sNvidiaSmiCheck / K8sGpuPodAccessCheck)",
+                )
+                rt_name = "containerd"
+                login_cmd_tmpl = None  # no direct login via ctr; NGC skipped at this level
+
+            # ── Levels 4/5: runc or crun + nvidia-container-runtime ──────────
+            for oci_name in ("runc", "crun") if rt_name is None else ():
+                if rt_name is not None:
+                    break
+                oci_ok, oci_ver = self._is_present(ssh, oci_name)
+                if not oci_ok:
+                    continue
+                gpu_op = self._gpu_operator_installed(ssh)
+                self.report_subtest(
+                    "container_runtime",
+                    gpu_op,
+                    f"{oci_name} {oci_ver} with nvidia-container-runtime"
+                    if gpu_op
+                    else f"{oci_name} {oci_ver} found but nvidia-container-runtime not installed",
+                )
+                if not gpu_op:
+                    self.set_failed(f"{oci_name} present but nvidia-container-runtime not installed")
+                    ssh.close()
+                    return
+                self.report_subtest(
+                    "gpu_container",
+                    True,
+                    f"GPU capability proven by {oci_name} + nvidia-container-runtime",
+                )
+                rt_name = oci_name
+                login_cmd_tmpl = None
+
+            if rt_name is None:
+                self.set_failed(
+                    "No GPU-capable container runtime found (tried: docker, nerdctl, containerd, runc, crun)"
+                )
                 ssh.close()
                 return
 
-            # Check NVIDIA container runtime
-            _, stdout, _ = run_ssh_command(
-                ssh,
-                "docker run --rm --gpus all nvcr.io/nvidia/cuda:13.0.0-base-ubuntu24.04 nvidia-smi 2>&1 || echo 'nvidia_docker_failed'",
-            )
-            nvidia_ok = "nvidia_docker_failed" not in stdout and "NVIDIA-SMI" in stdout
-            self.report_subtest(
-                "nvidia_docker",
-                nvidia_ok,
-                "NVIDIA Docker working" if nvidia_ok else f"NVIDIA Docker not configured: {stdout[:100]}",
-            )
-
-            # Check NGC login if key provided
-            if ngc_api_key:
+            # ── NGC registry login ────────────────────────────────────────────
+            if ngc_api_key and login_cmd_tmpl:
                 self.log.info("Testing NGC registry access...")
                 safe_key = ngc_api_key.replace("'", "'\\''")
-                _, stdout, _ = run_ssh_command(
-                    ssh, f"printf '%s' '{safe_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
+                login_cmd = login_cmd_tmpl.format(key=safe_key)
+                _, stdout, _ = run_ssh_command(ssh, login_cmd)
+                login_ok = "Login Succeeded" in stdout or "Succeeded" in stdout
+                self.report_subtest(
+                    "ngc_login",
+                    login_ok,
+                    "NGC login successful" if login_ok else f"NGC login failed: {stdout[:80]}",
                 )
-                login_ok = "Succeeded" in stdout
-                self.report_subtest("ngc_login", login_ok, "NGC login successful" if login_ok else "NGC login failed")
+                if not login_ok:
+                    self.set_failed("NGC registry login failed")
+                    ssh.close()
+                    return
             else:
-                self.report_subtest("ngc_login", True, "NGC_API_KEY not provided (skipped)")
+                reason = (
+                    "NGC_API_KEY not provided (skipped)"
+                    if not ngc_api_key
+                    else f"NGC login not applicable for {rt_name}"
+                )
+                self.report_subtest("ngc_login", True, reason)
 
             ssh.close()
-            self.set_passed("Container runtime check passed")
+            self.set_passed(f"GPU-capable container runtime check passed ({rt_name})")
 
         except Exception as e:
             self.set_failed(f"Container check failed: {e}")

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -787,10 +787,10 @@ class ShortLivedCredentialsCheck(BaseValidation):
 class LeastPrivilegePolicyCheck(BaseValidation):
     """Validate least-privilege policy dimensions are enforced (SEC04-01).
 
-    Verifies the provider probe exercised user-scoped, resource-scoped, and
-    network-scoped access policy constraints. The probe may emit a structured
-    top-level skip when it cannot provision the temporary identity needed for
-    the check.
+    Verifies the provider probe exercised user-scoped and resource-scoped
+    access policy constraints and that the allowed action succeeds. The probe
+    may emit a structured top-level skip when it cannot provision the
+    temporary identity needed for the check.
 
     Config:
         step_output: The step output to check
@@ -798,14 +798,12 @@ class LeastPrivilegePolicyCheck(BaseValidation):
     Step output:
         test_identity: Required non-empty identity used for the policy probe
         allowed_resource: Required non-empty resource identifier that should be allowed
-        allowed_source_cidr: Required non-empty source CIDR used for network-scope enforcement
         tests: dict with policy_dimensions_user_based,
                policy_dimensions_resource_based,
-               policy_dimensions_network_based,
                policy_dimensions_allowed_action_succeeds
     """
 
-    description: ClassVar[str] = "Check least-privilege access policies are user, resource, and network scoped"
+    description: ClassVar[str] = "Check least-privilege access policies are user and resource scoped"
     labels: ClassVar[tuple[str, ...]] = ("security", "iam")
 
     def run(self) -> None:
@@ -817,13 +815,12 @@ class LeastPrivilegePolicyCheck(BaseValidation):
         required = [
             "policy_dimensions_user_based",
             "policy_dimensions_resource_based",
-            "policy_dimensions_network_based",
             "policy_dimensions_allowed_action_succeeds",
         ]
         if not check_required_tests(self, required, "Least-privilege policy tests failed"):
             return
 
-        for field in ("test_identity", "allowed_resource", "allowed_source_cidr"):
+        for field in ("test_identity", "allowed_resource"):
             value = step_output.get(field)
             if not isinstance(value, str) or not value.strip():
                 self.set_failed(f"Least-privilege policy output missing non-empty '{field}'")

--- a/isvtest/tests/test_container_runtime_check.py
+++ b/isvtest/tests/test_container_runtime_check.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the broadened ContainerRuntimeCheck.
+
+Covers all five runtime detection levels:
+  Level 1: docker  + GPU container runs
+  Level 2: nerdctl + GPU container runs
+  Level 3: containerd + nvidia-container-runtime installed (GPU operator proves capability)
+  Level 4: runc    + nvidia-container-runtime installed
+  Level 5: crun    + nvidia-container-runtime installed
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from isvtest.validations.host import ContainerRuntimeCheck
+
+
+def _make_check(config: dict[str, Any] | None = None) -> ContainerRuntimeCheck:
+    """Return a ContainerRuntimeCheck instance with an empty or provided config."""
+    return ContainerRuntimeCheck(config=config or {})
+
+
+def _patched_run(
+    check: ContainerRuntimeCheck,
+    command_map: dict[str, str],
+    ngc_key: str = "",
+) -> ContainerRuntimeCheck:
+    """Run the check with command-aware mocked SSH responses.
+
+    Args:
+        check: The ContainerRuntimeCheck instance to run.
+        command_map: Maps command substrings to their mocked stdout responses.
+            The first key whose substring appears in the SSH command wins.
+            Use ``"__default__"`` as a catch-all for unmatched commands.
+        ngc_key: Optional NGC API key to inject into the check config.
+    """
+    cfg = dict(check.config)
+    cfg["ngc_api_key"] = ngc_key
+    check = ContainerRuntimeCheck(config=cfg)
+
+    def _fake_ssh(ssh: object, cmd: str) -> tuple[int, str, str]:
+        """Match the SSH command against command_map patterns; fall back to __default__."""
+        default = command_map.get("__default__", "")
+        for pattern, response in command_map.items():
+            if pattern != "__default__" and pattern in cmd:
+                return 0, response, ""
+        return 0, default, ""
+
+    with (
+        patch(
+            "isvtest.validations.host.get_ssh_config",
+            return_value={
+                "ssh_host": "10.0.0.1",
+                "ssh_user": "ubuntu",
+                "ssh_key_path": "/tmp/key.pem",
+            },
+        ),
+        patch("isvtest.validations.host.get_ssh_client", return_value=MagicMock()),
+        patch("isvtest.validations.host.run_ssh_command", side_effect=_fake_ssh),
+    ):
+        check.run()
+
+    return check
+
+
+# ---------------------------------------------------------------------------
+# Level 1 — Docker
+# ---------------------------------------------------------------------------
+
+
+class TestDockerLevel:
+    def test_passes_with_docker_and_gpu_container(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "Docker version 24.0.0",
+                "docker run": "NVIDIA-SMI 595 ...",
+            },
+        )
+        assert check.passed
+        assert "docker" in check.message
+
+    def test_docker_gpu_fails_falls_through_to_containerd(self) -> None:
+        """Docker GPU fails but containerd + GPU operator present → PASS at level 3."""
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "Docker version 24.0.0",
+                "docker run": "__gpu_run_failed__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "containerd 1.7.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "grep -rl": "/etc/containerd/config.toml",
+                "__default__": "__not_found__",
+            },
+        )
+        assert check.passed
+        assert "containerd" in check.message
+
+    def test_docker_ngc_login_passes(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "Docker version 24.0.0",
+                "docker run": "NVIDIA-SMI 595 ...",
+                "docker login": "Login Succeeded",
+            },
+            ngc_key="test-ngc-token",
+        )
+        assert check.passed
+
+    def test_docker_ngc_login_failure_fails_check(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "Docker version 24.0.0",
+                "docker run": "NVIDIA-SMI 595 ...",
+                "docker login": "unauthorized: bad credentials",
+            },
+            ngc_key="test-bad-token",
+        )
+        assert not check.passed
+        assert "NGC" in check.message
+
+    def test_fails_when_no_runtime_found(self) -> None:
+        check = _patched_run(_make_check(), {"__default__": "__not_found__"})
+        assert not check.passed
+        assert "No GPU-capable container runtime found" in check.message
+
+
+# ---------------------------------------------------------------------------
+# Level 2 — nerdctl
+# ---------------------------------------------------------------------------
+
+
+class TestNerdctlLevel:
+    def test_passes_with_nerdctl_when_docker_absent(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "nerdctl version 2.2.2",
+                "nerdctl run": "NVIDIA-SMI 595 ...",
+            },
+        )
+        assert check.passed
+        assert "nerdctl" in check.message
+
+    def test_nerdctl_gpu_fails_falls_through_to_containerd(self) -> None:
+        """nerdctl GPU fails (k8s namespace only) → falls through to containerd level."""
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "nerdctl version 2.2.2",
+                "nerdctl run": "__gpu_run_failed__",
+                "containerd --version": "containerd 1.7.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "grep -rl": "/etc/containerd/config.toml",
+                "__default__": "__not_found__",
+            },
+        )
+        assert check.passed
+        assert "containerd" in check.message
+
+    def test_nerdctl_ngc_login_passes(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "nerdctl version 2.2.2",
+                "nerdctl run": "NVIDIA-SMI 595 ...",
+                "nerdctl login": "Login Succeeded",
+            },
+            ngc_key="test-ngc-token",
+        )
+        assert check.passed
+
+    def test_nerdctl_ngc_login_failure_fails_check(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "nerdctl version 2.2.2",
+                "nerdctl run": "NVIDIA-SMI 595 ...",
+                "nerdctl login": "unauthorized: bad credentials",
+            },
+            ngc_key="test-bad-token",
+        )
+        assert not check.passed
+        assert "NGC" in check.message
+
+
+# ---------------------------------------------------------------------------
+# Level 3 — containerd + nvidia-container-runtime
+# ---------------------------------------------------------------------------
+
+
+class TestContainerdLevel:
+    """Docker absent, containerd + GPU operator present — standard k8s node scenario."""
+
+    def test_passes_with_containerd_and_gpu_operator(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "containerd 1.7.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "grep -rl": "/etc/containerd/config.toml",
+                "__default__": "__not_found__",
+            },
+        )
+        assert check.passed
+        assert "containerd" in check.message
+
+    def test_fails_when_containerd_present_but_no_gpu_operator_binary(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "containerd 1.7.0",
+                "__default__": "__not_found__",
+            },
+        )
+        assert not check.passed
+        assert "nvidia-container-runtime not installed" in check.message
+
+    def test_fails_when_binary_present_but_not_configured(self) -> None:
+        """Binary exists but containerd config/plugin has no nvidia entry → fail."""
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "containerd 1.7.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "__default__": "__not_configured__",
+            },
+        )
+        assert not check.passed
+
+    def test_ngc_login_skipped_for_containerd_level(self) -> None:
+        """NGC login is not applicable at the containerd level (no ctr login cmd)."""
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "containerd 1.7.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "grep -rl": "/etc/containerd/config.toml",
+                "__default__": "__not_found__",
+            },
+            ngc_key="test-ngc-token",
+        )
+        assert check.passed
+
+
+# ---------------------------------------------------------------------------
+# Level 4 — runc + nvidia-container-runtime
+# ---------------------------------------------------------------------------
+
+
+class TestRuncLevel:
+    def test_passes_with_runc_and_gpu_operator(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "__not_found__",
+                "runc --version": "runc version 1.1.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "grep -rl": "/etc/containerd/config.toml",
+                "__default__": "__not_found__",
+            },
+        )
+        assert check.passed
+        assert "runc" in check.message
+
+    def test_fails_when_runc_present_but_no_gpu_operator(self) -> None:
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "__not_found__",
+                "runc --version": "runc version 1.1.0",
+                "__default__": "__not_found__",
+            },
+        )
+        assert not check.passed
+
+    def test_runc_absent_falls_through_to_crun(self) -> None:
+        """runc absent → tries crun → PASS at level 5."""
+        check = _patched_run(
+            _make_check(),
+            {
+                "docker --version": "__not_found__",
+                "nerdctl --version": "__not_found__",
+                "containerd --version": "__not_found__",
+                "runc --version": "__not_found__",
+                "crun --version": "crun version 1.0",
+                "nvidia-container-runtime --version": "NVIDIA Container Runtime 1.19.0",
+                "grep -rl": "/etc/containerd/config.toml",
+                "__default__": "__not_found__",
+            },
+        )
+        assert check.passed
+        assert "crun" in check.message
+
+
+# ---------------------------------------------------------------------------
+# No runtime found
+# ---------------------------------------------------------------------------
+
+
+class TestNoRuntime:
+    def test_fails_when_nothing_found(self) -> None:
+        check = _patched_run(_make_check(), {"__default__": "__not_found__"})
+        assert not check.passed
+        assert "No GPU-capable container runtime found" in check.message
+
+    def test_fails_when_host_config_missing(self) -> None:
+        check = _make_check()
+        with patch(
+            "isvtest.validations.host.get_ssh_config",
+            return_value={"ssh_host": "", "ssh_user": "ubuntu", "ssh_key_path": ""},
+        ):
+            check.run()
+        assert not check.passed
+        assert "Missing host" in check.message

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -31,6 +31,7 @@ from isvtest.validations.security import (
     CustomerManagedKeyCheck,
     InsecureProtocolsCheck,
     KmsEncryptionOptionCheck,
+    LeastPrivilegePolicyCheck,
     MfaEnforcedCheck,
     OidcUserAuthCheck,
     ShortLivedCredentialsCheck,
@@ -854,6 +855,74 @@ def test_short_lived_credentials_check_skips_when_step_marks_skipped() -> None:
 
     with pytest.raises(pytest.skip.Exception, match="GetSessionToken not available"):
         ShortLivedCredentialsCheck(config={"step_output": step_output}).execute()
+
+
+LEAST_PRIVILEGE_REQUIRED_TESTS = {
+    "policy_dimensions_user_based": {"passed": True},
+    "policy_dimensions_resource_based": {"passed": True},
+    "policy_dimensions_allowed_action_succeeds": {"passed": True},
+}
+
+
+def _least_privilege_step_output(**overrides: Any) -> dict[str, Any]:
+    """Return valid SEC04-01 output without the removed source-CIDR evidence."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "security",
+        "test_name": "least_privilege_test",
+        "test_identity": "sec04-test-principal",
+        "allowed_resource": "sec04-test-resource",
+        "tests": deepcopy(LEAST_PRIVILEGE_REQUIRED_TESTS),
+    }
+    output.update(overrides)
+    return output
+
+
+class TestLeastPrivilegePolicyCheck:
+    """Tests for SEC04-01 least-privilege policy validation."""
+
+    def test_passes_without_source_cidr_dimension(self) -> None:
+        """Source-IP/CIDR is not part of the originating SEC04-01 requirement."""
+        result = LeastPrivilegePolicyCheck(config={"step_output": _least_privilege_step_output()}).execute()
+
+        assert result["passed"] is True
+
+    def test_ignores_legacy_source_cidr_evidence(self) -> None:
+        """Legacy provider output cannot reintroduce the removed CIDR subtest."""
+        tests = deepcopy(LEAST_PRIVILEGE_REQUIRED_TESTS)
+        tests["policy_dimensions_network_based"] = {
+            "passed": False,
+            "error": "source-IP identity binding is unavailable",
+        }
+        result = LeastPrivilegePolicyCheck(
+            config={
+                "step_output": _least_privilege_step_output(
+                    allowed_source_cidr="",
+                    tests=tests,
+                )
+            }
+        ).execute()
+
+        assert result["passed"] is True
+
+    def test_fails_when_required_dimension_is_missing(self) -> None:
+        """User, resource, and allowed-action evidence remain mandatory."""
+        tests = deepcopy(LEAST_PRIVILEGE_REQUIRED_TESTS)
+        tests.pop("policy_dimensions_resource_based")
+        result = LeastPrivilegePolicyCheck(config={"step_output": _least_privilege_step_output(tests=tests)}).execute()
+
+        assert result["passed"] is False
+        assert "policy_dimensions_resource_based" in result["error"]
+
+    @pytest.mark.parametrize("field", ["test_identity", "allowed_resource"])
+    def test_fails_when_required_identity_or_resource_is_empty(self, field: str) -> None:
+        """The remaining identity and resource evidence must be non-empty."""
+        result = LeastPrivilegePolicyCheck(
+            config={"step_output": _least_privilege_step_output(**{field: ""})}
+        ).execute()
+
+        assert result["passed"] is False
+        assert field in result["error"]
 
 
 TENANT_ISOLATION_REQUIRED_TESTS = {

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -271,7 +271,10 @@ def refresh_released_tests(new_version: str) -> None:
 def check(expected: str) -> None:
     """Verify all pyproject.toml files already have the expected version."""
     if not SEMVER_RE.match(expected):
-        print(f"error: '{expected}' is not valid semver (expected X.Y.Z)", file=sys.stderr)
+        print(
+            f"error: '{expected}' is not valid semver (expected X.Y.Z, optionally with a prerelease such as X.Y.Z-rc1)",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     ok = True

--- a/scripts/changelog-prompt.md
+++ b/scripts/changelog-prompt.md
@@ -18,15 +18,23 @@ NVIDIA ISV NCP Validation Suite repository.
 ## Goal
 
 For every release version that is not yet documented in `CHANGELOG.md`,
-add a complete `## [X.Y.Z] - YYYY-MM-DD` section, in descending version
-order, immediately above the first existing `## [X.Y.Z]` heading (or at
-the end of the file if no version sections exist yet). A version is
-considered a release if either:
+add a complete `## [X.Y.Z] - YYYY-MM-DD` section. Sections are kept in
+**descending semver order**, so insert each one immediately above the
+first existing `## [X.Y.Z]` heading whose version is lower than it (or at
+the end of the file if there is no such heading). For a release cut from
+`main` this is the top of the list; for an out-of-band patch release it
+usually is not — a `0.7.3` section belongs below `0.10.0`, not above it.
+A version is considered a release if either:
 
 1. There is a git tag of the form `vX.Y.Z`, OR
-2. The `version` field of the root `pyproject.toml` is newer than every
-   git tag — this is a **pending release** that has been bumped but is
-   not yet tagged (typically run as part of `make bump-*`).
+2. The `version` field of the root `pyproject.toml` is newer than the
+   **nearest ancestor tag** (`git describe --tags --abbrev=0 --match "v*"`)
+   — this is a **pending release** that has been bumped but is not yet
+   tagged (typically run as part of `make bump-*`). Compare against the
+   ancestor tag rather than against every tag in the repo: on a
+   `releases/X.Y.x` maintenance branch the pending `0.7.3` is older than
+   the newest tag on `main`, and comparing globally would miss it
+   entirely. See CONTRIBUTING.md, "Out-of-Band Releases".
 
 Do not modify the file header, the "How to update this file" block, or
 any version section that already has content.
@@ -36,15 +44,21 @@ any version section that already has content.
 1. Read `CHANGELOG.md` and list every `## [X.Y.Z]` heading already present.
 2. Run `git tag --sort=-v:refname` to list all release tags. Any tag of the
    form `vX.Y.Z` whose version is **not** already a heading in the file is
-   missing. Also read the root `pyproject.toml` — if its `version = "X.Y.Z"`
-   is newer than every git tag and not already a heading, treat it as a
-   pending release.
+   missing. Also run `git describe --tags --abbrev=0 --match "v*"` to get the
+   nearest ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
+   `version = "X.Y.Z"` is newer than that ancestor tag and not already a
+   heading, treat it as a pending release.
 3. For each missing version, in chronological order (oldest first):
-   - For a **tagged release**, the commit range is `<prev_tag>..<tag>`
-     (`git log --pretty='%H %s' <prev_tag>..<tag>`).
-   - For a **pending release**, the commit range is `<latest_tag>..HEAD`
-     (`git log --pretty='%H %s' <latest_tag>..HEAD`). Skip the bump
-     commit itself (`chore: update package versions to X.Y.Z`).
+   - For a **tagged release**, the commit range is `<prev_tag>..<tag>`, where
+     `<prev_tag>` is the tag the release was cut from — use
+     `git describe --tags --abbrev=0 --match "v*" <tag>^` rather than
+     "the previous tag by version number", so a patch cut from a maintenance
+     branch is diffed against its own base and not against an unrelated tag
+     on `main` (`git log --pretty='%H %s' <prev_tag>..<tag>`).
+   - For a **pending release**, the commit range is `<ancestor_tag>..HEAD`
+     (`git log --pretty='%H %s' <ancestor_tag>..HEAD`), using the nearest
+     ancestor tag from step 2. Skip the bump commit itself
+     (`chore: update package versions to X.Y.Z`).
    - Each commit subject ends with the PR number in parentheses, e.g.
      `(#425)`. Fetch the PR for richer context from
      `https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/<N>` (use the


### PR DESCRIPTION
Backports to the `0.7.x` maintenance line, cut from `v0.7.2`.

| commit | from |
|---|---|
| out-of-band release process + hardened workflows | #582 |
| repin dsx GitHub Actions after org transfer | #576 |
| remove unsupported SEC04 source-CIDR check | #577 |
| broaden `ContainerRuntimeCheck` to any GPU-capable runtime | #580 |

The workflow commits come first so this branch runs CI on pushes and tags through the hardened `tag.yml`.

`#577` needed conflict resolution: kept the branch's `labels` ClassVar (0.7.x still reads labels off the class) and its check list, applied only the SEC04 change to the branch's own test file, and regenerated `docs/test-plan.adoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GPU container validation across Docker, nerdctl, containerd, runc, and crun runtimes.
  * Added clearer reporting for runtime detection, GPU support, and registry login outcomes.
  * Strengthened release and tag validation, including semantic versions and required pipeline checks.

* **Bug Fixes**
  * Improved handling of runtime fallbacks and credential propagation.
  * Corrected version validation messaging to allow prerelease suffixes.

* **Documentation**
  * Added maintenance-branch and patch-release guidance.
  * Updated least-privilege security documentation to focus on identity- and resource-based policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->