### PR TITLE
chore: update package versions to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ Workflow:
 > attached to a milestone. The file you are reading now is the canonical
 > per-tag changelog.
 
+## [0.7.3] - 2026-08-16
+
+### Fixed
+
+- **GPU container runtime compatibility** ([#583](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/583))
+  Updates `ContainerRuntimeCheck` to recognize Docker, nerdctl, containerd, runc, and crun when GPU capability is configured, preventing valid non-Docker Kubernetes and OCI hosts from failing the runtime check.
+- **SEC04-01 least-privilege scope** ([#583](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/583))
+  Removes source CIDR as required evidence from `LeastPrivilegePolicyCheck`, aligning SEC04-01 with its user- and resource-scoping requirement and preventing unsupported network conditions from failing the validation.
+
+### Internal
+
+- Add maintenance-branch release guidance, harden CI and tagging workflows, and repin DSX security actions after their repository transfer ([#583](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/583)).
+
 ## [0.7.2] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,14 +34,15 @@ Workflow:
 
 ### Fixed
 
-- **GPU container runtime compatibility** ([#583](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/583))
+- **GPU container runtime compatibility** ([#580](https://github.com/NVIDIA/ai-cloud-validation/pull/580))
   Updates `ContainerRuntimeCheck` to recognize Docker, nerdctl, containerd, runc, and crun when GPU capability is configured, preventing valid non-Docker Kubernetes and OCI hosts from failing the runtime check.
-- **SEC04-01 least-privilege scope** ([#583](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/583))
+- **SEC04-01 least-privilege scope** ([#577](https://github.com/NVIDIA/ai-cloud-validation/pull/577))
   Removes source CIDR as required evidence from `LeastPrivilegePolicyCheck`, aligning SEC04-01 with its user- and resource-scoping requirement and preventing unsupported network conditions from failing the validation.
 
 ### Internal
 
-- Add maintenance-branch release guidance, harden CI and tagging workflows, and repin DSX security actions after their repository transfer ([#583](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/583)).
+- Add maintenance-branch release guidance and harden the CI and tagging workflows ([#582](https://github.com/NVIDIA/ai-cloud-validation/pull/582)).
+- Repin DSX security actions after their repository transfer ([#576](https://github.com/NVIDIA/ai-cloud-validation/pull/576)).
 
 ## [0.7.2] - 2026-06-03
 

--- a/isvctl/pyproject.toml
+++ b/isvctl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "isvctl"
-version = "0.7.2"
+version = "0.7.3"
 description = "ISV Lab controller for cluster lifecycle orchestration"
 readme = "README.md"
 license = "Apache-2.0"

--- a/isvreporter/pyproject.toml
+++ b/isvreporter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "isvreporter"
-version = "0.7.2"
+version = "0.7.3"
 description = "ISV Lab test results reporter - report validation test results to ISV Lab Service"
 readme = "README.md"
 license = "Apache-2.0"

--- a/isvtest/pyproject.toml
+++ b/isvtest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "isvtest"
-version = "0.7.2"
+version = "0.7.3"
 description = "NV ISV Lab tests"
 readme = "README.md"
 license = "Apache-2.0"

--- a/isvtest/src/isvtest/released_tests.json
+++ b/isvtest/src/isvtest/released_tests.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.2",
+  "version": "0.7.3",
   "tests": [
     "AccessKeyAuthenticatedCheck",
     "AccessKeyCreatedCheck",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "isv-ncp-validation-suite"
-version = "0.7.2"
+version = "0.7.3"
 description = "NVIDIA ISV NCP Validation Suite"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/changelog-prompt.md
+++ b/scripts/changelog-prompt.md
@@ -23,9 +23,9 @@ add a complete `## [X.Y.Z] - YYYY-MM-DD` section. Sections are kept in
 first existing `## [X.Y.Z]` heading whose version is lower than it (or at
 the end of the file if there is no such heading). For a release cut from
 `main` this is the top of the list. For an out-of-band patch release it
-depends on the file: on the maintenance branch itself `0.7.3` is the
-newest section, but once that section is forward-ported to `main` it
-belongs below `0.10.0`, not above it.
+depends on the file: on the maintenance branch itself the new patch is
+the newest section, but once that section is forward-ported to `main` it
+belongs below the newer lines already documented there, not above them.
 A version is considered a release if either:
 
 1. There is a git tag of the form `vX.Y.Z` **that is reachable from `HEAD`**, OR
@@ -34,8 +34,8 @@ A version is considered a release if either:
    — this is a **pending release** that has been bumped but is not yet
    tagged (typically run as part of `make bump-*`). Compare against the
    ancestor tag rather than against every tag in the repo: on a
-   `releases/X.Y.x` maintenance branch the pending `0.7.3` is older than
-   the newest tag on `main`, and comparing globally would miss it
+   `releases/X.Y.x` maintenance branch the pending patch version is older
+   than the newest tag on `main`, and comparing globally would miss it
    entirely. See CONTRIBUTING.md, "Out-of-Band Releases".
 
 Do not modify the file header, the "How to update this file" block, or
@@ -50,8 +50,8 @@ any version section that already has content.
 
    Use `--merged HEAD`, never a bare `git tag`. A bare listing returns every
    tag in the repository, including releases cut from other lines. On a
-   `releases/0.7.x` maintenance branch that would pull in `v0.8.0`, `v0.9.0`
-   and `v0.10.0` — none of which are ancestors of this branch — and invent
+   `releases/X.Y.x` maintenance branch that would pull in the tags of every
+   newer line — none of which are ancestors of this branch — and invent
    sections for work this branch does not contain. If a version is absent
    from `git tag --merged HEAD`, it is not a release of this branch: skip it,
    even when it is missing from `CHANGELOG.md` and looks like a gap.
@@ -73,7 +73,7 @@ any version section that already has content.
      (`chore: update package versions to X.Y.Z`).
    - Each commit subject ends with the PR number in parentheses, e.g.
      `(#425)`. Fetch the PR for richer context from
-     `https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/<N>` (use the
+     `https://github.com/NVIDIA/ai-cloud-validation/pull/<N>` (use the
      `gh pr view <N>` CLI if available, otherwise an HTTP fetch). If the PR
      is inaccessible, fall back to reading the commit itself with
      `git show <hash>`.
@@ -108,7 +108,7 @@ description (a second sentence only if genuinely needed) indented two
 spaces under the title:
 
 ```md
-- **Concise title summarizing the change** ([#N](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/N))
+- **Concise title summarizing the change** ([#N](https://github.com/NVIDIA/ai-cloud-validation/pull/N))
   One sentence explaining what changed and why (add a second only if
   genuinely needed). Describe the user-visible behavior — not the
   implementation — and reference the relevant validation ID, CLI flag,
@@ -119,7 +119,7 @@ For **Internal**, use a terse one-line form with a linked PR ref (no
 bold title, no description paragraph):
 
 ```md
-- Brief description ([#N](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/N)).
+- Brief description ([#N](https://github.com/NVIDIA/ai-cloud-validation/pull/N)).
 ```
 
 ### Roll-up entries
@@ -129,7 +129,7 @@ refactor or a multi-PR feature series), collapse them into a single
 bullet with all PR refs inline and one shared description:
 
 ```md
-- **Common theme across the series** ([#A](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/A), [#B](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/B), [#C](https://github.com/NVIDIA/ISV-NCP-Validation-Suite/pull/C))
+- **Common theme across the series** ([#A](https://github.com/NVIDIA/ai-cloud-validation/pull/A), [#B](https://github.com/NVIDIA/ai-cloud-validation/pull/B), [#C](https://github.com/NVIDIA/ai-cloud-validation/pull/C))
   One description that covers the whole series. Prefer this over three
   near-identical separate bullets.
 ```

--- a/scripts/changelog-prompt.md
+++ b/scripts/changelog-prompt.md
@@ -22,11 +22,13 @@ add a complete `## [X.Y.Z] - YYYY-MM-DD` section. Sections are kept in
 **descending semver order**, so insert each one immediately above the
 first existing `## [X.Y.Z]` heading whose version is lower than it (or at
 the end of the file if there is no such heading). For a release cut from
-`main` this is the top of the list; for an out-of-band patch release it
-usually is not — a `0.7.3` section belongs below `0.10.0`, not above it.
+`main` this is the top of the list. For an out-of-band patch release it
+depends on the file: on the maintenance branch itself `0.7.3` is the
+newest section, but once that section is forward-ported to `main` it
+belongs below `0.10.0`, not above it.
 A version is considered a release if either:
 
-1. There is a git tag of the form `vX.Y.Z`, OR
+1. There is a git tag of the form `vX.Y.Z` **that is reachable from `HEAD`**, OR
 2. The `version` field of the root `pyproject.toml` is newer than the
    **nearest ancestor tag** (`git describe --tags --abbrev=0 --match "v*"`)
    — this is a **pending release** that has been bumped but is not yet
@@ -42,10 +44,20 @@ any version section that already has content.
 ## Steps
 
 1. Read `CHANGELOG.md` and list every `## [X.Y.Z]` heading already present.
-2. Run `git tag --sort=-v:refname` to list all release tags. Any tag of the
-   form `vX.Y.Z` whose version is **not** already a heading in the file is
-   missing. Also run `git describe --tags --abbrev=0 --match "v*"` to get the
-   nearest ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
+2. Run `git tag --merged HEAD --sort=-v:refname` to list the release tags
+   **reachable from the current branch**. Any tag of the form `vX.Y.Z` whose
+   version is **not** already a heading in the file is missing.
+
+   Use `--merged HEAD`, never a bare `git tag`. A bare listing returns every
+   tag in the repository, including releases cut from other lines. On a
+   `releases/0.7.x` maintenance branch that would pull in `v0.8.0`, `v0.9.0`
+   and `v0.10.0` — none of which are ancestors of this branch — and invent
+   sections for work this branch does not contain. If a version is absent
+   from `git tag --merged HEAD`, it is not a release of this branch: skip it,
+   even when it is missing from `CHANGELOG.md` and looks like a gap.
+
+   Also run `git describe --tags --abbrev=0 --match "v*"` to get the nearest
+   ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
    `version = "X.Y.Z"` is newer than that ancestor tag and not already a
    heading, treat it as a pending release.
 3. For each missing version, in chronological order (oldest first):

--- a/uv.lock
+++ b/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "isv-ncp-validation-suite"
-version = "0.7.2"
+version = "0.7.3"
 source = { virtual = "." }
 dependencies = [
     { name = "isvctl" },
@@ -600,7 +600,7 @@ test = [
 
 [[package]]
 name = "isvctl"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "isvctl" }
 dependencies = [
     { name = "isvreporter" },
@@ -623,7 +623,7 @@ requires-dist = [
 
 [[package]]
 name = "isvreporter"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "isvreporter" }
 dependencies = [
     { name = "pyyaml" },
@@ -638,7 +638,7 @@ requires-dist = [
 
 [[package]]
 name = "isvtest"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "isvtest" }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Version bump for the `0.7.x` maintenance line, cut from `v0.7.2`.

- All packages and `released_tests.json` to `0.7.3`. The released test set is unchanged — only the manifest version moves.
- `CHANGELOG.md` section for `0.7.3`.
- Scopes `changelog-fill` tag discovery to `git tag --merged HEAD`. Run on a maintenance branch it previously treated `v0.8.0`/`v0.9.0`/`v0.10.0` as undocumented releases and wrote sections for work this branch does not contain.

After merge, `Create version tag` can be dispatched against `releases/0.7.x` once CI is green on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU container runtime detection across Docker, nerdctl, containerd, runc, and crun.
  * Removed source CIDR evidence from the SEC04-01 assessment.

* **Release**
  * Released version 0.7.3 across the project’s tools and test suite.
  * Updated release documentation and test version metadata.

* **Documentation**
  * Clarified release detection, branch ordering, tag discovery, and repository links in release guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->