### PR TITLE
fix(changelog): scope tag discovery to the current branch

### DIFF
--- a/scripts/changelog-prompt.md
+++ b/scripts/changelog-prompt.md
@@ -22,18 +22,20 @@ add a complete `## [X.Y.Z] - YYYY-MM-DD` section. Sections are kept in
 **descending semver order**, so insert each one immediately above the
 first existing `## [X.Y.Z]` heading whose version is lower than it (or at
 the end of the file if there is no such heading). For a release cut from
-`main` this is the top of the list; for an out-of-band patch release it
-usually is not — a `0.7.3` section belongs below `0.10.0`, not above it.
+`main` this is the top of the list. For an out-of-band patch release it
+depends on the file: on the maintenance branch itself the new patch is
+the newest section, but once that section is forward-ported to `main` it
+belongs below the newer lines already documented there, not above them.
 A version is considered a release if either:
 
-1. There is a git tag of the form `vX.Y.Z`, OR
+1. There is a git tag of the form `vX.Y.Z` **that is reachable from `HEAD`**, OR
 2. The `version` field of the root `pyproject.toml` is newer than the
    **nearest ancestor tag** (`git describe --tags --abbrev=0 --match "v*"`)
    — this is a **pending release** that has been bumped but is not yet
    tagged (typically run as part of `make bump-*`). Compare against the
    ancestor tag rather than against every tag in the repo: on a
-   `releases/X.Y.x` maintenance branch the pending `0.7.3` is older than
-   the newest tag on `main`, and comparing globally would miss it
+   `releases/X.Y.x` maintenance branch the pending patch version is older
+   than the newest tag on `main`, and comparing globally would miss it
    entirely. See CONTRIBUTING.md, "Out-of-Band Releases".
 
 Do not modify the file header, the "How to update this file" block, or
@@ -42,10 +44,20 @@ any version section that already has content.
 ## Steps
 
 1. Read `CHANGELOG.md` and list every `## [X.Y.Z]` heading already present.
-2. Run `git tag --sort=-v:refname` to list all release tags. Any tag of the
-   form `vX.Y.Z` whose version is **not** already a heading in the file is
-   missing. Also run `git describe --tags --abbrev=0 --match "v*"` to get the
-   nearest ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
+2. Run `git tag --merged HEAD --sort=-v:refname` to list the release tags
+   **reachable from the current branch**. Any tag of the form `vX.Y.Z` whose
+   version is **not** already a heading in the file is missing.
+
+   Use `--merged HEAD`, never a bare `git tag`. A bare listing returns every
+   tag in the repository, including releases cut from other lines. On a
+   `releases/X.Y.x` maintenance branch that would pull in the tags of every
+   newer line — none of which are ancestors of this branch — and invent
+   sections for work this branch does not contain. If a version is absent
+   from `git tag --merged HEAD`, it is not a release of this branch: skip it,
+   even when it is missing from `CHANGELOG.md` and looks like a gap.
+
+   Also run `git describe --tags --abbrev=0 --match "v*"` to get the nearest
+   ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
    `version = "X.Y.Z"` is newer than that ancestor tag and not already a
    heading, treat it as a pending release.
 3. For each missing version, in chronological order (oldest first):

--- a/scripts/changelog-prompt.md
+++ b/scripts/changelog-prompt.md
@@ -30,7 +30,7 @@ A version is considered a release if either:
 
 1. There is a git tag of the form `vX.Y.Z` **that is reachable from `HEAD`**, OR
 2. The `version` field of the root `pyproject.toml` is newer than the
-   **nearest ancestor tag** (`git describe --tags --abbrev=0 --match "v*"`)
+   **nearest ancestor tag** (`git describe --tags --abbrev=0 --match "v*" --exclude "*-rc*"`)
    — this is a **pending release** that has been bumped but is not yet
    tagged (typically run as part of `make bump-*`). Compare against the
    ancestor tag rather than against every tag in the repo: on a
@@ -56,17 +56,22 @@ any version section that already has content.
    from `git tag --merged HEAD`, it is not a release of this branch: skip it,
    even when it is missing from `CHANGELOG.md` and looks like a gap.
 
-   Also run `git describe --tags --abbrev=0 --match "v*"` to get the nearest
-   ancestor tag of `HEAD`, and read the root `pyproject.toml` — if its
-   `version = "X.Y.Z"` is newer than that ancestor tag and not already a
-   heading, treat it as a pending release.
+   Also run `git describe --tags --abbrev=0 --match "v*" --exclude "*-rc*"`
+   to get the nearest ancestor tag of `HEAD`, and read the root
+   `pyproject.toml` — if its `version = "X.Y.Z"` is newer than that ancestor
+   tag and not already a heading, treat it as a pending release.
+
+   `--exclude "*-rc*"` matters because release candidates deliberately get no
+   changelog section. If an ancestor lookup returned `vX.Y.Z-rcN`, the range
+   would start at the candidate and the commits between the previous final
+   release and that candidate would be documented nowhere.
 3. For each missing version, in chronological order (oldest first):
    - For a **tagged release**, the commit range is `<prev_tag>..<tag>`, where
      `<prev_tag>` is the tag the release was cut from — use
-     `git describe --tags --abbrev=0 --match "v*" <tag>^` rather than
-     "the previous tag by version number", so a patch cut from a maintenance
-     branch is diffed against its own base and not against an unrelated tag
-     on `main` (`git log --pretty='%H %s' <prev_tag>..<tag>`).
+     `git describe --tags --abbrev=0 --match "v*" --exclude "*-rc*" <tag>^`
+     rather than "the previous tag by version number", so a patch cut from a
+     maintenance branch is diffed against its own base and not against an
+     unrelated tag on `main` (`git log --pretty='%H %s' <prev_tag>..<tag>`).
    - For a **pending release**, the commit range is `<ancestor_tag>..HEAD`
      (`git log --pretty='%H %s' <ancestor_tag>..HEAD`), using the nearest
      ancestor tag from step 2. Skip the bump commit itself


### PR DESCRIPTION
`changelog-fill` listed tags with a bare `git tag`, which returns every tag in the repository. Run on a maintenance branch it treated the tags of every newer line as undocumented releases and wrote sections for work that branch does not contain — observed while cutting `v0.7.3`, where it invented `0.8.0`, `0.9.0` and `0.10.0` sections.

Uses `git tag --merged HEAD` instead, and says explicitly that a version absent from that list must be skipped even though it looks like a gap in `CHANGELOG.md`.

Inert on `main`, where every tag is reachable. It matters only on maintenance branches, which inherit this file when they are cut.

Also drops the hardcoded versions from the ordering rules, per review on #585.

Ported from `releases/0.7.x`, where it was fixed to unblock `v0.7.3`. Prompt file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog guidance to include only release tags reachable from the current branch.
  * Excluded release candidates when identifying ancestor releases.
  * Clarified branch-specific release ordering and pending-release comparisons.
  * Updated commit-range guidance to use the nearest non-release-candidate ancestor and skip unrelated branch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->