### PR TITLE
test(breakfix): require retirement notice evidence (BFX02-02)

### DIFF
--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_retirement_notices.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_retirement_notices.py
@@ -27,11 +27,13 @@ def main() -> int:
         notices_queryable=True,
         notices=[
             {
-                "machine_id": "demo-machine-001",
-                "rack_id": "demo-rack-001",
-                "status": "scheduled",
-                "message": "End-of-life retirement",
-                "retire_after": "2027-01-15T00:00:00Z",
+                "target_type": "machine",
+                "target_id": "demo-machine-001",
+                "notice_type": "machine-retirement",
+                "origin_kind": "provider",
+                "origin": "provider.breakfix-api",
+                "notice_id": "demo-retirement-001",
+                "not_before": "2027-01-15T00:00:00Z",
             }
         ],
     )

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -261,7 +261,7 @@ its plan item is not platform-scoped.
 | `query_topology` | test | `providers/nico/scripts/topology/query_topology.py` | `hosts_checked`, `hosts[].{host_id,failure_domain}` |
 | `query_serial_numbers` | test | `providers/nico/scripts/hardware_inventory/query_serial_numbers.py` | `machines_checked`, `machines[].components.{chassis,baseboard,cpu,gpu,nic}.{present,identifiers}` (BFX03-01) |
 | `query_maintenance_events` | test | `providers/nico/scripts/breakfix/query_maintenance_events.py` | `events_queryable`, `events[].{machine_id,status,message}` (BFX02-01) |
-| `query_retirement_notices` | test | `providers/my-isv/scripts/breakfix/query_retirement_notices.py` | `notices_queryable`, `notices` (BFX02-02) |
+| `query_retirement_notices` | test | `providers/my-isv/scripts/breakfix/query_retirement_notices.py` | `notices_queryable`, `notices[].{target_type,target_id,notice_type,origin_kind,origin,not_before}` (BFX02-02) |
 | `query_repair_history` | test | `providers/nico/scripts/breakfix/query_repair_history.py` | `history_queryable`, `records[].{machine_id,entries}` -- a record needs non-empty `entries` to count (BFX02-03) |
 | `query_switch_firmware` | test | `providers/my-isv/scripts/breakfix/query_switch_firmware.py` | `trays[].{tray_id,firmware_version}` (BFX03-02) |
 | `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,kernel_log_available}` (BFX03-03) |

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -30,6 +30,7 @@ passes, and the requirement stays visibly unproven.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, ClassVar
 
 import pytest
@@ -128,7 +129,9 @@ class RetirementNoticesCheck(_QueryableRecordsCheck):
     """Validate retirement notices for a node/rack are queryable (BFX02-02).
 
     Step output:
-        success, notices_queryable: bool, notices: list[dict]
+        success, notices_queryable: bool,
+        notices: list[{target_type, target_id, notice_type, origin_kind,
+                       origin, not_before}]
     """
 
     description: ClassVar[str] = "Query retirement notices for a node or rack"
@@ -139,6 +142,36 @@ class RetirementNoticesCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "retirement notices"
     api_label: ClassVar[str] = "Retirement notice"
     record_noun: ClassVar[str] = "notice"
+
+    def _is_evidence(self, record: Any) -> bool:
+        """Require an authoritative retirement notice with target and time evidence."""
+        if not isinstance(record, dict):
+            return False
+        if record.get("origin_kind") != "provider":
+            return False
+        if _record_label(record, "origin", "provider", "source") == "unknown":
+            return False
+        if record.get("target_type") not in {"instance", "machine", "node", "rack"}:
+            return False
+        if _record_label(record, "target_id", "machine_id", "node_id", "rack_id") == "unknown":
+            return False
+        if record.get("notice_type") not in {
+            "retirement",
+            "instance-retirement",
+            "machine-retirement",
+            "node-retirement",
+            "rack-retirement",
+        }:
+            return False
+
+        timestamp = _record_label(record, "not_before", "scheduled_at", "retire_after", "deadline")
+        if timestamp == "unknown":
+            return False
+        try:
+            parsed_timestamp = datetime.fromisoformat(timestamp)
+        except ValueError:
+            return False
+        return parsed_timestamp.tzinfo is not None
 
 
 class RepairHistoryCheck(_QueryableRecordsCheck):

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -36,7 +36,19 @@ def _run(check_class: type[BaseValidation], step_output: dict[str, Any]) -> Base
 # bar as the BFX02 query APIs, so the flag alone cannot pass the check.
 _QUERYABLE_CASES = [
     (MaintenanceEventsCheck, "events_queryable", "events", {"machine_id": "m-1", "status": "maintenance"}),
-    (RetirementNoticesCheck, "notices_queryable", "notices", {"machine_id": "m-1", "status": "scheduled"}),
+    (
+        RetirementNoticesCheck,
+        "notices_queryable",
+        "notices",
+        {
+            "target_type": "machine",
+            "target_id": "m-1",
+            "notice_type": "machine-retirement",
+            "origin_kind": "provider",
+            "origin": "provider.breakfix-api",
+            "not_before": "2027-01-15T00:00:00Z",
+        },
+    ),
     (RepairHistoryCheck, "history_queryable", "records", {"machine_id": "m-1", "entries": [{"status": "x"}]}),
     (
         PlannedMaintenanceNotificationCheck,
@@ -117,6 +129,49 @@ class TestQueryableRecordChecks:
         check = _run(RepairHistoryCheck, step_output)
         assert check.passed
         assert "1 machine record(s)" in check.message
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            {"machine_id": "m-1", "status": "scheduled"},
+            {
+                "target_type": "machine",
+                "target_id": "m-1",
+                "notice_type": "machine-retirement",
+                "origin_kind": "provider",
+                "origin": "provider.breakfix-api",
+                "not_before": "not-a-timestamp",
+            },
+            {
+                "target_type": "machine",
+                "target_id": "m-1",
+                "notice_type": "machine-retirement",
+                "origin_kind": "provider",
+                "origin": "provider.breakfix-api",
+                "issued_at": "2027-01-15T00:00:00Z",
+            },
+            {
+                "target_type": "machine",
+                "target_id": "m-1",
+                "notice_type": "maintenance",
+                "origin_kind": "provider",
+                "origin": "provider.breakfix-api",
+                "not_before": "2027-01-15T00:00:00Z",
+            },
+            {
+                "target_type": "machine",
+                "target_id": "m-1",
+                "notice_type": "machine-retirement",
+                "origin_kind": "self_reported",
+                "origin": "provider.breakfix-api",
+                "not_before": "2027-01-15T00:00:00Z",
+            },
+        ],
+    )
+    def test_retirement_notice_rejects_unproven_records(self, record: dict[str, Any]) -> None:
+        """A generic lifecycle record without target/time/source proof cannot pass BFX02-02."""
+        with pytest.raises(pytest.skip.Exception):
+            _run(RetirementNoticesCheck, {"success": True, "notices_queryable": True, "notices": [record]})
 
 
 class TestOperationChecks:


### PR DESCRIPTION
## Summary

Harden BFX02-02 so generic lifecycle records cannot be treated as retirement-notice evidence.

A PASS requires:

- provider-origin evidence
- an explicit instance, machine, node, or rack target
- a retirement-specific notice type
- a timezone-aware scheduled retirement timestamp

Generic maintenance, drain, scheduled, closed, down, or self-reported records do not pass.

## Validation

- focused break-fix tests passed
- full unit and demo suites passed
- suite wiring, formatting, and pre-commit checks passed
- read-only provider validation found no authoritative retirement notice, so the live result remains SKIP/unproven rather than a false PASS

Part of #212