### PR TITLE
test(breakfix): validate GB300 BMC journal log retrieval (BFX03-03)

### DIFF
--- a/isvctl/configs/providers/gb300/config/bare_metal.yaml
+++ b/isvctl/configs/providers/gb300/config/bare_metal.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# GB300 bare-metal validation configuration.
+#
+# Run this provider on a GB300 BCM head. The BFX03-03 step reads the configured
+# compute node's BMC credentials from existing BCM inventory and performs only
+# Redfish GETs against a Manager-scoped BMC Journal LogService. It does not
+# clear logs, collect a diagnostic dump, or change BMC state.
+#
+# Required for BFX03-03:
+#   tests.settings.gb300_node_host: gb300-node-01
+#
+# Optional when the BMC certificate does not chain to the BCM host's system
+# trust store:
+#   tests.settings.gb300_bmc_ca_cert: /path/to/trusted-bmc-ca.pem
+#
+# Usage:
+#   uv run isvctl test run \
+#     -f isvctl/configs/providers/gb300/config/bare_metal.yaml \
+#     --set tests.settings.gb300_node_host=gb300-node-01 \
+#     -- -k BmcKernelLogCheck
+
+import:
+  - ../../../suites/bare_metal.yaml
+
+version: "1.0"
+
+commands:
+  bare_metal:
+    phases: ["test"]
+    steps:
+      - name: query_bmc_kernel_logs
+        phase: test
+        continue_on_failure: true
+        command: "python ../scripts/breakfix/query_bmc_kernel_logs.py"
+        args:
+          - "--node-host={{ gb300_node_host | default('', true) }}"
+          - "--ca-cert={{ gb300_bmc_ca_cert | default('', true) }}"
+        timeout: 120
+
+tests:
+  cluster_name: "gb300-bare-metal-validation"
+  description: "GB300 bare-metal validation"
+
+  settings:
+    region: ""
+    instance_type: ""
+    teardown_flag: ""
+    gb300_node_host: ""
+    gb300_bmc_ca_cert: ""

--- a/isvctl/configs/providers/gb300/scripts/breakfix/query_bmc_kernel_logs.py
+++ b/isvctl/configs/providers/gb300/scripts/breakfix/query_bmc_kernel_logs.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Obtain GB300 BMC log messages with read-only Redfish requests (BFX03-03).
+
+The script is intended to run on a GB300 BCM head. It resolves one configured
+compute node's BMC endpoint and credentials from read-only ``cmsh`` inventory,
+then discovers a Manager-scoped Redfish BMC Journal LogService. Credentials and
+raw log messages remain inside the privileged subprocess and are never emitted.
+TLS uses the BCM host's system trust store or an explicitly configured BMC CA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+_HOST_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_MODULE_SETUP = """\
+export MODULEPATH=/cm/local/modulefiles:/cm/shared/modulefiles
+source /cm/local/apps/environment-modules/current/init/bash
+module load shared cmsh >/dev/null 2>&1
+"""
+_QUERY_SCRIPT = (
+    _MODULE_SETUP
+    + """\
+node_host="$1"
+bmc_ca_cert="$2"
+
+tls_args=()
+if [ -n "$bmc_ca_cert" ]; then
+    if [ ! -f "$bmc_ca_cert" ] || [ ! -r "$bmc_ca_cert" ]; then
+        exit 24
+    fi
+    tls_args+=(--cacert "$bmc_ca_cert")
+fi
+
+bmc_ip=$(cmsh-lazy-load -c "device; use $node_host; interfaces; get rf0 ip" 2>/dev/null || true)
+if [ -z "$bmc_ip" ]; then
+    bmc_ip=$(cmsh-lazy-load -c "device; use $node_host; interfaces; get ipmi0 ip" 2>/dev/null || true)
+fi
+
+bmc_creds=$(cmsh-lazy-load -c "device; use $node_host; bmcsettings; get username; get password" 2>/dev/null || true)
+bmc_user=$(printf '%s\n' "$bmc_creds" | sed -n '1p')
+bmc_pass=$(printf '%s\n' "$bmc_creds" | sed -n '2p')
+if [ -z "$bmc_user" ] || [ -z "$bmc_pass" ]; then
+    category=$(cmsh-lazy-load -c "device; use $node_host; get category" 2>/dev/null || true)
+    bmc_user=$(cmsh-lazy-load -c "category; use $category; bmcsettings; get username" 2>/dev/null || true)
+    bmc_pass=$(cmsh-lazy-load -c "category; use $category; bmcsettings; get password" 2>/dev/null || true)
+fi
+
+if [ -z "$bmc_ip" ] || [ -z "$bmc_user" ] || [ -z "$bmc_pass" ]; then
+    exit 20
+fi
+
+netrc_file=$(mktemp)
+response_file=$(mktemp)
+trap 'rm -f "$netrc_file" "$response_file"' EXIT
+chmod 600 "$netrc_file" "$response_file"
+printf 'default login %s password %s\n' "$bmc_user" "$bmc_pass" > "$netrc_file"
+
+get_redfish() {
+    curl --max-time 30 --connect-timeout 10 --fail --silent --show-error \
+        "${tls_args[@]}" --netrc-file "$netrc_file" "https://$bmc_ip$1"
+}
+
+managers=$(get_redfish "/redfish/v1/Managers") || exit 21
+while IFS= read -r manager_uri; do
+    [ -n "$manager_uri" ] || continue
+    manager=$(get_redfish "$manager_uri") || continue
+    services_uri=$(printf '%s' "$manager" | jq -r '.LogServices."@odata.id" // empty')
+    [ -n "$services_uri" ] || services_uri="$manager_uri/LogServices"
+    services=$(get_redfish "$services_uri") || continue
+
+    while IFS= read -r service_uri; do
+        [ -n "$service_uri" ] || continue
+        service=$(get_redfish "$service_uri") || continue
+        service_id=$(printf '%s' "$service" | jq -r '.Id // empty')
+        service_identity=$(
+            printf '%s' "$service" | jq -r '[(.Name // ""), (.Description // "")] | join(" ") | ascii_downcase'
+        )
+        if [ "$service_id" != "Journal" ] || [[ "$service_identity" != *bmc*journal* ]]; then
+            continue
+        fi
+
+        entries_uri=$(printf '%s' "$service" | jq -r '.Entries."@odata.id" // empty')
+        [ -n "$entries_uri" ] || continue
+        get_redfish "$entries_uri" > "$response_file" || continue
+        message_count=$(
+            jq '[.Members[]? | select(type == "object" and ((.Message // "") | strings | length > 0))] | length' \
+                "$response_file"
+        )
+        if [ "$message_count" -lt 1 ]; then
+            continue
+        fi
+        jq -n --arg log_source "$entries_uri" --argjson message_count "$message_count" \
+            '{log_source: $log_source, message_count: $message_count}'
+        exit 0
+    done < <(printf '%s' "$services" | jq -r '.Members[]?."@odata.id" // empty')
+done < <(printf '%s' "$managers" | jq -r '.Members[]?."@odata.id" // empty')
+
+exit 23
+"""
+)
+
+
+class InspectionError(RuntimeError):
+    """Raised when direct BMC log evidence cannot be obtained."""
+
+
+class ProviderArgumentParser(argparse.ArgumentParser):
+    """Raise provider errors instead of exiting without a JSON result."""
+
+    def error(self, message: str) -> None:
+        """Convert invalid arguments into the provider failure path."""
+        raise InspectionError(f"Invalid arguments: {message}")
+
+
+def _emit(result: dict[str, Any]) -> int:
+    """Print provider-neutral JSON and return its exit status."""
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("success") else 1
+
+
+def _validate_host(host: str) -> str:
+    """Reject values that cannot be safely used as BCM device names."""
+    value = host.strip()
+    if not _HOST_RE.fullmatch(value):
+        raise InspectionError("invalid GB300 node hostname")
+    return value
+
+
+def _run_privileged(host: str, ca_cert: str = "") -> subprocess.CompletedProcess[str]:
+    """Run the fixed read-only BCM and Redfish helper as root."""
+    return subprocess.run(
+        ["sudo", "-n", "bash", "-s", "--", _validate_host(host), ca_cert],
+        input=_QUERY_SCRIPT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=90,
+    )
+
+
+def _query_host(host: str, ca_cert: str = "") -> dict[str, Any]:
+    """Return normalized evidence for one GB300 compute-node BMC."""
+    node_host = _validate_host(host)
+    completed = _run_privileged(node_host, ca_cert)
+    if completed.returncode != 0:
+        raise InspectionError("unable to retrieve a non-empty GB300 BMC Journal log")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise InspectionError("GB300 BMC returned invalid Journal evidence JSON") from exc
+
+    log_source = payload.get("log_source") if isinstance(payload, dict) else None
+    source_pattern = r"^/redfish/v1/Managers/[^/]+/LogServices/Journal/Entries/?$"
+    if not isinstance(log_source, str) or not re.fullmatch(source_pattern, log_source):
+        raise InspectionError("GB300 BMC Journal evidence has an invalid log source")
+    message_count = payload.get("message_count")
+    if isinstance(message_count, bool) or not isinstance(message_count, int) or message_count < 1:
+        raise InspectionError("GB300 BMC Journal returned no log messages")
+
+    return {
+        "host_id": node_host,
+        "kernel_log_available": True,
+        "message_count": message_count,
+        "log_source": log_source,
+    }
+
+
+def main() -> int:
+    """Retrieve BMC log messages for the configured GB300 node."""
+    parser = ProviderArgumentParser(description="Obtain GB300 BMC log messages through Redfish")
+    parser.add_argument(
+        "--node-host",
+        default="",
+        help="GB300 compute-node hostname",
+    )
+    parser.add_argument(
+        "--ca-cert",
+        default="",
+        help="Trusted BMC CA certificate (default: system trust store)",
+    )
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "gb300",
+        "source": "redfish Manager BMC Journal GET",
+        "hosts": [],
+    }
+    try:
+        args = parser.parse_args()
+        if not args.node_host.strip():
+            raise InspectionError("GB300 node host is required")
+        result["hosts"] = [_query_host(args.node_host, args.ca_cert)]
+    except (InspectionError, subprocess.TimeoutExpired) as exc:
+        result["error_type"] = "bmc_log_inspection"
+        result["error"] = str(exc) if isinstance(exc, InspectionError) else "GB300 BMC log inspection timed out"
+        return _emit(result)
+
+    result["success"] = True
+    return _emit(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
@@ -24,7 +24,14 @@ def main() -> int:
     return emit_stub(
         "query_bmc_kernel_logs",
         hint="BMC kernel log query",
-        hosts=[{"host_id": "demo-host-001", "kernel_log_available": True}],
+        hosts=[
+            {
+                "host_id": "demo-host-001",
+                "kernel_log_available": True,
+                "log_source": "/redfish/v1/Managers/BMC/LogServices/Journal/Entries",
+                "message_count": 1,
+            }
+        ],
     )
 
 

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -264,7 +264,7 @@ its plan item is not platform-scoped.
 | `query_retirement_notices` | test | `providers/my-isv/scripts/breakfix/query_retirement_notices.py` | `notices_queryable`, `notices` (BFX02-02) |
 | `query_repair_history` | test | `providers/nico/scripts/breakfix/query_repair_history.py` | `history_queryable`, `records[].{machine_id,entries}` -- a record needs non-empty `entries` to count (BFX02-03) |
 | `query_switch_firmware` | test | `providers/my-isv/scripts/breakfix/query_switch_firmware.py` | `trays[].{tray_id,firmware_version}` (BFX03-02) |
-| `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,kernel_log_available}` (BFX03-03) |
+| `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,kernel_log_available,log_source,message_count}`; PASS requires a non-empty Manager BMC Journal (BFX03-03) |
 | `return_node_maintenance` | test | `providers/my-isv/scripts/breakfix/return_node_maintenance.py` | `operation.{requested,accepted,machine_id,maintenance_mode}` (BFX01-02) |
 | `return_rack_maintenance` | test | `providers/my-isv/scripts/breakfix/return_rack_maintenance.py` | `operation.{requested,accepted,rack_id}` (BFX01-03) |
 | `request_host_replacement` | test | `providers/my-isv/scripts/breakfix/request_host_replacement.py` | `operation.{requested,node_removed_from_pool,machine_id}` (BFX01-05) |

--- a/isvctl/tests/providers/gb300/test_gb300_bmc_kernel_logs.py
+++ b/isvctl/tests/providers/gb300/test_gb300_bmc_kernel_logs.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for direct GB300 BMC log inspection (BFX03-03)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+from isvtest.validations.breakfix import BmcKernelLogCheck
+
+from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.orchestrator.context import Context
+from isvctl.orchestrator.step_executor import StepExecutor
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
+GB300_ROOT = ISVCTL_ROOT / "configs" / "providers" / "gb300"
+SCRIPT_PATH = GB300_ROOT / "scripts" / "breakfix" / "query_bmc_kernel_logs.py"
+CONFIG_PATH = GB300_ROOT / "config" / "bare_metal.yaml"
+
+
+def _load_script() -> ModuleType:
+    """Load the provider script as an isolated module."""
+    spec = importlib.util.spec_from_file_location("test_gb300_bmc_kernel_logs_script", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(stdout: str, *, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess[str]:
+    """Build a subprocess result for privileged-helper mocks."""
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+def _journal_evidence(*, message_count: int = 3) -> str:
+    """Build representative normalized journal evidence."""
+    return json.dumps(
+        {
+            "log_source": "/redfish/v1/Managers/BMC_0/LogServices/Journal/Entries",
+            "message_count": message_count,
+        }
+    )
+
+
+def test_config_wires_the_read_only_bmc_query() -> None:
+    """The GB300 bare-metal config binds BFX03-03's read-only query step."""
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    steps = config["commands"]["bare_metal"]["steps"]
+    step = next(item for item in steps if item["name"] == "query_bmc_kernel_logs")
+
+    assert step == {
+        "name": "query_bmc_kernel_logs",
+        "phase": "test",
+        "continue_on_failure": True,
+        "command": "python ../scripts/breakfix/query_bmc_kernel_logs.py",
+        "args": [
+            "--node-host={{ gb300_node_host | default('', true) }}",
+            "--ca-cert={{ gb300_bmc_ca_cert | default('', true) }}",
+        ],
+        "timeout": 120,
+    }
+    assert config["tests"]["settings"]["gb300_node_host"] == ""
+    assert config["tests"]["settings"]["gb300_bmc_ca_cert"] == ""
+
+
+def test_bmc_inputs_render_from_test_settings() -> None:
+    """The GB300 target and trust path are ordinary YAML settings."""
+    merged = merge_yaml_files(
+        [CONFIG_PATH],
+        set_values=[
+            "tests.settings.gb300_node_host=gb300-node-01",
+            "tests.settings.gb300_bmc_ca_cert=/trusted/bmc-ca.pem",
+        ],
+    )
+    config = RunConfig.model_validate(merged)
+    step = next(item for item in config.commands["bare_metal"].steps if item.name == "query_bmc_kernel_logs")
+
+    assert StepExecutor()._render_args(step.args, Context(config)) == [
+        "--node-host=gb300-node-01",
+        "--ca-cert=/trusted/bmc-ca.pem",
+    ]
+
+
+def test_privileged_helper_contains_only_read_operations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The GB300 helper performs BCM reads and Redfish GETs only."""
+    module = _load_script()
+    observed: dict[str, Any] = {}
+
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed.update(command=command, kwargs=kwargs)
+        return _completed(_journal_evidence())
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    module._run_privileged("gb300-node-01", "/etc/ssl/certs/bmc-ca.pem")
+
+    script = observed["kwargs"]["input"]
+    assert observed["command"] == [
+        "sudo",
+        "-n",
+        "bash",
+        "-s",
+        "--",
+        "gb300-node-01",
+        "/etc/ssl/certs/bmc-ca.pem",
+    ]
+    assert "--insecure" not in script
+    assert '--cacert "$bmc_ca_cert"' in script
+    assert '[ ! -f "$bmc_ca_cert" ] || [ ! -r "$bmc_ca_cert" ]' in script
+    assert 'get_redfish "/redfish/v1/Managers"' in script
+    assert 'service_id" != "Journal"' in script
+    assert "*bmc*journal*" in script
+    assert "LogServices/EventLog" not in script
+    assert "/redfish/v1/Systems" not in script
+    assert "--request GET" not in script
+    assert all(
+        token not in script for token in ("-X POST", "-X PATCH", "-X DELETE", "clearlog", "CollectDiagnosticData")
+    )
+
+
+def test_representative_log_produces_passing_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Representative Manager Journal messages satisfy BFX03-03."""
+    module = _load_script()
+    monkeypatch.setattr(module, "_run_privileged", lambda host, ca_cert: _completed(_journal_evidence()))
+
+    host = module._query_host("gb300-node-01", "/trusted/bmc-ca.pem")
+
+    assert host == {
+        "host_id": "gb300-node-01",
+        "kernel_log_available": True,
+        "message_count": 3,
+        "log_source": "/redfish/v1/Managers/BMC_0/LogServices/Journal/Entries",
+    }
+    check = BmcKernelLogCheck(config={"step_output": {"success": True, "hosts": [host]}})
+    check.run()
+    assert check.passed
+
+
+def test_empty_log_cannot_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reachable BMC without actual messages is not positive evidence."""
+    module = _load_script()
+    monkeypatch.setattr(
+        module,
+        "_run_privileged",
+        lambda host, ca_cert: _completed(_journal_evidence(message_count=0)),
+    )
+
+    with pytest.raises(module.InspectionError, match="no log messages"):
+        module._query_host("gb300-node-01")
+
+
+def test_main_fails_when_target_is_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An applicable GB300 run fails rather than skipping without a target."""
+    module = _load_script()
+    monkeypatch.setattr(sys, "argv", [SCRIPT_PATH.name])
+
+    assert module.main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["hosts"] == []
+    assert payload["error"] == "GB300 node host is required"
+    assert "skipped" not in payload
+
+
+def test_query_failure_does_not_leak_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Credentials and raw command diagnostics never enter provider JSON."""
+    module = _load_script()
+    monkeypatch.setattr(
+        module,
+        "_run_privileged",
+        lambda host, ca_cert: _completed("", returncode=23, stderr="password=do-not-print"),
+    )
+    monkeypatch.setattr(sys, "argv", [SCRIPT_PATH.name, "--node-host=gb300-node-01"])
+
+    assert module.main() == 1
+    output = capsys.readouterr().out
+    assert "do-not-print" not in output
+    assert "password=" not in output
+    assert json.loads(output)["error"] == "unable to retrieve a non-empty GB300 BMC Journal log"
+
+
+def test_invalid_arguments_emit_failure_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Argument errors must preserve the provider JSON contract."""
+    module = _load_script()
+    monkeypatch.setattr(sys, "argv", [SCRIPT_PATH.name, "--unknown-option"])
+    monkeypatch.setattr(
+        module,
+        "_query_host",
+        lambda *args: pytest.fail("the BMC must not be queried when parsing fails"),
+    )
+
+    assert module.main() == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert captured.err == ""
+    assert payload["success"] is False
+    assert payload["hosts"] == []
+    assert "unrecognized arguments" in payload["error"]
+
+
+def test_invalid_hostname_is_rejected_before_privileged_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shell metacharacters cannot enter the fixed privileged helper."""
+    module = _load_script()
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: pytest.fail("must not run"))
+
+    with pytest.raises(module.InspectionError, match="invalid GB300 node hostname"):
+        module._run_privileged("node;reboot")

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -30,11 +30,14 @@ passes, and the requirement stays visibly unproven.
 
 from __future__ import annotations
 
+import re
 from typing import Any, ClassVar
 
 import pytest
 
 from isvtest.core.validation import BaseValidation
+
+_BMC_JOURNAL_SOURCE_RE = re.compile(r"^/redfish/v1/Managers/[^/]+/LogServices/Journal/Entries/?$")
 
 
 def _record_label(record: dict[str, Any], *keys: str) -> str:
@@ -198,7 +201,15 @@ class BmcKernelLogCheck(BaseValidation):
     """Validate BMC kernel log messages are obtainable for a node (BFX03-03).
 
     Step output:
-        success, hosts: list[{host_id, kernel_log_available: bool}]
+        success, hosts: list[{
+            host_id,
+            kernel_log_available: bool,
+            log_source,
+            message_count,
+        }]
+
+    The availability boolean cannot pass by itself. Each host must identify a
+    Manager-scoped BMC Journal Entries source and a positive message count.
     """
 
     description: ClassVar[str] = "Obtain BMC kernel log messages for a node"
@@ -219,12 +230,33 @@ class BmcKernelLogCheck(BaseValidation):
         if len(hosts) < min_hosts:
             self.set_failed(f"Expected at least {min_hosts} host(s), got {len(hosts)}")
             return
-        unavailable = [h for h in hosts if not h.get("kernel_log_available")]
+        malformed = [host for host in hosts if not isinstance(host, dict)]
+        if malformed:
+            self.set_failed(f"BMC kernel log step returned {len(malformed)} malformed host record(s)")
+            return
+        unavailable = [host for host in hosts if not host.get("kernel_log_available")]
         if unavailable:
             labels = ", ".join(_record_label(h, "host_id", "machine_id") for h in unavailable[:3])
             self.set_failed(f"BMC kernel logs unavailable for {len(unavailable)} host(s): {labels}")
             return
-        self.set_passed(f"BMC kernel logs obtainable for {len(hosts)} host(s)")
+        missing_evidence = [host for host in hosts if not self._has_message_evidence(host)]
+        if missing_evidence:
+            labels = ", ".join(_record_label(h, "host_id", "machine_id") for h in missing_evidence[:3])
+            self.set_failed(f"BMC Journal message evidence missing for {len(missing_evidence)} host(s): {labels}")
+            return
+        self.set_passed(f"BMC kernel log messages obtainable for {len(hosts)} host(s)")
+
+    @staticmethod
+    def _has_message_evidence(host: dict[str, Any]) -> bool:
+        """Return whether a host reports non-empty Manager BMC Journal evidence."""
+        host_id = host.get("host_id")
+        if not isinstance(host_id, str) or not host_id.strip():
+            return False
+        count = host.get("message_count")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+            return False
+        source = host.get("log_source")
+        return isinstance(source, str) and _BMC_JOURNAL_SOURCE_RE.fullmatch(source) is not None
 
 
 class _OperationCheck(BaseValidation):

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -11,6 +11,7 @@ import pytest
 
 from isvtest.core.validation import BaseValidation
 from isvtest.validations.breakfix import (
+    BmcKernelLogCheck,
     CordonNodeCheck,
     FailureNotificationCheck,
     GpuResetCheck,
@@ -29,6 +30,18 @@ def _run(check_class: type[BaseValidation], step_output: dict[str, Any]) -> Base
     check = check_class(config={"step_output": step_output})
     check.run()
     return check
+
+
+def _bmc_journal_host(**overrides: Any) -> dict[str, Any]:
+    """Return one valid BMC Journal host record with optional overrides."""
+    host = {
+        "host_id": "node-1",
+        "kernel_log_available": True,
+        "log_source": "/redfish/v1/Managers/BMC_0/LogServices/Journal/Entries",
+        "message_count": 3,
+    }
+    host.update(overrides)
+    return host
 
 
 # (check class, observable flag key, record list key, one sample record)
@@ -156,6 +169,40 @@ class TestNodeHealthAgentCheck:
     def test_fails_when_no_agents_returned(self) -> None:
         """BFX04-01 needs evidence an agent is running; zero records is not that."""
         assert not _run(NodeHealthAgentCheck, {"success": True, "agents_observable": True, "agents": []}).passed
+
+
+class TestBmcKernelLogCheck:
+    """Cover non-empty Manager BMC Journal evidence for BFX03-03."""
+
+    def test_passes_with_nonempty_manager_journal(self) -> None:
+        """A non-empty Manager BMC Journal is positive message evidence."""
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": [_bmc_journal_host()]})
+        assert check.passed
+        assert "1 host(s)" in check.message
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            {"host_id": "node-1", "kernel_log_available": True},
+            _bmc_journal_host(host_id=""),
+            _bmc_journal_host(message_count=0),
+            _bmc_journal_host(message_count=True),
+            _bmc_journal_host(message_count="3"),
+            _bmc_journal_host(log_source=""),
+            _bmc_journal_host(log_source="/redfish/v1/Systems/System_0/LogServices/EventLog/Entries"),
+        ],
+    )
+    def test_rejects_boolean_only_or_incomplete_evidence(self, host: dict[str, Any]) -> None:
+        """A provider assertion, empty count, or non-Journal source cannot pass."""
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": [host]})
+        assert not check.passed
+        assert "evidence missing" in check._error
+
+    def test_rejects_malformed_host_record(self) -> None:
+        """A non-object host record fails cleanly rather than raising."""
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": ["node-1"]})
+        assert not check.passed
+        assert "malformed" in check._error
 
 
 class TestCordonNodeCheck:


### PR DESCRIPTION
## Summary

- add read-only GB300 BMC journal retrieval for BFX03-03
- discover Manager-scoped BMC Journal LogServices through Redfish GET requests
- require a non-empty message count and exact Journal Entries source
- reject Boolean-only health-probe inference
- protect credentials and raw log messages from provider output
- use the standard GB300 bare-metal provider configuration

## Safety

TLS verification fails closed. The provider uses system trust by default and accepts an explicitly configured CA certificate without bypassing certificate validation.

## Validation

- focused provider and break-fix tests passed
- provider configuration and suite wiring validate
- full unit and demo suites passed
- read-only validation on an applicable GB300 environment returned non-empty Manager Journal evidence and produced PASS

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GB300 bare-metal validation for inspecting BMC kernel logs through the Manager Journal.
  * Reports sanitized host details, log source, availability, and message count.
  * Supports optional CA certificates and configurable node hosts.
  * Added demo-provider output for log source and message count.

* **Bug Fixes**
  * Strengthened validation for missing, malformed, empty, or invalid BMC log evidence.
  * Improved handling of argument errors, timeouts, command failures, and sensitive error output.

* **Documentation**
  * Updated suite documentation with output fields and pass criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->