### PR TITLE
test(breakfix): validate GPUd or Sentinel on GPU nodes (BFX04-01)

### DIFF
--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -1999,6 +1999,7 @@ domains:
                 labels:
                   - bare_metal
                   - breakfix
+                  - kubernetes
                 dependencies:
                   - LimitedEnv
                 req_id: BFX04

--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -206,6 +206,17 @@ commands:
           TF_AUTO_APPROVE: "true"
           NODE_POOL_STATE_FILE: "terraform-delete.tfstate"
 
+      # BFX04-01: read-only inventory of Fleet Intelligence/GPUd or
+      # NVSentinel DaemonSet and pod coverage across every GPU node.
+      - name: query_node_health_agents
+        phase: test
+        command: "python3 ../../shared/breakfix/query_node_health_agents.py"
+        args:
+          - "--nodes="
+        requires_available_validations:
+          - K8sNodeHealthAgentCheck
+        timeout: 120
+
       - name: teardown
         phase: teardown
         command: "../scripts/eks/teardown.sh"

--- a/isvctl/configs/providers/gb300/config/bare_metal.yaml
+++ b/isvctl/configs/providers/gb300/config/bare_metal.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# GB300 bare-metal validation configuration.
+#
+# BFX04-01 performs read-only inspection of NVIDIA Fleet Intelligence Agent
+# (GPUd) or NVSentinel. Set tests.settings.bfx04_nodes to comma-separated SSH
+# targets for direct systemd inspection.
+#
+# Usage:
+#   uv run isvctl test run \
+#     -f isvctl/configs/providers/gb300/config/bare_metal.yaml \
+#     --set tests.settings.bfx04_nodes=gb300-node-01,gb300-node-02 \
+#     -- -k NodeHealthAgentCheck
+
+import:
+  - ../../../suites/bare_metal.yaml
+
+version: "1.0"
+
+commands:
+  bare_metal:
+    phases: ["test"]
+    steps:
+      - name: query_node_health_agents
+        phase: test
+        command: "python ../../shared/breakfix/query_node_health_agents.py"
+        args:
+          - "--nodes={{ bfx04_nodes | default('', true) }}"
+        requires_available_validations:
+          - NodeHealthAgentCheck
+        timeout: 120
+
+tests:
+  cluster_name: "gb300-bare-metal-validation"
+  description: "GB300 bare-metal validation"
+
+  settings:
+    region: ""
+    instance_type: ""
+    teardown_flag: ""
+    show_skipped_tests: true
+    bfx04_nodes: ""

--- a/isvctl/configs/providers/minikube.yaml
+++ b/isvctl/configs/providers/minikube.yaml
@@ -34,6 +34,14 @@ commands:
         phase: setup
         command: "my-isv/scripts/k8s/setup_minikube.sh"
         timeout: 60
+      - name: query_node_health_agents
+        phase: test
+        command: "python shared/breakfix/query_node_health_agents.py"
+        args:
+          - "--nodes="
+        requires_available_validations:
+          - K8sNodeHealthAgentCheck
+        timeout: 120
       - name: teardown
         phase: teardown
         command: "my-isv/scripts/k8s/teardown_minikube.sh"

--- a/isvctl/configs/providers/my-isv/config/k8s.yaml
+++ b/isvctl/configs/providers/my-isv/config/k8s.yaml
@@ -73,6 +73,15 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 600
 
+      - name: query_node_health_agents
+        phase: test
+        command: "python ../../shared/breakfix/query_node_health_agents.py"
+        args:
+          - "--nodes="
+        requires_available_validations:
+          - K8sNodeHealthAgentCheck
+        timeout: 120
+
 tests:
   description: "my-isv Kubernetes platform suite (real cluster required)"
   settings:

--- a/isvctl/configs/providers/shared/breakfix/query_node_health_agents.py
+++ b/isvctl/configs/providers/shared/breakfix/query_node_health_agents.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inspect NVIDIA node-health agents with read-only systemd or Kubernetes queries.
+
+BFX04-01 accepts either NVIDIA Fleet Intelligence Agent (GPUd) or the
+NVSentinel GPU Health Monitor. A GPU node is covered only when a supported
+agent pod is Running, Ready, and controlled by a matching DaemonSet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+AGENT_LABEL = "app.kubernetes.io/name"
+SUPPORTED_AGENTS = frozenset({"fleet-intelligence-agent", "gpu-health-monitor"})
+GPU_LABEL = "nvidia.com/gpu.present"
+GPU_RESOURCE = "nvidia.com/gpu"
+SYSTEMD_AGENTS = ("fleetintd", "gpud", "nvsentinel", "gpu-health-monitor")
+NODE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class KubernetesQueryError(RuntimeError):
+    """Raised when a read-only Kubernetes inventory query fails."""
+
+
+class NodeQueryError(RuntimeError):
+    """Raised when a read-only bare-metal node query fails."""
+
+
+class ProviderArgumentParser(argparse.ArgumentParser):
+    """Raise provider errors instead of exiting without a JSON result."""
+
+    def error(self, message: str) -> None:
+        """Convert invalid arguments into the provider failure path."""
+        raise NodeQueryError(f"Invalid arguments: {message}")
+
+
+class CommandOverrideError(RuntimeError):
+    """Raised when a configured command prefix cannot be parsed."""
+
+
+def _command_override(env_name: str, default: str) -> list[str]:
+    """Return a safe configured command prefix or locate its default binary."""
+    override = os.environ.get(env_name, "").strip()
+    if override:
+        try:
+            command = shlex.split(override)
+        except ValueError as exc:
+            raise CommandOverrideError(f"Invalid {env_name} command override") from exc
+        if command:
+            return command
+    executable = shutil.which(default)
+    if executable:
+        return [executable]
+    raise NodeQueryError(f"No {default}-compatible command is available")
+
+
+def _kubectl_command() -> list[str]:
+    """Return the configured kubectl-compatible command prefix."""
+    try:
+        return _command_override("KUBECTL", "kubectl")
+    except NodeQueryError:
+        pass
+    microk8s = shutil.which("microk8s")
+    if microk8s:
+        return [microk8s, "kubectl"]
+    raise KubernetesQueryError("No kubectl-compatible command is available")
+
+
+def _ssh_command() -> list[str]:
+    """Return the configured SSH-compatible command prefix."""
+    return _command_override("SSH", "ssh")
+
+
+def _parse_nodes(value: str) -> list[str]:
+    """Parse and validate comma/whitespace-separated SSH node names."""
+    nodes = list(dict.fromkeys(part for part in re.split(r"[\s,]+", value.strip()) if part))
+    invalid = [node for node in nodes if not NODE_PATTERN.fullmatch(node)]
+    if invalid:
+        raise NodeQueryError("Invalid bare-metal node name")
+    return nodes
+
+
+def _query_systemd_node(node: str) -> dict[str, Any]:
+    """Return supported systemd-agent status for one SSH-reachable node."""
+    remote_command = "systemctl is-active " + " ".join(SYSTEMD_AGENTS) + " 2>/dev/null || true"
+    command = [
+        *_ssh_command(),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        node,
+        remote_command,
+    ]
+    try:
+        response = subprocess.run(command, capture_output=True, text=True, timeout=20, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise NodeQueryError(f"Node health agent query failed for {node}") from exc
+    if response.returncode != 0:
+        raise NodeQueryError(f"Node health agent query failed for {node}")
+    states = response.stdout.splitlines()
+    if len(states) != len(SYSTEMD_AGENTS):
+        raise NodeQueryError(f"Node health agent query returned invalid status for {node}")
+    active = [service for service, state in zip(SYSTEMD_AGENTS, states, strict=True) if state.strip() == "active"]
+    return {
+        "node_id": node,
+        "agent_name": active[0] if active else "GPUd/Sentinel",
+        "running": bool(active),
+    }
+
+
+def _evaluate_systemd(nodes: list[str]) -> dict[str, Any]:
+    """Build provider-neutral BFX04-01 evidence from systemd service states."""
+    return {
+        "success": True,
+        "platform": "bare_metal",
+        "test_name": "query_node_health_agents",
+        "agents_observable": True,
+        "agents": [_query_systemd_node(node) for node in nodes],
+    }
+
+
+def _get_collection(resource: str, *, all_namespaces: bool = False) -> dict[str, Any]:
+    """Read one Kubernetes resource collection and decode its JSON document."""
+    command = [*_kubectl_command(), "get", resource]
+    if all_namespaces:
+        command.append("--all-namespaces")
+    command.extend(["--output=json", "--request-timeout=30s"])
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=40, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise KubernetesQueryError(f"Kubernetes API query failed for {resource}") from exc
+    if result.returncode != 0:
+        raise KubernetesQueryError(f"Kubernetes API query failed for {resource}")
+    try:
+        payload = json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise KubernetesQueryError(f"Kubernetes API returned invalid JSON for {resource}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+        raise KubernetesQueryError(f"Kubernetes API returned an invalid collection for {resource}")
+    return payload
+
+
+def _positive_gpu_count(node: dict[str, Any]) -> bool:
+    """Return whether node capacity or allocatable data proves a GPU exists."""
+    status = node.get("status") if isinstance(node.get("status"), dict) else {}
+    for field in ("capacity", "allocatable"):
+        resources = status.get(field) if isinstance(status.get(field), dict) else {}
+        value = resources.get(GPU_RESOURCE)
+        try:
+            if value is not None and int(value) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _gpu_nodes(nodes: dict[str, Any]) -> list[str]:
+    """Return sorted node names identified as GPU-bearing by label or capacity."""
+    names: set[str] = set()
+    for node in nodes.get("items", []):
+        if not isinstance(node, dict):
+            continue
+        metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+        labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
+        name = metadata.get("name")
+        if (
+            isinstance(name, str)
+            and name
+            and (str(labels.get(GPU_LABEL, "")).lower() == "true" or _positive_gpu_count(node))
+        ):
+            names.add(name)
+    return sorted(names)
+
+
+def _supported_daemonsets(daemonsets: dict[str, Any]) -> list[dict[str, str]]:
+    """Return identity records for exact-label supported agent DaemonSets."""
+    records: list[dict[str, str]] = []
+    for daemonset in daemonsets.get("items", []):
+        if not isinstance(daemonset, dict):
+            continue
+        metadata = daemonset.get("metadata") if isinstance(daemonset.get("metadata"), dict) else {}
+        labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
+        agent_name = labels.get(AGENT_LABEL)
+        name = metadata.get("name")
+        namespace = metadata.get("namespace") or "default"
+        if agent_name not in SUPPORTED_AGENTS or not isinstance(name, str) or not name:
+            continue
+        if not isinstance(namespace, str) or not namespace:
+            continue
+        uid = metadata.get("uid")
+        records.append(
+            {
+                "namespace": namespace,
+                "name": name,
+                "uid": uid if isinstance(uid, str) else "",
+                "agent_name": agent_name,
+            }
+        )
+    return records
+
+
+def _owned_by(pod: dict[str, Any], daemonset: dict[str, str]) -> bool:
+    """Return whether a pod is controlled by the given DaemonSet."""
+    metadata = pod.get("metadata") if isinstance(pod.get("metadata"), dict) else {}
+    references = metadata.get("ownerReferences")
+    if not isinstance(references, list):
+        return False
+    for reference in references:
+        if not isinstance(reference, dict):
+            continue
+        if reference.get("kind") != "DaemonSet" or reference.get("controller") is not True:
+            continue
+        if reference.get("name") != daemonset["name"]:
+            continue
+        if daemonset["uid"] and reference.get("uid") != daemonset["uid"]:
+            continue
+        return True
+    return False
+
+
+def _pod_ready(pod: dict[str, Any]) -> bool:
+    """Return whether the pod Ready condition is explicitly true."""
+    status = pod.get("status") if isinstance(pod.get("status"), dict) else {}
+    conditions = status.get("conditions")
+    if not isinstance(conditions, list):
+        return False
+    return any(
+        isinstance(condition, dict) and condition.get("type") == "Ready" and condition.get("status") == "True"
+        for condition in conditions
+    )
+
+
+def _running_agents(pods: dict[str, Any], daemonsets: list[dict[str, str]]) -> dict[str, str]:
+    """Map GPU node names to supported Ready/Running DaemonSet-owned agents."""
+    records: dict[str, str] = {}
+    for pod in pods.get("items", []):
+        if not isinstance(pod, dict):
+            continue
+        metadata = pod.get("metadata") if isinstance(pod.get("metadata"), dict) else {}
+        if metadata.get("deletionTimestamp"):
+            continue
+        labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
+        agent_name = labels.get(AGENT_LABEL)
+        namespace = metadata.get("namespace") or "default"
+        spec = pod.get("spec") if isinstance(pod.get("spec"), dict) else {}
+        status = pod.get("status") if isinstance(pod.get("status"), dict) else {}
+        node_name = spec.get("nodeName")
+        if agent_name not in SUPPORTED_AGENTS or not isinstance(node_name, str) or not node_name:
+            continue
+        if status.get("phase") != "Running" or not _pod_ready(pod):
+            continue
+        owner = next(
+            (
+                daemonset
+                for daemonset in daemonsets
+                if daemonset["namespace"] == namespace
+                and daemonset["agent_name"] == agent_name
+                and _owned_by(pod, daemonset)
+            ),
+            None,
+        )
+        if owner is not None:
+            records[node_name] = agent_name
+    return records
+
+
+def _evaluate(nodes: dict[str, Any], daemonsets: dict[str, Any], pods: dict[str, Any]) -> dict[str, Any]:
+    """Build minimal provider-neutral BFX04-01 evidence from Kubernetes inventory."""
+    gpu_nodes = _gpu_nodes(nodes)
+    result: dict[str, Any] = {
+        "success": True,
+        "platform": "kubernetes",
+        "test_name": "query_node_health_agents",
+        "agents_observable": True,
+        "agents": [],
+    }
+    if not gpu_nodes:
+        result.update(
+            {
+                "skipped": True,
+                "skip_reason": "No GPU nodes detected; BFX04-01 is not applicable",
+            }
+        )
+        return result
+
+    daemonset_records = _supported_daemonsets(daemonsets)
+    running = _running_agents(pods, daemonset_records)
+    result["agents"] = [
+        {
+            "node_id": node_name,
+            "agent_name": running.get(node_name, "GPUd/Sentinel"),
+            "running": node_name in running,
+        }
+        for node_name in gpu_nodes
+    ]
+    return result
+
+
+def main() -> int:
+    """Query the cluster and emit one structured BFX04-01 result."""
+    parser = ProviderArgumentParser(description="Inspect NVIDIA node-health agents")
+    parser.add_argument(
+        "--nodes",
+        default="",
+        help="Comma-separated SSH node names; omit to use Kubernetes",
+    )
+    configured_nodes = ""
+    try:
+        args = parser.parse_args()
+        configured_nodes = args.nodes
+        nodes = _parse_nodes(configured_nodes)
+        if nodes:
+            result = _evaluate_systemd(nodes)
+        else:
+            result = _evaluate(
+                _get_collection("nodes"),
+                _get_collection("daemonsets.apps", all_namespaces=True),
+                _get_collection("pods", all_namespaces=True),
+            )
+    except (CommandOverrideError, KubernetesQueryError, NodeQueryError) as exc:
+        result = {
+            "success": False,
+            "platform": "bare_metal" if configured_nodes.strip() else "kubernetes",
+            "test_name": "query_node_health_agents",
+            "error_type": "node_health_query_failed",
+            "error": str(exc),
+        }
+        print(json.dumps(result))
+        return 1
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -301,6 +301,16 @@ volume. The three test-phase steps all reuse that fixture.
 
 Validations use `kubectl` directly (or a custom CLI via the `KUBECTL` env var): node counts, GPU operator, pod health, NCCL/NIM workloads. Break-fix cordon and GPU reset are optional provider steps.
 
+The GB300 bare-metal provider wires the read-only BFX04-01 query in
+`providers/gb300/config/bare_metal.yaml`. Kubernetes providers wire the same
+shared query to the provider-neutral check in `suites/k8s.yaml`.
+For GB300 bare metal, set `tests.settings.bfx04_nodes` to comma-separated SSH targets;
+each must run `fleetintd`, `gpud`, `nvsentinel`, or `gpu-health-monitor`. With
+no node list, the shared query uses Kubernetes and requires an official Fleet Intelligence Agent
+(`fleet-intelligence-agent`) or NVSentinel GPU Health Monitor
+(`gpu-health-monitor`) Ready/Running DaemonSet-owned pod on every detected GPU
+node. Generic DCGM exporter telemetry does not satisfy this requirement.
+
 ### Slurm (`slurm.yaml`)
 
 | Step | Phase | Script |

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -862,7 +862,7 @@ tests:
       checks:
         NodeHealthAgentCheck:
           test_id: "BFX04-01"
-          labels: ["bare_metal", "breakfix"]
+          labels: ["bare_metal", "breakfix", "kubernetes"]
 
     planned_maintenance_notification:
       step: query_planned_notifications

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -403,5 +403,12 @@ tests:
           test_id: "BFX01-04"
           labels: ["kubernetes", "breakfix", "min_req"]
 
+    node_health_agents:
+      step: query_node_health_agents
+      checks:
+        K8sNodeHealthAgentCheck:
+          test_id: "BFX04-01"
+          labels: ["bare_metal", "breakfix", "kubernetes"]
+
   exclude:
     labels: []

--- a/isvctl/tests/test_node_health_agents_provider.py
+++ b/isvctl/tests/test_node_health_agents_provider.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the read-only node-health-agent provider (BFX04-01)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.orchestrator.context import Context
+from isvctl.orchestrator.step_executor import StepExecutor
+
+CONFIGS_ROOT = Path(__file__).resolve().parents[1] / "configs"
+SCRIPT = CONFIGS_ROOT / "providers" / "shared" / "breakfix" / "query_node_health_agents.py"
+GB300_CONFIG = CONFIGS_ROOT / "providers" / "gb300" / "config" / "bare_metal.yaml"
+K8S_SUITE = CONFIGS_ROOT / "suites" / "k8s.yaml"
+MINIKUBE_CONFIG = CONFIGS_ROOT / "providers" / "minikube.yaml"
+AWS_EKS_CONFIG = CONFIGS_ROOT / "providers" / "aws" / "config" / "eks.yaml"
+MY_ISV_K8S_CONFIG = CONFIGS_ROOT / "providers" / "my-isv" / "config" / "k8s.yaml"
+
+
+def _load_script() -> ModuleType:
+    """Load the provider script as an isolated module."""
+    spec = importlib.util.spec_from_file_location("test_kubernetes_node_health_agents_script", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _nodes(*names: str) -> dict[str, object]:
+    """Return GPU node inventory for the supplied names."""
+    return {
+        "items": [
+            {
+                "metadata": {"name": name, "labels": {"nvidia.com/gpu.present": "true"}},
+                "status": {"capacity": {"nvidia.com/gpu": "4"}},
+            }
+            for name in names
+        ]
+    }
+
+
+def _daemonset(agent_name: str = "fleet-intelligence-agent") -> dict[str, object]:
+    """Return one supported agent DaemonSet inventory item."""
+    return {
+        "metadata": {
+            "namespace": "nvidia-system",
+            "name": agent_name,
+            "uid": f"uid-{agent_name}",
+            "labels": {"app.kubernetes.io/name": agent_name},
+        }
+    }
+
+
+def _pod(
+    node: str,
+    *,
+    agent_name: str = "fleet-intelligence-agent",
+    phase: str = "Running",
+    ready: bool = True,
+    owned: bool = True,
+) -> dict[str, object]:
+    """Return one candidate agent pod inventory item."""
+    owner_references = []
+    if owned:
+        owner_references.append(
+            {
+                "kind": "DaemonSet",
+                "name": agent_name,
+                "uid": f"uid-{agent_name}",
+                "controller": True,
+            }
+        )
+    return {
+        "metadata": {
+            "namespace": "nvidia-system",
+            "name": f"{agent_name}-{node}",
+            "labels": {"app.kubernetes.io/name": agent_name},
+            "ownerReferences": owner_references,
+        },
+        "spec": {"nodeName": node},
+        "status": {"phase": phase, "conditions": [{"type": "Ready", "status": "True" if ready else "False"}]},
+    }
+
+
+def test_gb300_config_wires_read_only_node_health_query() -> None:
+    """The GB300 bare-metal config binds BFX04-01's read-only query step."""
+    config = RunConfig.model_validate(merge_yaml_files([GB300_CONFIG]))
+    steps = config.get_steps("bare_metal")
+    step = next(item for item in steps if item.name == "query_node_health_agents")
+
+    assert config.get_phases("bare_metal") == ["test"]
+    assert step.command == "python ../../shared/breakfix/query_node_health_agents.py"
+    assert step.args == ["--nodes={{ bfx04_nodes | default('', true) }}"]
+    assert step.requires_available_validations == ["NodeHealthAgentCheck"]
+    assert config.tests.settings["bfx04_nodes"] == ""
+
+
+def test_config_keeps_empty_nodes_value_for_kubernetes_fallback() -> None:
+    """An empty YAML setting must not leave a dangling argparse flag."""
+    config = RunConfig.model_validate(merge_yaml_files([GB300_CONFIG]))
+    step = next(item for item in config.get_steps("bare_metal") if item.name == "query_node_health_agents")
+
+    rendered = StepExecutor()._render_args(step.args, Context(config))
+
+    assert rendered == ["--nodes="]
+
+
+def test_bare_metal_nodes_render_from_test_settings() -> None:
+    """Bare-metal targets are supplied through the provider YAML contract."""
+    merged = merge_yaml_files(
+        [GB300_CONFIG],
+        set_values=["tests.settings.bfx04_nodes=gb300-node-01,gb300-node-02"],
+    )
+    config = RunConfig.model_validate(merged)
+    step = next(item for item in config.get_steps("bare_metal") if item.name == "query_node_health_agents")
+    expected = ["--nodes=gb300-node-01,gb300-node-02"]
+
+    assert StepExecutor()._render_args(step.args, Context(config)) == expected
+
+
+def test_k8s_suite_declares_node_health_agent_validation() -> None:
+    """The canonical Kubernetes suite must expose BFX04-01."""
+    config = yaml.safe_load(K8S_SUITE.read_text())
+    validation = config["tests"]["validations"]["node_health_agents"]
+
+    assert validation["step"] == "query_node_health_agents"
+    assert validation["checks"]["K8sNodeHealthAgentCheck"] == {
+        "test_id": "BFX04-01",
+        "labels": ["bare_metal", "breakfix", "kubernetes"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("provider_config", "command"),
+    [
+        (MINIKUBE_CONFIG, "python shared/breakfix/query_node_health_agents.py"),
+        (AWS_EKS_CONFIG, "python3 ../../shared/breakfix/query_node_health_agents.py"),
+        (MY_ISV_K8S_CONFIG, "python ../../shared/breakfix/query_node_health_agents.py"),
+    ],
+)
+def test_kubernetes_providers_wire_node_health_inventory(provider_config: Path, command: str) -> None:
+    """Kubernetes provider configs must execute the shared read-only query."""
+    config = yaml.safe_load(provider_config.read_text())
+    step = next(
+        item for item in config["commands"]["kubernetes"]["steps"] if item["name"] == "query_node_health_agents"
+    )
+
+    assert step == {
+        "name": "query_node_health_agents",
+        "phase": "test",
+        "command": command,
+        "args": ["--nodes="],
+        "requires_available_validations": ["K8sNodeHealthAgentCheck"],
+        "timeout": 120,
+    }
+
+
+@pytest.mark.parametrize("agent_name", ["fleet-intelligence-agent", "gpu-health-monitor"])
+def test_supported_agent_covers_every_gpu_node(agent_name: str) -> None:
+    """Either supported NVIDIA agent can prove complete GPU-node coverage."""
+    module = _load_script()
+    result = module._evaluate(
+        _nodes("gpu-1", "gpu-2"),
+        {"items": [_daemonset(agent_name)]},
+        {"items": [_pod("gpu-1", agent_name=agent_name), _pod("gpu-2", agent_name=agent_name)]},
+    )
+
+    assert result["success"] is True
+    assert result.get("skipped") is not True
+    assert result["agents_observable"] is True
+    assert result["agents"] == [
+        {"node_id": "gpu-1", "agent_name": agent_name, "running": True},
+        {"node_id": "gpu-2", "agent_name": agent_name, "running": True},
+    ]
+
+
+def test_missing_supported_agent_returns_failing_record_per_gpu_node() -> None:
+    """No supported DaemonSet is observable evidence that the agents are absent."""
+    module = _load_script()
+    result = module._evaluate(_nodes("gpu-1", "gpu-2"), {"items": []}, {"items": []})
+
+    assert result.get("skipped") is not True
+    assert result["agents_observable"] is True
+    assert [record["running"] for record in result["agents"]] == [False, False]
+
+
+def test_unready_pod_fails_only_its_gpu_node() -> None:
+    """A pod must be both Running and Ready to cover its node."""
+    module = _load_script()
+    result = module._evaluate(
+        _nodes("gpu-1", "gpu-2"),
+        {"items": [_daemonset()]},
+        {"items": [_pod("gpu-1"), _pod("gpu-2", ready=False)]},
+    )
+
+    assert result["agents"][0]["running"] is True
+    assert result["agents"][1] == {"node_id": "gpu-2", "agent_name": "GPUd/Sentinel", "running": False}
+
+
+def test_generic_dcgm_exporter_is_not_accepted() -> None:
+    """DCGM telemetry alone does not satisfy the GPUd/Sentinel requirement."""
+    module = _load_script()
+    result = module._evaluate(
+        _nodes("gpu-1"),
+        {"items": [_daemonset("dcgm-exporter")]},
+        {"items": [_pod("gpu-1", agent_name="dcgm-exporter")]},
+    )
+
+    assert result["agents"] == [{"node_id": "gpu-1", "agent_name": "GPUd/Sentinel", "running": False}]
+
+
+def test_unowned_pod_is_not_accepted() -> None:
+    """An exact label is insufficient without a matching DaemonSet owner."""
+    module = _load_script()
+    result = module._evaluate(
+        _nodes("gpu-1"),
+        {"items": [_daemonset()]},
+        {"items": [_pod("gpu-1", owned=False)]},
+    )
+
+    assert result["agents"][0]["running"] is False
+
+
+def test_no_gpu_nodes_is_a_structured_skip() -> None:
+    """An environment without GPU nodes is outside BFX04-01's scope."""
+    module = _load_script()
+    result = module._evaluate({"items": []}, {"items": [_daemonset()]}, {"items": []})
+
+    assert result["success"] is True
+    assert result["skipped"] is True
+    assert result["agents"] == []
+
+
+def test_bare_metal_fleetintd_running_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A running Fleet Intelligence systemd service is direct node evidence."""
+    module = _load_script()
+    response = subprocess.CompletedProcess([], 0, stdout="active\ninactive\ninactive\ninactive\n", stderr="")
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return response
+
+    monkeypatch.setattr(module, "_ssh_command", lambda: ["ssh"])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = module._evaluate_systemd(["gb300-node-01"])
+
+    assert result["platform"] == "bare_metal"
+    assert result["agents"] == [{"node_id": "gb300-node-01", "agent_name": "fleetintd", "running": True}]
+    assert commands[0][-1] == ("systemctl is-active fleetintd gpud nvsentinel gpu-health-monitor 2>/dev/null || true")
+
+
+def test_bare_metal_missing_agent_returns_failing_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inactive supported services cannot produce a false bare-metal pass."""
+    module = _load_script()
+    response = subprocess.CompletedProcess([], 0, stdout="inactive\ninactive\ninactive\ninactive\n", stderr="")
+    monkeypatch.setattr(module, "_ssh_command", lambda: ["ssh"])
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: response)
+
+    result = module._evaluate_systemd(["gb300-node-01"])
+
+    assert result["agents"] == [{"node_id": "gb300-node-01", "agent_name": "GPUd/Sentinel", "running": False}]
+
+
+def test_bare_metal_node_names_are_validated() -> None:
+    """Node input cannot add SSH options or remote shell syntax."""
+    module = _load_script()
+
+    with pytest.raises(module.NodeQueryError, match="Invalid bare-metal node name"):
+        module._parse_nodes("--proxycommand=bad,node;touch")
+
+
+def test_query_failure_is_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """kubectl output is not copied into the structured failure payload."""
+    module = _load_script()
+    monkeypatch.setattr(module, "_kubectl_command", lambda: ["kubectl"])
+    response = subprocess.CompletedProcess([], 1, stdout="private inventory", stderr="private auth error")
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: response)
+    monkeypatch.setattr(sys, "argv", [SCRIPT.name])
+
+    assert module.main() == 1
+    output = capsys.readouterr().out
+    assert "private" not in output
+    payload = json.loads(output)
+    assert payload["success"] is False
+    assert payload["error_type"] == "node_health_query_failed"
+
+
+def test_invalid_arguments_emit_failure_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Argument errors must preserve the provider JSON contract."""
+    module = _load_script()
+    monkeypatch.setattr(sys, "argv", [SCRIPT.name, "--unknown-option"])
+
+    assert module.main() == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert captured.err == ""
+    assert payload["success"] is False
+    assert payload["error_type"] == "node_health_query_failed"
+    assert "unrecognized arguments" in payload["error"]
+
+
+@pytest.mark.parametrize(
+    ("env_name", "argv"),
+    [
+        ("KUBECTL", [SCRIPT.name]),
+        ("SSH", [SCRIPT.name, "--nodes", "gpu-1"]),
+    ],
+)
+def test_malformed_command_override_is_structured(
+    env_name: str,
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unmatched quote in a command override emits JSON, not a traceback."""
+    module = _load_script()
+    monkeypatch.setenv(env_name, "unmatched-'")
+    monkeypatch.setattr(sys, "argv", argv)
+
+    assert module.main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["error_type"] == "node_health_query_failed"
+    assert payload["error"] == f"Invalid {env_name} command override"

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -383,6 +383,10 @@ class NodeHealthAgentCheck(BaseValidation):
         self.set_passed(f"Node health agent running on {len(agents)} node(s)")
 
 
+class K8sNodeHealthAgentCheck(NodeHealthAgentCheck):
+    """Validate BFX04-01 through Kubernetes node and workload inventory."""
+
+
 class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
     """Validate tenants can be notified of planned maintenance (BFX05-01).
 

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -157,6 +157,45 @@ class TestNodeHealthAgentCheck:
         """BFX04-01 needs evidence an agent is running; zero records is not that."""
         assert not _run(NodeHealthAgentCheck, {"success": True, "agents_observable": True, "agents": []}).passed
 
+    def test_skips_when_provider_reports_no_gpu_nodes(self) -> None:
+        """The provider's no-GPU payload is an intentional framework skip."""
+        step_output = {
+            "success": True,
+            "skipped": True,
+            "skip_reason": "No GPU nodes detected; BFX04-01 is not applicable",
+            "agents_observable": True,
+            "agents": [],
+        }
+
+        with pytest.raises(pytest.skip.Exception, match="No GPU nodes detected"):
+            _run(NodeHealthAgentCheck, step_output)
+
+    def test_passes_when_each_reported_node_has_a_running_agent(self) -> None:
+        """Provider-neutral running records satisfy BFX04-01."""
+        step_output = {
+            "success": True,
+            "agents_observable": True,
+            "agents": [
+                {"node_id": "gpu-1", "agent_name": "fleet-intelligence-agent", "running": True},
+                {"node_id": "gpu-2", "agent_name": "gpu-health-monitor", "running": True},
+            ],
+        }
+        assert _run(NodeHealthAgentCheck, step_output).passed
+
+    def test_fails_when_any_reported_node_lacks_a_running_agent(self) -> None:
+        """One uncovered GPU node prevents a false partial-coverage pass."""
+        step_output = {
+            "success": True,
+            "agents_observable": True,
+            "agents": [
+                {"node_id": "gpu-1", "agent_name": "fleet-intelligence-agent", "running": True},
+                {"node_id": "gpu-2", "agent_name": "GPUd/Sentinel", "running": False},
+            ],
+        }
+        check = _run(NodeHealthAgentCheck, step_output)
+        assert not check.passed
+        assert "gpu-2" in check.message
+
 
 class TestCordonNodeCheck:
     """Cover the BFX01-04 cordon check."""


### PR DESCRIPTION
## Summary

- add read-only BFX04-01 validation for configured bare-metal GPU nodes
- verify Fleet Intelligence, GPUd, or NVSentinel through exact service state
- support Kubernetes DaemonSet and pod coverage without accepting generic telemetry
- emit provider-neutral node-health-agent evidence
- use the standard GB300 bare-metal provider configuration

## Validation

- focused provider and break-fix tests passed
- provider configuration and suite wiring validate
- full unit and demo suites passed
- read-only GB300 validation observed a supported health agent running and produced PASS
- Kubernetes negative-path validation correctly rejected environments without ready supported agent coverage

Closes #555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only health-agent checks for GPU nodes across bare-metal and Kubernetes environments.
  * Validates supported GPUd or NVSentinel agents for running, ready, and properly managed status.
  * Added structured results, clear failure reporting, and automatic skipping for clusters without GPU nodes.
  * Enabled the check for AWS EKS, Minikube, custom Kubernetes environments, and GB300 bare-metal systems.

* **Documentation**
  * Updated setup guidance for GB300 bare-metal validation.

* **Tests**
  * Added comprehensive coverage for agent status, node discovery, failures, skips, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->