### PR TITLE
feat(runai): add Run:AI compatibility kit suite

### DIFF
--- a/isvctl/configs/providers/shared/run_compatibility_kit.py
+++ b/isvctl/configs/providers/shared/run_compatibility_kit.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the Run:AI compatibility kit container against a Kubernetes cluster.
+
+The kit is a prebuilt Docker image published to NVIDIA NGC without guest
+access (its build clones a private E2E suite, so this script never builds
+it - point --image / RUNAI_COMPAT_KIT_IMAGE at the nvcr.io path or a locally
+loaded tag). Pulling an nvcr.io image logs in with NGC_API_KEY first; a
+locally present image needs no credentials. The kit runs as uid 65532 and cannot read a
+host-owned mode-0600 kubeconfig from a bind mount, so the kubeconfig is staged
+through a short-lived Docker volume with the runtime uid/mode - the same flow
+as the kit's own Makefile.
+
+The kit writes its artifacts (Allure report, CSV summary, log, results zip)
+into --results-dir. This script parses the Allure summary and the CSV into the
+provider-neutral JSON contract; pass/fail policy lives in the
+RunAICompatibilityCheck validation, not here.
+
+Modes:
+    (default)    stage kubeconfig, run the kit, parse results
+    --preflight  setup-phase probe: docker + kubeconfig present, image pullable
+    --cleanup    teardown-phase sweep: remove leftover container/volume
+
+Usage:
+    python run_compatibility_kit.py --results-dir ./runai-compatibility-results
+    python run_compatibility_kit.py --image runai/certification-kit:latest --timeout 3600
+    python run_compatibility_kit.py --preflight
+    python run_compatibility_kit.py --cleanup
+
+Output JSON (default mode):
+{
+    "success": true,
+    "platform": "k8s",
+    "test_name": "runai_compatibility",
+    "tests": {
+        "compatibility": {
+            "passed": false,
+            "message": "89/107 tests passed (1 failed, 0 broken, 17 skipped)",
+            "error": "Failed tests: Create distributed policy and verify its applied",
+            "failed_tests": ["Create distributed policy and verify its applied"]
+        }
+    }
+}
+
+`success` means the kit executed and produced results; the compatibility
+verdict is `tests.compatibility.passed`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_IMAGE = "nvcr.io/nvidia/runai/runai-compatibility-kit:latest"
+IMAGE_ENV_VAR = "RUNAI_COMPAT_KIT_IMAGE"
+NGC_REGISTRY = "nvcr.io"
+# The kit's own Makefile builds this local tag; point RUNAI_COMPAT_KIT_IMAGE at
+# it to run a locally built kit without touching NGC.
+LOCAL_MAKEFILE_TAG = "runai/certification-kit:latest"
+CONTAINER_NAME = "isv-runai-compatibility-kit"
+VOLUME_NAME = "isv-runai-compatibility-kit-kubeconfig"
+KIT_RESULTS_MOUNT = "/app/e2e/results"
+KIT_KUBE_DIR = "/home/runai/.kube"
+KIT_UID_GID = "65532:65532"
+SUMMARY_RELPATH = Path("allure-report") / "widgets" / "summary.json"
+CSV_RELPATH = Path("test-results-summary.csv")
+MAX_FAILED_NAMES = 10
+LOG_TAIL_CHARS = 2000
+
+
+def log(message: str) -> None:
+    """Progress/log line on stderr - stdout carries only the final JSON."""
+    print(message, file=sys.stderr)
+
+
+def run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+    """Run a docker CLI command, returning (exit_code, combined output)."""
+    proc = subprocess.run(
+        ["docker", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stdout or ""
+
+
+def docker_available() -> bool:
+    """Return whether a usable docker CLI + daemon is present."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        exit_code, _ = run_docker(["version"], timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return exit_code == 0
+
+
+def resolve_image(arg_value: str) -> str:
+    """Image precedence: --image arg > RUNAI_COMPAT_KIT_IMAGE env > default."""
+    return arg_value or os.environ.get(IMAGE_ENV_VAR, "") or DEFAULT_IMAGE
+
+
+def ngc_login(image: str) -> str | None:
+    """Log in to NGC when the image lives there. Returns an error, or None.
+
+    The kit publishes to NGC without guest access, so pulling needs an
+    authenticated docker login. The key goes over stdin, never argv.
+    """
+    if not image.startswith(f"{NGC_REGISTRY}/"):
+        return None
+    api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
+    if not api_key:
+        return f"image {image} is on {NGC_REGISTRY} but NGC_API_KEY is not set"
+    log(f"Logging in to {NGC_REGISTRY}...")
+    proc = subprocess.run(
+        ["docker", "login", NGC_REGISTRY, "-u", "$oauthtoken", "--password-stdin"],
+        input=api_key,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        return f"docker login {NGC_REGISTRY} failed: {(proc.stdout or '').strip()[-LOG_TAIL_CHARS:]}"
+    return None
+
+
+def ensure_image(image: str) -> str | None:
+    """Make the kit image locally available. Returns an error, or None.
+
+    A locally present image needs neither login nor pull, so a preloaded
+    runner works without NGC credentials.
+    """
+    exit_code, _ = run_docker(["image", "inspect", image], timeout=60)
+    if exit_code == 0:
+        return None
+    error = ngc_login(image)
+    if error:
+        return error
+    log(f"Image {image} not present locally, pulling...")
+    exit_code, output = run_docker(["pull", image], timeout=1800)
+    if exit_code != 0:
+        return f"image {image} is neither local nor pullable: {output.strip()[-LOG_TAIL_CHARS:]}"
+    return None
+
+
+def resolve_kubeconfig(arg_value: str) -> Path | None:
+    """Kubeconfig precedence: --kubeconfig arg > KUBECONFIG env > ~/.kube/config.
+
+    Returns the first candidate that exists, or None.
+    """
+    candidates = [arg_value, os.environ.get("KUBECONFIG", ""), "~/.kube/config"]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate).expanduser()
+        if path.is_file():
+            return path
+    return None
+
+
+def parse_summary(summary_text: str) -> dict[str, int]:
+    """Extract test counts from the Allure summary widget JSON.
+
+    Raises ValueError when the document does not carry the expected
+    ``statistic`` block.
+    """
+    try:
+        document = json.loads(summary_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"summary is not valid JSON: {exc}") from exc
+
+    statistic = document.get("statistic") if isinstance(document, dict) else None
+    if not isinstance(statistic, dict):
+        raise ValueError("summary has no 'statistic' block")
+
+    counts = {}
+    for key in ("passed", "failed", "broken", "skipped", "unknown", "total"):
+        value = statistic.get(key, 0)
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"summary statistic '{key}' is not an integer: {value!r}")
+        counts[key] = value
+    return counts
+
+
+def failed_test_names(csv_text: str) -> list[str]:
+    """Names of failed/broken tests from the kit CSV, deduplicated in order."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for row in csv.DictReader(io.StringIO(csv_text)):
+        name = (row.get("Test Name") or "").strip()
+        status = (row.get("Status") or "").strip().lower()
+        if name and status in ("failed", "broken") and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def build_compatibility(counts: dict[str, int], failed_names: list[str]) -> dict[str, Any]:
+    """Build the ``tests.compatibility`` contract block from parsed results."""
+    passed = counts["failed"] == 0 and counts["broken"] == 0 and counts["unknown"] == 0 and counts["passed"] > 0
+    message = (
+        f"{counts['passed']}/{counts['total']} tests passed "
+        f"({counts['failed']} failed, {counts['broken']} broken, {counts['skipped']} skipped)"
+    )
+    compatibility: dict[str, Any] = {"passed": passed, "message": message}
+    if not passed:
+        if failed_names:
+            shown = failed_names[:MAX_FAILED_NAMES]
+            error = "Failed tests: " + "; ".join(shown)
+            if len(failed_names) > len(shown):
+                error += f" ... and {len(failed_names) - len(shown)} more"
+            compatibility["failed_tests"] = shown
+        elif counts["passed"] == 0:
+            error = "no tests passed"
+        else:
+            error = message
+        compatibility["error"] = error
+    return compatibility
+
+
+def compatibility_from_results(results_dir: Path) -> dict[str, Any]:
+    """Parse the kit's results directory into the compatibility block.
+
+    Raises ValueError when the Allure summary is missing or malformed. A
+    missing CSV only costs the failed-test names, not the verdict.
+    """
+    summary_path = results_dir / SUMMARY_RELPATH
+    if not summary_path.is_file():
+        raise ValueError(f"kit produced no Allure summary at {summary_path}")
+    counts = parse_summary(summary_path.read_text())
+
+    csv_path = results_dir / CSV_RELPATH
+    names: list[str] = []
+    if csv_path.is_file():
+        try:
+            names = failed_test_names(csv_path.read_text())
+        except csv.Error as exc:
+            log(f"Could not parse {csv_path.name}: {exc}")
+    return build_compatibility(counts, names)
+
+
+def remove_leftovers() -> list[str]:
+    """Best-effort removal of the kit container and kubeconfig volume."""
+    removed = []
+    exit_code, _ = run_docker(["rm", "-f", CONTAINER_NAME], timeout=60)
+    if exit_code == 0:
+        removed.append(f"container {CONTAINER_NAME}")
+    exit_code, _ = run_docker(["volume", "rm", VOLUME_NAME], timeout=60)
+    if exit_code == 0:
+        removed.append(f"volume {VOLUME_NAME}")
+    return removed
+
+
+def stage_kubeconfig(image: str, kubeconfig: Path) -> None:
+    """Copy the kubeconfig into a volume owned by the kit's runtime uid.
+
+    Raises RuntimeError with the docker output on failure.
+    """
+    exit_code, output = run_docker(["volume", "create", VOLUME_NAME], timeout=60)
+    if exit_code != 0:
+        raise RuntimeError(f"docker volume create failed: {output.strip()}")
+
+    exit_code, output = run_docker(
+        [
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "--entrypoint",
+            "/bin/bash",
+            "-v",
+            f"{kubeconfig}:/source/config:ro",
+            "--mount",
+            f"type=volume,source={VOLUME_NAME},target={KIT_KUBE_DIR}",
+            image,
+            "-ec",
+            f"cp /source/config {KIT_KUBE_DIR}/config"
+            f" && chown {KIT_UID_GID} {KIT_KUBE_DIR}/config"
+            f" && chmod 0600 {KIT_KUBE_DIR}/config",
+        ],
+        timeout=300,
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"kubeconfig staging failed: {output.strip()[-LOG_TAIL_CHARS:]}")
+
+
+def run_kit(image: str, results_dir: Path, timeout: int) -> tuple[int, str]:
+    """Run the kit container. On timeout, force-remove it and re-raise."""
+    try:
+        return run_docker(
+            [
+                "run",
+                "--rm",
+                "--name",
+                CONTAINER_NAME,
+                "-v",
+                f"{results_dir}:{KIT_RESULTS_MOUNT}",
+                "--mount",
+                f"type=volume,source={VOLUME_NAME},target={KIT_KUBE_DIR}",
+                image,
+            ],
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        run_docker(["rm", "-f", CONTAINER_NAME], timeout=60)
+        raise
+
+
+def skipped_result(result: dict[str, Any], reason: str) -> dict[str, Any]:
+    """Mark the contract as skipped (validations then skip, not fail)."""
+    log(f"Skipping: {reason}")
+    result["success"] = True
+    result["skipped"] = True
+    result["skip_reason"] = reason
+    return result
+
+
+def run_preflight(args: argparse.Namespace) -> dict[str, Any]:
+    """Setup-phase probe: docker usable, kubeconfig present, image available."""
+    image = resolve_image(args.image)
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "k8s",
+        "test_name": "runai_compatibility_preflight",
+        "image": image,
+    }
+
+    if not docker_available():
+        return skipped_result(result, "docker is not available on this host")
+    if resolve_kubeconfig(args.kubeconfig) is None:
+        return skipped_result(result, "no kubeconfig found (set --kubeconfig or KUBECONFIG)")
+
+    error = ensure_image(image)
+    if error:
+        result["error"] = error
+        return result
+
+    result["success"] = True
+    return result
+
+
+def run_cleanup() -> dict[str, Any]:
+    """Teardown-phase sweep for leftovers from an aborted run."""
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "k8s",
+        "test_name": "runai_compatibility_cleanup",
+    }
+    if not docker_available():
+        return skipped_result(result, "docker is not available on this host")
+    removed = remove_leftovers()
+    log("Removed: " + (", ".join(removed) if removed else "nothing to clean up"))
+    result["success"] = True
+    return result
+
+
+def run_compatibility(args: argparse.Namespace) -> dict[str, Any]:
+    """Default mode: stage kubeconfig, run the kit, parse its results."""
+    image = resolve_image(args.image)
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "k8s",
+        "test_name": "runai_compatibility",
+        "tests": {},
+    }
+
+    if not docker_available():
+        return skipped_result(result, "docker is not available on this host")
+    kubeconfig = resolve_kubeconfig(args.kubeconfig)
+    if kubeconfig is None:
+        return skipped_result(result, "no kubeconfig found (set --kubeconfig or KUBECONFIG)")
+
+    results_dir = Path(args.results_dir).expanduser().resolve()
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    remove_leftovers()  # a previous aborted run must not collide on fixed names
+    try:
+        # Preflight normally did this already; standalone runs get the same
+        # NGC-login-then-pull path instead of an unauthenticated docker run pull.
+        error = ensure_image(image)
+        if error:
+            raise RuntimeError(error)
+
+        log(f"Staging kubeconfig {kubeconfig} for the kit runtime user...")
+        stage_kubeconfig(image, kubeconfig)
+
+        log(f"Running {image} (timeout: {args.timeout}s, results: {results_dir})...")
+        _exit_code, output = run_kit(image, results_dir, args.timeout)
+        tail = output.strip()[-LOG_TAIL_CHARS:]
+        if tail:
+            log(f"Kit output (tail):\n{tail}")
+
+        # Playwright exits non-zero on test failures, so the container exit
+        # code cannot distinguish "kit broke" from "tests failed". The parsed
+        # summary is the signal: present means the kit ran to reporting.
+        result["tests"]["compatibility"] = compatibility_from_results(results_dir)
+        result["success"] = True
+        log(f"Compatibility artifacts (Allure report, results package) in {results_dir}")
+    except subprocess.TimeoutExpired:
+        result["error"] = f"compatibility kit did not finish within {args.timeout}s"
+        result["error_type"] = "timeout"
+    except (RuntimeError, ValueError, OSError) as exc:
+        result["error"] = str(exc)
+    finally:
+        run_docker(["volume", "rm", VOLUME_NAME], timeout=60)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the Run:AI compatibility kit container")
+    parser.add_argument("--image", default="", help=f"Kit image (default: ${IMAGE_ENV_VAR} or {DEFAULT_IMAGE})")
+    parser.add_argument("--kubeconfig", default="", help="Kubeconfig path (default: $KUBECONFIG or ~/.kube/config)")
+    parser.add_argument(
+        "--results-dir",
+        default="runai-compatibility-results",
+        help="Host directory the kit writes its artifacts into",
+    )
+    parser.add_argument("--timeout", type=int, default=3600, help="Seconds to allow the kit container to run")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--preflight", action="store_true", help="Only check docker/kubeconfig/image availability")
+    mode.add_argument("--cleanup", action="store_true", help="Only remove leftover kit container/volume")
+    args = parser.parse_args()
+
+    if args.preflight:
+        result = run_preflight(args)
+    elif args.cleanup:
+        result = run_cleanup()
+    else:
+        result = run_compatibility(args)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -310,6 +310,24 @@ Validations use `kubectl` directly (or a custom CLI via the `KUBECTL` env var): 
 
 Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job scheduling.
 
+### Run:AI (`runai.yaml`)
+
+| Step | Phase | Script | Key JSON Fields |
+|------|-------|--------|-----------------|
+| `preflight_compatibility_kit` | setup | `providers/shared/run_compatibility_kit.py --preflight` | `image` |
+| `run_compatibility_kit` | test | `providers/shared/run_compatibility_kit.py` | `tests.compatibility.{passed,message,error,failed_tests}` |
+| `cleanup_compatibility_kit` | teardown | `providers/shared/run_compatibility_kit.py --cleanup` | — |
+
+Runs the prebuilt Run:AI compatibility kit container (its own E2E suite) against
+the cluster the kubeconfig points at, then asserts the kit's verdict. Needs a
+docker CLI and a kubeconfig on the isvctl host; both steps report skipped when
+either is missing. The kit publishes to NVIDIA NGC without guest access: the
+default image `nvcr.io/nvidia/runai/runai-compatibility-kit:latest` pull
+authenticates with `NGC_API_KEY`; override via `RUNAI_COMPAT_KIT_IMAGE`, e.g.
+with a locally built `runai/certification-kit:latest` (no credentials needed).
+The kit's artifact package (Allure report, CSV, submission zip) lands in the
+`kit_results_dir` setting.
+
 ### Control Plane (`control-plane.yaml`)
 
 | Step | Phase | Script | Key JSON Fields |

--- a/isvctl/configs/suites/runai.yaml
+++ b/isvctl/configs/suites/runai.yaml
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run:AI Compatibility Kit Validation
+#
+# Runs the Run:AI compatibility kit - a prebuilt Docker image whose entrypoint
+# executes the Run:AI E2E compatibility suite against the Kubernetes cluster
+# the kubeconfig points at - and validates its verdict.
+#
+# The kit image is NOT built here (its build clones a private E2E repo); it
+# is published to NVIDIA NGC without guest access. The default image is
+# nvcr.io/nvidia/runai/runai-compatibility-kit:latest and pulling it
+# authenticates with NGC_API_KEY; set RUNAI_COMPAT_KIT_IMAGE to override,
+# e.g. to the kit Makefile's locally built runai/certification-kit:latest
+# (a local image needs no credentials). The kubeconfig comes from KUBECONFIG
+# or ~/.kube/config.
+#
+# The commands are provider-agnostic: they need only a docker CLI and a
+# kubeconfig on the machine running isvctl. When docker or the kubeconfig is
+# missing, the steps report skipped and the validation skips rather than fails.
+#
+# Steps:
+#   SETUP
+#     1. preflight_compatibility_kit - docker + kubeconfig present, image pullable
+#   TEST
+#     2. run_compatibility_kit - stage kubeconfig, run the kit, parse results
+#   TEARDOWN
+#     3. cleanup_compatibility_kit - remove leftover container/volume (best effort)
+#
+# The kit writes its full artifact package (Allure HTML report, CSV summary,
+# run log, submission zip) into the kit_results_dir on the host.
+#
+# Usage:
+#   uv run isvctl test run -f isvctl/configs/suites/runai.yaml
+#   RUNAI_COMPAT_KIT_IMAGE=runai/certification-kit:latest \
+#     uv run isvctl test run -f isvctl/configs/suites/runai.yaml
+
+version: "1.0"
+
+commands:
+  # Key must match tests.capability - the orchestrator resolves the command
+  # group for the declared capability.
+  kubernetes:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      # Image and kubeconfig come from the environment (RUNAI_COMPAT_KIT_IMAGE,
+      # KUBECONFIG), not args: an empty templated arg value would be dropped
+      # and desync the flag list. Direct script runs may use --image/--kubeconfig.
+      - name: preflight_compatibility_kit
+        phase: setup
+        command: "python ../providers/shared/run_compatibility_kit.py"
+        args: ["--preflight"]
+        timeout: 1900
+        requires_available_validations: ["RunAICompatibilityCheck"]
+
+      - name: run_compatibility_kit
+        phase: test
+        command: "python ../providers/shared/run_compatibility_kit.py"
+        args: ["--results-dir", "{{kit_results_dir}}", "--timeout", "{{kit_timeout}}"]
+        # Step timeout leaves headroom over the script's own --timeout, which
+        # force-removes the container on expiry; an orchestrator kill would
+        # leave it running for the teardown sweep to catch.
+        timeout: 4500
+        requires_available_validations: ["RunAICompatibilityCheck"]
+
+      - name: cleanup_compatibility_kit
+        phase: teardown
+        command: "python ../providers/shared/run_compatibility_kit.py"
+        args: ["--cleanup"]
+        timeout: 120
+        continue_on_failure: true
+
+tests:
+  capability: kubernetes
+  cluster_name: "runai-compatibility"
+  description: "Run:AI compatibility kit validation"
+
+  settings:
+    show_skipped_tests: false
+    kit_results_dir: "runai-compatibility-results"
+    kit_timeout: "3600"
+
+  validations:
+    compatibility:
+      step: run_compatibility_kit
+      checks:
+        RunAICompatibilityCheck:
+          test_id: "N/A"
+          labels: ["runai", "kubernetes", "workload", "slow"]
+
+  exclude:
+    labels: []

--- a/isvctl/src/isvctl/config/env_catalog.py
+++ b/isvctl/src/isvctl/config/env_catalog.py
@@ -195,6 +195,13 @@ ENV_VARS: tuple[EnvVar, ...] = (
         Requirement.OPTIONAL,
         "optional OIDC scope for NICo client_credentials auth",
     ),
+    # Run:AI compatibility kit (suites/runai.yaml)
+    EnvVar(
+        "RUNAI_COMPAT_KIT_IMAGE",
+        "Run:AI",
+        Requirement.OPTIONAL,
+        "Run:AI compatibility kit image (default nvcr.io/nvidia/runai/runai-compatibility-kit:latest)",
+    ),
 )
 
 
@@ -229,6 +236,7 @@ SECTIONS: tuple[Section, ...] = (
     Section("ngc", "NGC", "NGC_"),
     Section("aws", "AWS", "AWS_"),
     Section("nico", "NICo", "NICO_"),
+    Section("runai", "Run:AI", "RUNAI_"),
 )
 
 _GROUP_TO_SECTION: dict[str, Section] = {s.group: s for s in SECTIONS}

--- a/isvtest/src/isvtest/validations/runai.py
+++ b/isvtest/src/isvtest/validations/runai.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run:AI compatibility kit validations.
+
+Assertions over the JSON contract emitted by the shared
+``run_compatibility_kit.py`` step script, which runs the Run:AI compatibility
+kit container against the target Kubernetes cluster.
+"""
+
+from typing import ClassVar
+
+from isvtest.core.validation import BaseValidation, check_required_tests
+
+
+class RunAICompatibilityCheck(BaseValidation):
+    """Validate the Run:AI compatibility kit suite passed on the cluster.
+
+    Config:
+        step_output: Output of the run_compatibility_kit step
+
+    Step output:
+        tests.compatibility.passed: Overall kit verdict (no failed/broken tests)
+        tests.compatibility.message: Pass/fail/skip counts summary
+        tests.compatibility.error: Failure detail incl. failed test names
+    """
+
+    description: ClassVar[str] = "Check the Run:AI compatibility kit test suite passed on the cluster"
+
+    def run(self) -> None:
+        if not check_required_tests(self, ["compatibility"], "Run:AI compatibility failed"):
+            return
+        compatibility = self.config.get("step_output", {}).get("tests", {}).get("compatibility", {})
+        self.set_passed(compatibility.get("message") or "Run:AI compatibility passed")

--- a/isvtest/tests/test_runai.py
+++ b/isvtest/tests/test_runai.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Run:AI compatibility kit validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isvtest.validations.runai import RunAICompatibilityCheck
+
+
+def _kit_output(**compatibility_overrides: Any) -> dict[str, Any]:
+    """Build a passing run_compatibility_kit step output."""
+    compatibility: dict[str, Any] = {
+        "passed": True,
+        "message": "89/106 tests passed (0 failed, 0 broken, 17 skipped)",
+    }
+    compatibility.update(compatibility_overrides)
+    return {
+        "success": True,
+        "platform": "k8s",
+        "test_name": "runai_compatibility",
+        "tests": {"compatibility": compatibility},
+    }
+
+
+def _run_check(step_output: dict[str, Any]) -> dict[str, Any]:
+    return RunAICompatibilityCheck(config={"step_output": step_output}).execute()
+
+
+def test_compatibility_check_passes_with_summary_message() -> None:
+    result = _run_check(_kit_output())
+
+    assert result["passed"] is True
+    assert result["output"] == "89/106 tests passed (0 failed, 0 broken, 17 skipped)"
+
+
+def test_compatibility_check_fails_with_kit_error_detail() -> None:
+    result = _run_check(
+        _kit_output(
+            passed=False,
+            error="Failed tests: Create distributed policy and verify its applied",
+        )
+    )
+
+    assert result["passed"] is False
+    assert "Run:AI compatibility failed" in result["error"]
+    assert "Create distributed policy" in result["error"]
+
+
+def test_compatibility_check_fails_without_tests_block() -> None:
+    result = _run_check({"success": True, "platform": "k8s"})
+
+    assert result["passed"] is False
+    assert "No 'tests' in step output" in result["error"]
+
+
+def test_compatibility_check_fails_when_compatibility_missing() -> None:
+    result = _run_check({"success": True, "platform": "k8s", "tests": {"other": {"passed": True}}})
+
+    assert result["passed"] is False
+    assert "compatibility" in result["error"]

--- a/scripts/tests/test_run_compatibility_kit.py
+++ b/scripts/tests/test_run_compatibility_kit.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for providers/shared/run_compatibility_kit.py.
+
+Cover the results parsing (Allure summary + CSV -> contract JSON) and the
+mode flows with the docker CLI mocked out - no docker daemon needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "isvctl" / "configs" / "providers" / "shared" / "run_compatibility_kit.py"
+)
+_spec = importlib.util.spec_from_file_location("run_compatibility_kit", _SCRIPT_PATH)
+assert _spec and _spec.loader
+kit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kit)
+
+
+def _summary_text(passed: int = 89, failed: int = 1, broken: int = 0, skipped: int = 17, unknown: int = 0) -> str:
+    total = passed + failed + broken + skipped + unknown
+    return json.dumps(
+        {
+            "reportName": "Allure Report",
+            "statistic": {
+                "failed": failed,
+                "broken": broken,
+                "skipped": skipped,
+                "passed": passed,
+                "unknown": unknown,
+                "total": total,
+            },
+        }
+    )
+
+
+CSV_TEXT = (
+    "Test Name,Status,Duration (ms),Tags,Error Details\n"
+    '"should create access key","passed","2007",""\n'
+    '"Create distributed policy and verify its applied","failed","1915",""\n'
+    '"Create distributed policy and verify its applied","failed","1911",""\n'
+    '"creates a workload with nfs","skipped","0",""\n'
+    '"flaky infra test","broken","10",""\n'
+)
+
+
+# ─── parse_summary ───────────────────────────────────────────────────
+
+
+def test_parse_summary_extracts_counts() -> None:
+    counts = kit.parse_summary(_summary_text())
+    assert counts == {"passed": 89, "failed": 1, "broken": 0, "skipped": 17, "unknown": 0, "total": 107}
+
+
+def test_parse_summary_rejects_invalid_json() -> None:
+    with pytest.raises(ValueError, match="not valid JSON"):
+        kit.parse_summary("<html>not json</html>")
+
+
+def test_parse_summary_rejects_missing_statistic() -> None:
+    with pytest.raises(ValueError, match="no 'statistic'"):
+        kit.parse_summary(json.dumps({"reportName": "Allure Report"}))
+
+
+def test_parse_summary_rejects_non_integer_counts() -> None:
+    with pytest.raises(ValueError, match="'failed' is not an integer"):
+        kit.parse_summary(json.dumps({"statistic": {"failed": "one"}}))
+    with pytest.raises(ValueError, match="'failed' is not an integer"):
+        kit.parse_summary(json.dumps({"statistic": {"failed": True}}))
+
+
+# ─── failed_test_names ───────────────────────────────────────────────
+
+
+def test_failed_test_names_collects_failed_and_broken_deduplicated() -> None:
+    assert kit.failed_test_names(CSV_TEXT) == [
+        "Create distributed policy and verify its applied",
+        "flaky infra test",
+    ]
+
+
+def test_failed_test_names_empty_for_clean_csv() -> None:
+    clean = 'Test Name,Status,Duration (ms),Tags,Error Details\n"ok test","passed","1",""\n'
+    assert kit.failed_test_names(clean) == []
+    assert kit.failed_test_names("") == []
+
+
+# ─── build_compatibility ─────────────────────────────────────────────
+
+
+def test_build_compatibility_passes_when_nothing_failed() -> None:
+    counts = {"passed": 89, "failed": 0, "broken": 0, "skipped": 17, "unknown": 0, "total": 106}
+    compatibility = kit.build_compatibility(counts, [])
+    assert compatibility["passed"] is True
+    assert compatibility["message"] == "89/106 tests passed (0 failed, 0 broken, 17 skipped)"
+    assert "error" not in compatibility
+
+
+def test_build_compatibility_fails_with_failed_test_names() -> None:
+    counts = {"passed": 89, "failed": 1, "broken": 0, "skipped": 17, "unknown": 0, "total": 107}
+    compatibility = kit.build_compatibility(counts, ["Create distributed policy and verify its applied"])
+    assert compatibility["passed"] is False
+    assert compatibility["error"] == "Failed tests: Create distributed policy and verify its applied"
+    assert compatibility["failed_tests"] == ["Create distributed policy and verify its applied"]
+
+
+def test_build_compatibility_caps_failed_test_names() -> None:
+    counts = {"passed": 0, "failed": 15, "broken": 0, "skipped": 0, "unknown": 0, "total": 15}
+    compatibility = kit.build_compatibility(counts, [f"test {i}" for i in range(15)])
+    assert len(compatibility["failed_tests"]) == kit.MAX_FAILED_NAMES
+    assert "and 5 more" in compatibility["error"]
+
+
+def test_build_compatibility_fails_when_nothing_passed() -> None:
+    counts = {"passed": 0, "failed": 0, "broken": 0, "skipped": 5, "unknown": 0, "total": 5}
+    compatibility = kit.build_compatibility(counts, [])
+    assert compatibility["passed"] is False
+    assert compatibility["error"] == "no tests passed"
+
+
+def test_build_compatibility_fails_on_broken_or_unknown() -> None:
+    broken = {"passed": 10, "failed": 0, "broken": 2, "skipped": 0, "unknown": 0, "total": 12}
+    assert kit.build_compatibility(broken, [])["passed"] is False
+    unknown = {"passed": 10, "failed": 0, "broken": 0, "skipped": 0, "unknown": 1, "total": 11}
+    assert kit.build_compatibility(unknown, [])["passed"] is False
+
+
+# ─── compatibility_from_results ──────────────────────────────────────
+
+
+def _write_results(results_dir: Path, summary: str | None = None, csv_text: str | None = None) -> None:
+    if summary is not None:
+        summary_path = results_dir / kit.SUMMARY_RELPATH
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(summary)
+    if csv_text is not None:
+        (results_dir / kit.CSV_RELPATH).write_text(csv_text)
+
+
+def test_compatibility_from_results_parses_full_package(tmp_path: Path) -> None:
+    _write_results(tmp_path, summary=_summary_text(), csv_text=CSV_TEXT)
+    compatibility = kit.compatibility_from_results(tmp_path)
+    assert compatibility["passed"] is False
+    assert "Create distributed policy" in compatibility["error"]
+
+
+def test_compatibility_from_results_requires_summary(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no Allure summary"):
+        kit.compatibility_from_results(tmp_path)
+
+
+def test_compatibility_from_results_tolerates_missing_csv(tmp_path: Path) -> None:
+    _write_results(tmp_path, summary=_summary_text(passed=10, failed=0, skipped=0))
+    compatibility = kit.compatibility_from_results(tmp_path)
+    assert compatibility["passed"] is True
+
+
+# ─── resolution precedence ───────────────────────────────────────────
+
+
+def test_resolve_image_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(kit.IMAGE_ENV_VAR, raising=False)
+    assert kit.resolve_image("") == kit.DEFAULT_IMAGE
+    monkeypatch.setenv(kit.IMAGE_ENV_VAR, "registry/env-image:1")
+    assert kit.resolve_image("") == "registry/env-image:1"
+    assert kit.resolve_image("registry/arg-image:2") == "registry/arg-image:2"
+
+
+def test_resolve_kubeconfig_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    arg_config = tmp_path / "arg-config"
+    env_config = tmp_path / "env-config"
+    arg_config.write_text("apiVersion: v1")
+    env_config.write_text("apiVersion: v1")
+
+    monkeypatch.setenv("KUBECONFIG", str(env_config))
+    assert kit.resolve_kubeconfig(str(arg_config)) == arg_config
+    assert kit.resolve_kubeconfig("") == env_config
+    # A configured path that does not exist falls through to the next source.
+    assert kit.resolve_kubeconfig(str(tmp_path / "missing")) == env_config
+
+
+def test_resolve_kubeconfig_none_when_nothing_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KUBECONFIG", str(tmp_path / "missing"))
+    monkeypatch.setenv("HOME", str(tmp_path))  # ~/.kube/config resolves under tmp
+    assert kit.resolve_kubeconfig("") is None
+
+
+# ─── mode flows (docker mocked) ──────────────────────────────────────
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "image": "",
+        "kubeconfig": "",
+        "results_dir": "results",
+        "timeout": 60,
+        "preflight": False,
+        "cleanup": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_run_compatibility_skips_without_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(kit, "docker_available", lambda: False)
+    result = kit.run_compatibility(_args())
+    assert result["success"] is True
+    assert result["skipped"] is True
+    assert "docker" in result["skip_reason"]
+
+
+def test_run_compatibility_skips_without_kubeconfig(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "resolve_kubeconfig", lambda _arg: None)
+    result = kit.run_compatibility(_args())
+    assert result["success"] is True
+    assert result["skipped"] is True
+    assert "kubeconfig" in result["skip_reason"]
+
+
+def test_run_compatibility_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Docker calls all succeed and the kit leaves a parsable results package."""
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+    results_dir = tmp_path / "results"
+    docker_calls: list[list[str]] = []
+
+    def fake_run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+        docker_calls.append(args)
+        if args[:1] == ["run"] and "--name" in args:
+            # The kit run: emit the results package the parser reads back.
+            _write_results(results_dir, summary=_summary_text(passed=10, failed=0, skipped=0), csv_text="")
+        return 0, ""
+
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", fake_run_docker)
+
+    result = kit.run_compatibility(_args(kubeconfig=str(kubeconfig), results_dir=str(results_dir)))
+
+    assert result["success"] is True
+    assert result["tests"]["compatibility"]["passed"] is True
+    # The kubeconfig staging volume must be removed at the end of the run.
+    assert ["volume", "rm", kit.VOLUME_NAME] in docker_calls
+
+
+def test_run_compatibility_fails_when_summary_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The kit ran but left no Allure summary - the step must fail, not pass."""
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+
+    def fake_run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+        if args[:1] == ["run"] and "--name" in args:
+            return 1, "kit exploded"  # kit run fails and writes no results
+        return 0, ""
+
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", fake_run_docker)
+
+    result = kit.run_compatibility(_args(kubeconfig=str(kubeconfig), results_dir=str(tmp_path / "results")))
+
+    assert result["success"] is False
+    assert "no Allure summary" in result["error"]
+
+
+def test_run_compatibility_fails_when_staging_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+
+    def fake_run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+        if args[:2] == ["volume", "create"]:
+            return 1, "daemon down"
+        return 0, ""
+
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", fake_run_docker)
+
+    result = kit.run_compatibility(_args(kubeconfig=str(kubeconfig), results_dir=str(tmp_path / "results")))
+
+    assert result["success"] is False
+    assert "docker volume create failed" in result["error"]
+
+
+def test_run_compatibility_reports_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+
+    def fake_run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+        if args[:1] == ["run"] and "--name" in args:
+            raise subprocess.TimeoutExpired(cmd=["docker", *args], timeout=timeout or 0)
+        return 0, ""
+
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", fake_run_docker)
+
+    result = kit.run_compatibility(_args(kubeconfig=str(kubeconfig), results_dir=str(tmp_path / "results")))
+
+    assert result["success"] is False
+    assert result["error_type"] == "timeout"
+
+
+def test_run_preflight_pulls_missing_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+    docker_calls: list[list[str]] = []
+
+    def fake_run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+        docker_calls.append(args)
+        if args[:2] == ["image", "inspect"]:
+            return 1, "no such image"
+        return 0, ""
+
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", fake_run_docker)
+
+    result = kit.run_preflight(_args(image="registry/kit:1", kubeconfig=str(kubeconfig), preflight=True))
+
+    assert result["success"] is True
+    assert ["pull", "registry/kit:1"] in docker_calls
+
+
+def test_ngc_login_skipped_for_non_ngc_image() -> None:
+    assert kit.ngc_login("registry.example.com/kit:1") is None
+    assert kit.ngc_login(kit.LOCAL_MAKEFILE_TAG) is None
+
+
+def test_ngc_login_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv("NGC_NIM_API_KEY", raising=False)
+    error = kit.ngc_login(f"{kit.NGC_REGISTRY}/org/kit:1")
+    assert error is not None
+    assert "NGC_API_KEY" in error
+
+
+def test_ngc_login_sends_key_over_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NGC_API_KEY", "nvapi-secret")
+    calls: list[dict[str, Any]] = []
+
+    def fake_subprocess_run(cmd: list[str], **kwargs: Any) -> Any:
+        calls.append({"cmd": cmd, "input": kwargs.get("input")})
+
+        class _Proc:
+            returncode = 0
+            stdout = "Login Succeeded"
+
+        return _Proc()
+
+    monkeypatch.setattr(kit.subprocess, "run", fake_subprocess_run)
+
+    assert kit.ngc_login(f"{kit.NGC_REGISTRY}/org/kit:1") is None
+    assert calls[0]["cmd"][:3] == ["docker", "login", kit.NGC_REGISTRY]
+    assert "--password-stdin" in calls[0]["cmd"]
+    assert calls[0]["input"] == "nvapi-secret"
+    # The key must never appear in argv (visible in the process table).
+    assert "nvapi-secret" not in calls[0]["cmd"]
+
+
+def test_ensure_image_short_circuits_when_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    docker_calls: list[list[str]] = []
+
+    def fake_run_docker(args: list[str], timeout: int | None = None) -> tuple[int, str]:
+        docker_calls.append(args)
+        return 0, ""
+
+    monkeypatch.setattr(kit, "run_docker", fake_run_docker)
+
+    assert kit.ensure_image(f"{kit.NGC_REGISTRY}/org/kit:1") is None
+    assert docker_calls == [["image", "inspect", f"{kit.NGC_REGISTRY}/org/kit:1"]]
+
+
+def test_ensure_image_fails_for_ngc_image_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv("NGC_NIM_API_KEY", raising=False)
+    monkeypatch.setattr(kit, "run_docker", lambda args, timeout=None: (1, "no such image"))
+
+    error = kit.ensure_image(f"{kit.NGC_REGISTRY}/org/kit:1")
+    assert error is not None
+    assert "NGC_API_KEY" in error
+
+
+def test_run_preflight_fails_when_image_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", lambda args, timeout=None: (1, "denied"))
+
+    # Non-NGC image: exercises the pull-failure branch without a login attempt.
+    result = kit.run_preflight(_args(image="registry.example.com/kit:1", kubeconfig=str(kubeconfig), preflight=True))
+
+    assert result["success"] is False
+    assert "neither local nor pullable" in result["error"]
+
+
+def test_run_preflight_default_image_needs_ngc_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default image lives on NGC, so pulling it without a key must fail clearly."""
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1")
+
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv("NGC_NIM_API_KEY", raising=False)
+    monkeypatch.delenv(kit.IMAGE_ENV_VAR, raising=False)
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", lambda args, timeout=None: (1, "no such image"))
+
+    result = kit.run_preflight(_args(kubeconfig=str(kubeconfig), preflight=True))
+
+    assert result["success"] is False
+    assert "NGC_API_KEY" in result["error"]
+
+
+def test_run_cleanup_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(kit, "docker_available", lambda: True)
+    monkeypatch.setattr(kit, "run_docker", lambda args, timeout=None: (0, ""))
+    result = kit.run_cleanup()
+    assert result["success"] is True
+
+
+def test_run_cleanup_skips_without_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(kit, "docker_available", lambda: False)
+    result = kit.run_cleanup()
+    assert result["success"] is True
+    assert result["skipped"] is True


### PR DESCRIPTION
## Summary

Integrates the **Run:AI compatibility kit** — a prebuilt Docker image whose entrypoint runs the Run:AI E2E test suite against a Kubernetes cluster — into the step-based validation framework. The kit is the *script that does the work*; isvctl orchestrates it and asserts its verdict:

```text
suites/runai.yaml → run_compatibility_kit.py (docker) → JSON contract → RunAICompatibilityCheck
```

## What's in here

- **`providers/shared/run_compatibility_kit.py`** — stages the kubeconfig into a uid-65532 Docker volume (mirroring the kit's own Makefile flow, since the kit runtime can't read a host-owned mode-0600 bind mount), runs the kit, and parses its Allure summary + CSV into the provider-neutral contract (`tests.compatibility.{passed,message,error,failed_tests}`). Modes:
  - `--preflight` (setup): docker + kubeconfig present, image available (NGC login + pull if needed)
  - default (test): stage kubeconfig → run kit → parse results
  - `--cleanup` (teardown): best-effort sweep of leftover container/volume from aborted runs
- **`suites/runai.yaml`** — kubernetes-capability suite wiring the three steps and the validation. Steps are gated with `requires_available_validations` so the expensive docker run never happens while the check is unreleased.
- **`isvtest/validations/runai.py`** — `RunAICompatibilityCheck`, asserting the kit verdict and surfacing failed-test names.
- **`env_catalog`** — registers `RUNAI_COMPAT_KIT_IMAGE` (Run:AI section) for `isvctl configure` / `doctor`.

## Design notes

- **The kit image is never built here.** Its build clones the private `run-ai/runai-e2e-internal` repo; it publishes to NVIDIA NGC without guest access. Default image: `nvcr.io/nvidia/runai/runai-compatibility-kit:latest`. Pulling from nvcr.io authenticates via `docker login` with `NGC_API_KEY` (key passed over stdin, never argv). A locally preloaded image (e.g. the kit Makefile's `runai/certification-kit:latest`) needs no credentials.
- **Container exit code is not the verdict** — Playwright exits non-zero on test failures, so the parsed Allure summary is the signal; pass/fail policy lives in the validation, not the script.
- **Skip, not fail**, when docker or a kubeconfig is missing (matches `deploy_nim.py` semantics; merged multi-suite runs stay green).
- The new check **ships unreleased** — `released_tests.json` untouched; run with `ISVTEST_INCLUDE_UNRELEASED=1` until the release process lands it.

## Testing

- 37 unit tests (`scripts/tests/test_run_compatibility_kit.py`, `isvtest/tests/test_runai.py`): parsing, verdict edge cases (broken/unknown/all-skipped), image/kubeconfig resolution precedence, NGC login (incl. key-never-in-argv), all three mode flows with docker mocked.
- `make test` (151 passed), `make lint`, `make demo-test`, `uvx pre-commit run -a`, suite wiring validator — all green.
- **Full E2E against the real kit image layers**: built a fake-entrypoint variant of the local `runai/certification-kit:latest` (same uid, same `/bin/bash` staging path, asserts the kubeconfig actually landed in the volume) and ran the suite end to end:
  ```text
  [PASS] SETUP   : preflight_compatibility_kit: passed
  [PASS] TEST    : run_compatibility_kit: passed
    [compatibility] RunAICompatibilityCheck: PASSED - 5/7 tests passed (0 failed, 0 broken, 2 skipped)
  [PASS] TEARDOWN: cleanup_compatibility_kit: passed
  ```
  Zero leftover containers/volumes after the run. Also verified the no-kubeconfig skip path and the unreleased-gating path (steps skip, no docker invoked).

## Open item

⚠️ The kit repo's `artifact-metadata.json` still says `service_name: runai-certification-kit` — if the publish pipeline derives the NGC image name from it, the published path will be `...runai-certification-kit`, not the `...runai-compatibility-kit` default used here. Needs the rename on the kit side (or a default bump here) before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)