### PR TITLE
fix(security): shell-quote NGC API key and sandbox Jinja2 templates

### DIFF
--- a/isvctl/configs/providers/shared/deploy_nim.py
+++ b/isvctl/configs/providers/shared/deploy_nim.py
@@ -46,6 +46,7 @@ Requires: paramiko
 import argparse
 import json
 import os
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -111,7 +112,7 @@ def main() -> int:
         print("Logging in to NGC registry...", file=sys.stderr)
         exit_code, _, stderr_out = run_cmd(
             ssh,
-            f"echo '{args.ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
+            f"echo {shlex.quote(args.ngc_api_key)} | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
         )
         if exit_code != 0:
             result["error"] = f"NGC login failed: {stderr_out}"
@@ -128,7 +129,7 @@ def main() -> int:
             f"docker run -d --gpus all"
             f" --name {args.container_name}"
             f" -p {args.port}:8000"
-            f" -e NGC_API_KEY='{args.ngc_api_key}'"  # NIM container expects NGC_API_KEY
+            f" -e NGC_API_KEY={shlex.quote(args.ngc_api_key)}"  # NIM container expects NGC_API_KEY
             f" {image}"
         )
         exit_code, stdout, stderr_out = run_cmd(ssh, docker_cmd, timeout=1200)

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -27,13 +27,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 from isvtest.config.loader import _ternary
-from jinja2 import ChainableUndefined, Environment
+from jinja2 import ChainableUndefined
+from jinja2.sandbox import SandboxedEnvironment
 
 from isvctl.config.schema import CommandOutput, RunConfig
 from isvctl.redaction import filter_env
 
 
-def _create_jinja_env() -> Environment:
+def _create_jinja_env() -> SandboxedEnvironment:
     """Create Jinja2 environment with custom filters.
 
     Uses ChainableUndefined so that chained attribute access on missing
@@ -41,10 +42,15 @@ def _create_jinja_env() -> Environment:
     returns Undefined instead of raising UndefinedError.  This lets the
     ``| default()`` filter work even when a step has not yet run or failed.
 
+    Uses SandboxedEnvironment so that templates in user-supplied YAML
+    configs cannot reach dangerous attributes (e.g. ``__class__.__mro__``
+    chains) even though the rendered output is only used as command
+    arguments.
+
     Returns:
-        Configured Jinja2 Environment
+        Configured Jinja2 SandboxedEnvironment
     """
-    env = Environment(undefined=ChainableUndefined)
+    env = SandboxedEnvironment(undefined=ChainableUndefined)
     env.filters["tojson"] = lambda x: json.dumps(x)
     env.filters["ternary"] = _ternary
     return env


### PR DESCRIPTION
## Summary
- `deploy_nim.py`: `args.ngc_api_key` was interpolated into single-quoted shell commands without escaping (docker login, docker run -e NGC_API_KEY=...). A key containing a single quote could break out and run arbitrary commands on the remote SSH host. Now wrapped with `shlex.quote()`.
- `isvctl/orchestrator/context.py`: the Jinja2 `Environment` used for YAML-config templating was unsandboxed, allowing templates to potentially reach dangerous object attributes (`__class__.__mro__` chains). Switched to `jinja2.sandbox.SandboxedEnvironment`.

## Test plan
- [x] `uv run pytest isvctl/tests -k "context or jinja"` — 14 passed
- [x] Manual sandbox check: `{{ x.__class__.__mro__ }}` renders to an empty string (blocked) instead of leaking the MRO chain
- [x] `uv run python -m py_compile isvctl/configs/providers/shared/deploy_nim.py`
- [x] `uvx ruff check` on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when handling API keys during container deployment.
  * Enhanced template processing to prevent unsafe access while preserving support for missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->