### PR TITLE
feat(breakfix): implement BFX01-01 as a provider repair-API test

### DIFF
--- a/docs/requirements/test-requirements-matrix.adoc
+++ b/docs/requirements/test-requirements-matrix.adoc
@@ -1437,7 +1437,7 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | [[BFX01-01]]BFX01-01
 | Infrastructure and Data Services
 | Break-Fix
-| Reset GPUs on an individual node via the Breakfix API
+| Report a GPU fault via the Breakfix API; verify the node enters a repair state
 | BFX01
 | offtake
 | full

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -311,7 +311,7 @@ a|
 | pending
 |
 
-.142+| Infrastructure and Data Services
+.143+| Infrastructure and Data Services
 .9+| Control Plane accessible
 .9+| Control plane can be accessed
 .9+|
@@ -2183,13 +2183,13 @@ a|
 | approved
 |
 
-.14+| Break-Fix
+.15+| Break-Fix
 .3+| A break-fix service works with a variety of components to detect, triage, remediate, and validate nodes in an AI factory. The critical focus here is on the GPU nodes, but the system can scale beyond.
 .3+| Lazarus, Shoreline
 | [[BFX04-01]]BFX04-01
 | BFX04
 |
-|
+| bare_metal, breakfix
 |
 | P1
 a|
@@ -2203,7 +2203,7 @@ a|
 | [[BFX05-01]]BFX05-01
 | BFX05
 |
-|
+| bare_metal, breakfix
 |
 |
 a|
@@ -2217,7 +2217,7 @@ a|
 | [[BFX06-01]]BFX06-01
 | BFX06
 |
-|
+| bare_metal, breakfix
 |
 |
 a|
@@ -2228,26 +2228,26 @@ a|
 | approved
 |
 
-.5+| Breakfix API Lifecycle
-.5+|
+.6+| Breakfix API Lifecycle
+.6+|
 | [[BFX01-01]]BFX01-01
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
-| min_req
-|
+| bare_metal, breakfix, min_req
+| Provider break-fix APIs expose no on-demand GPU reset; the tenant-observable contract is that a reported GPU fault is accepted and moves the node into repair. The tenant-side in-cluster reset is BFX01-06.
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
 |
 | M5
 |
-| Reset GPUs on an individual node via the Breakfix API
+| Report a GPU fault via the Breakfix API; verify the node enters a repair state
 | pending
 |
 
 | [[BFX01-02]]BFX01-02
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
@@ -2261,7 +2261,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
 | [[BFX01-03]]BFX01-03
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
@@ -2275,7 +2275,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
 | [[BFX01-04]]BFX01-04
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
-| min_req
+| breakfix, kubernetes, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
@@ -2289,7 +2289,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
 | [[BFX01-05]]BFX01-05
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
@@ -2300,12 +2300,26 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
 | pending
 |
 
+| [[BFX01-06]]BFX01-06
+| BFX01
+|
+| breakfix, kubernetes, min_req
+| Exercises the tenant's own node access (privileged DaemonSet / SSH), not a provider capability. Passes wherever the tenant has root and a working nvidia-smi, so it asserts nothing about the provider. The API-based test is BFX01-01.
+| P2
+a|
+|
+| M5
+|
+| Reset GPUs on a node from inside the cluster (tenant-side, no provider API)
+| pending
+|
+
 .3+| Breakfix Events Query
 .3+|
 | [[BFX02-01]]BFX02-01
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
@@ -2319,7 +2333,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
 | [[BFX02-02]]BFX02-02
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
@@ -2333,7 +2347,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
 | [[BFX02-03]]BFX02-03
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
@@ -2363,7 +2377,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
 | [[BFX03-02]]BFX03-02
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
@@ -2377,7 +2391,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
 | [[BFX03-03]]BFX03-03
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2035,14 +2035,14 @@ domains:
                 milestone: ""
           - description: Breakfix API Lifecycle
             tests:
-              - summary: Reset GPUs on an individual node via the Breakfix API
+              - summary: Report a GPU fault via the Breakfix API; verify the node enters a repair state
                 labels:
+                  - bare_metal
                   - breakfix
-                  - kubernetes
                   - min_req
                 priority: P2
                 milestone: M5
-                notes: ""
+                notes: Provider break-fix APIs expose no on-demand GPU reset; the tenant-observable contract is that a reported GPU fault is accepted and moves the node into repair. The tenant-side in-cluster reset is BFX01-06.
                 github_issues:
                   - "#206"
                 req_id: BFX01
@@ -2099,6 +2099,18 @@ domains:
                   - "#210"
                 req_id: BFX01
                 test_id: BFX01-05
+                status: pending
+              - summary: Reset GPUs on a node from inside the cluster (tenant-side, no provider API)
+                labels:
+                  - breakfix
+                  - kubernetes
+                  - min_req
+                priority: P2
+                milestone: M5
+                notes: Exercises the tenant's own node access (privileged DaemonSet / SSH), not a provider capability. Passes wherever the tenant has root and a working nvidia-smi, so it asserts nothing about the provider. The API-based test is BFX01-01.
+                github_issues: []
+                req_id: BFX01
+                test_id: BFX01-06
                 status: pending
           - description: Breakfix Events Query
             tests:

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/reset_gpus.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/reset_gpus.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reset GPUs on a node (BFX01-01) - my-isv template."""
+"""Reset GPUs on a node from inside the cluster (BFX01-06, tenant-side) - my-isv template."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from common.stub import emit_stub
 
 
 def main() -> int:
-    """Emit the GPU reset template result (BFX01-01)."""
+    """Emit the GPU reset template result (BFX01-06)."""
     parser = argparse.ArgumentParser(description="Reset GPUs via breakfix API (template)")
     parser.add_argument("--region", default="", help="Cloud region")
     parser.add_argument("--machine-id", default="", help="Target machine/node id")

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -440,6 +440,11 @@ commands:
       # instance move Ready -> Repairing -> Ready. Online repair is cleared in a
       # finally, so a node cannot be stranded out of the pool. Skips when the site
       # has no GPU machine with a Ready instance.
+      #
+      # Skips by default even when a target exists: it names the node it would use
+      # and waits for the operator to confirm, because a shared site's only tenant
+      # instance may not be ours. Allow it with NICO_ALLOW_ONLINE_REPAIR=1, or add
+      # --machine-id <id> here to pin a node you own.
       - name: request_gpu_repair
         phase: test
         continue_on_failure: true

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -451,7 +451,7 @@ commands:
           - "{{site_id}}"
           - "--api-base"
           - "{{nico_api_base}}"
-        timeout: 600
+        timeout: 900
 
       - name: return_node_maintenance
         phase: test

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -436,6 +436,23 @@ commands:
           - "{{nico_api_base}}"
         timeout: 120
 
+      # Reports a GPU fault via NICo online repair and watches the assigned
+      # instance move Ready -> Repairing -> Ready. Online repair is cleared in a
+      # finally, so a node cannot be stranded out of the pool. Skips when the site
+      # has no GPU machine with a Ready instance.
+      - name: request_gpu_repair
+        phase: test
+        continue_on_failure: true
+        command: "python ../scripts/breakfix/request_gpu_repair.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 600
+
       - name: return_node_maintenance
         phase: test
         continue_on_failure: true

--- a/isvctl/configs/providers/nico/scripts/auth/_key_access.py
+++ b/isvctl/configs/providers/nico/scripts/auth/_key_access.py
@@ -45,10 +45,9 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.error import HTTPError
 
 from common.nico_client import (
-    forge_delete,
+    delete_if_present,
     forge_get,
     forge_patch,
     forge_post,
@@ -151,16 +150,6 @@ def provision(*, org: str, site_id: str, api_base: str, token: str, created: Thr
             pass
 
 
-def _delete_if_present(org: str, path: str, token: str, *, base_url: str) -> None:
-    """DELETE a NICo resource; treat 404 as already removed."""
-    try:
-        forge_delete(org, path, token, base_url=base_url)
-    except HTTPError as e:
-        if e.code == 404:
-            return
-        raise
-
-
 def remove(*, org: str, site_id: str, api_base: str, token: str, created: ThrowawayKey) -> list[str]:
     """Remove what ``provision`` created; return a list of cleanup failures.
 
@@ -175,7 +164,7 @@ def remove(*, org: str, site_id: str, api_base: str, token: str, created: Throwa
         if not resource_id:
             continue
         try:
-            _delete_if_present(org, f"{resource}/{resource_id}", token, base_url=api_base)
+            delete_if_present(org, f"{resource}/{resource_id}", token, base_url=api_base)
         except Exception as e:
             errors.append(f"{resource} {resource_id}: {type(e).__name__}: {e}")
 

--- a/isvctl/configs/providers/nico/scripts/breakfix/_common.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/_common.py
@@ -9,28 +9,39 @@ import json
 from typing import Any
 from urllib.error import URLError
 
-from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+from common.nico_client import NicoAuth, NicoAuthError, forge_get_all, resolve_auth
 
 
 def list_site_machines(
-    *, org: str, site_id: str, api_base: str, empty_contract: dict[str, Any] | None = None
+    *,
+    org: str,
+    site_id: str,
+    api_base: str,
+    empty_contract: dict[str, Any] | None = None,
+    auth: NicoAuth | None = None,
+    include_metadata: bool = True,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Fetch machines for a site, or build the structured failure/skip payload.
 
     Returns ``(machines, result)``. When ``machines`` is empty the caller must
     emit ``result`` and stop: it already carries the skip or the error, plus the
     zeroed ``empty_contract`` fields the bound validation still expects to read.
+
+    A caller that already holds credentials passes ``auth`` so the token is minted
+    once per run rather than once per helper. ``include_metadata`` can be turned
+    off by callers that only read a machine's identity and capabilities, which
+    keeps the listing and its per-page parsing small.
     """
     result: dict[str, Any] = {"success": False, "platform": "nico", "site_id": site_id}
     result.update(empty_contract or {})
     try:
-        auth = resolve_auth()
+        auth = auth or resolve_auth()
         machines = forge_get_all(
             org,
             "machine",
             auth.token,
             base_url=api_base,
-            params={"siteId": site_id, "includeMetadata": "true"},
+            params={"siteId": site_id, "includeMetadata": "true" if include_metadata else "false"},
             result_key="machines",
         )
     except NicoAuthError as exc:

--- a/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report a GPU fault through the NICo repair API and observe the repair state (BFX01-01).
+
+BFX01-01 asks for a GPU reset "via the break-fix API". NICo exposes no GPU-reset
+operation -- and neither does the automation behind it, which discovers repair
+work by polling and then runs for minutes to weeks. What a tenant *can* do
+synchronously is report a GPU fault and watch the provider move the node into a
+repair state. That is what this step exercises.
+
+The mechanism is NICo's *online repair*: a privileged tenant reports a
+``healthIssue`` against a machine, NICo applies a site health override and moves
+the assigned instance from ``Ready`` to ``Repairing``, and clearing online repair
+takes it back out again. The instance keeps its tenant assignment throughout, so
+the round trip is non-destructive and reversible -- unlike the disruptive
+release-for-repair path (``DELETE instance`` with ``machineHealthIssue``), which
+belongs to BFX01-02.
+
+Online repair requires a machine with an assigned instance in ``Ready``. A site
+with no such machine emits a structured skip rather than a failure: nothing is
+broken, the precondition simply is not met. The same applies to a site whose
+machines report no GPUs, since a GPU fault report would be meaningless there.
+
+NICo API endpoints used (the ``/carbide/`` segment is the current deployed name
+for what newer docs call ``/nico/``; the other NICo scripts use it too):
+  GET   /{org}/carbide/machine?siteId={site_id}
+  GET   /{org}/carbide/instance/{instance_id}
+  PATCH /{org}/carbide/machine/{machine_id}   (operationId update-machine)
+
+Auth:
+  - NICO_BEARER_TOKEN, or OIDC client_credentials
+    (NICO_SSA_ISSUER / NICO_CLIENT_ID / NICO_CLIENT_SECRET).
+  - Requires provider admin, or a tenant admin whose tenant has the
+    ``TargetedInstanceCreation`` capability. NICo rejects anyone else with 403.
+
+Entering online repair requires acknowledging data-corruption and repair-team-access
+risk; those acknowledgements are NICo's required contract, not a choice this step
+makes. ``allowAutoInstanceDeletionOnFailure`` is pinned ``false`` so NICo never
+deletes the tenant's instance on our behalf.
+
+Online repair is cleared in a ``finally``, so the node cannot be left in
+``Repairing`` even when the teardown phase never runs. A failure to clear it fails
+the step (via ``cleanup_errors``) because a node stuck out of the allocatable pool
+must be visible. ``--skip-restore`` leaves it in repair for debugging; recover with
+``PATCH machine`` ``{"onlineRepair": {"enabled": false}}``, or by removing the
+health override at ``DELETE /machine/{id}/health-report/{source}``.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "operation": {
+      "requested": true,             // API accepted the GPU fault report
+      "repair_state_observed": true, // provider moved the node into repair
+      "restored": true,              // provider took it back out afterwards
+      "node_id": "fm100...",
+      "message": "..."               // diagnostic detail
+    }
+  }
+
+Usage:
+    NICO_BEARER_TOKEN=<token> \
+        python request_gpu_repair.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    infra-controller docs/manuals/repair/online_repair.md
+    infra-controller rest-api/openapi/spec.yaml (update-machine, MachineUpdateRequest)
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breakfix._common import emit, list_site_machines
+from common.nico_client import (
+    NicoAuthError,
+    forge_get,
+    forge_patch,
+    resolve_auth,
+    sum_capabilities,
+)
+
+REPAIR_STATUS = "Repairing"
+READY_STATUS = "Ready"
+
+POLL_INTERVAL_SECONDS = 5
+POLL_DEADLINE_SECONDS = 180
+
+# NICo requires a healthIssue when entering online repair. Category must be one of
+# Hardware, Network, Performance, Storage, Software, Other.
+GPU_HEALTH_ISSUE: dict[str, str] = {
+    "category": "Hardware",
+    "summary": "Validation suite GPU fault report (BFX01-01)",
+    "details": (
+        "Reported by the NVIDIA AI Cloud Validation Suite to verify that a tenant-reported GPU "
+        "fault moves the node into a provider repair state. No physical fault is implied and no "
+        "repair action is expected; online repair is cleared again immediately."
+    ),
+}
+
+
+def _enter_body() -> dict[str, Any]:
+    """Build the update-machine body that enters online repair."""
+    return {
+        "onlineRepair": {
+            "enabled": True,
+            # Pinned false: NICo must never delete the tenant's instance on our behalf.
+            "policy": {"allowAutoInstanceDeletionOnFailure": False},
+            "acknowledgments": {
+                "acceptDataCorruptionRisk": True,
+                "acceptRepairTeamAccess": True,
+                "acceptInstanceDeletionRisk": True,
+            },
+        },
+        "healthIssue": dict(GPU_HEALTH_ISSUE),
+    }
+
+
+def _exit_body() -> dict[str, Any]:
+    """Build the update-machine body that clears online repair.
+
+    NICo rejects the exit request if it carries healthIssue, policy, or
+    acknowledgments, so it must contain nothing but the flag.
+    """
+    return {"onlineRepair": {"enabled": False}}
+
+
+def _instance_status(org: str, instance_id: str, token: str, *, base_url: str) -> str:
+    """Return an instance's current status, or an empty string when absent."""
+    instance = forge_get(org, f"instance/{instance_id}", token, base_url=base_url)
+    status = instance.get("status")
+    return status if isinstance(status, str) else ""
+
+
+def _await_status(
+    org: str,
+    instance_id: str,
+    token: str,
+    *,
+    base_url: str,
+    target: str,
+    leaving: bool = False,
+    deadline_seconds: int = POLL_DEADLINE_SECONDS,
+) -> str:
+    """Poll an instance until it reaches (or leaves) ``target``; return the last status.
+
+    NICo applies the health override through a site workflow, so the instance
+    status changes shortly after the API returns rather than within it.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    status = _instance_status(org, instance_id, token, base_url=base_url)
+    while True:
+        reached = (status != target) if leaving else (status == target)
+        if reached or time.monotonic() >= deadline:
+            return status
+        time.sleep(POLL_INTERVAL_SECONDS)
+        status = _instance_status(org, instance_id, token, base_url=base_url)
+
+
+def _gpu_machines_with_instances(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return machines that have GPUs and an assigned instance."""
+    return [
+        m
+        for m in machines
+        if m.get("instanceId") and sum_capabilities(m.get("machineCapabilities") or [], "GPU") > 0
+    ]
+
+
+def _select_target(
+    candidates: list[dict[str, Any]], org: str, token: str, *, base_url: str, machine_id: str = ""
+) -> tuple[dict[str, Any], str] | None:
+    """Return the first (machine, instance_id) whose instance is ``Ready``.
+
+    ``machine_id`` restricts the search to one machine, so an operator can target
+    a known node instead of whichever the site happens to offer first.
+    """
+    for machine in candidates:
+        if machine_id and machine.get("id") != machine_id:
+            continue
+        instance_id = str(machine.get("instanceId") or "")
+        if _instance_status(org, instance_id, token, base_url=base_url) == READY_STATUS:
+            return machine, instance_id
+    return None
+
+
+def _skip_reason(machines: list[dict[str, Any]], candidates: list[dict[str, Any]], machine_id: str) -> str:
+    """Explain why no machine at the site can exercise online repair."""
+    if machine_id:
+        return (
+            f"Machine {machine_id} does not have a GPU and an assigned instance in {READY_STATUS}; "
+            "online repair requires both"
+        )
+    if not candidates:
+        return (
+            f"None of the {len(machines)} machine(s) at the site has both GPUs and an assigned instance; "
+            "online repair requires a GPU node with a tenant instance"
+        )
+    return (
+        f"{len(candidates)} GPU machine(s) have instances but none is in {READY_STATUS}; "
+        "online repair requires a Ready instance"
+    )
+
+
+def main() -> int:
+    """Report a GPU fault, observe the repair state, and print the JSON contract."""
+    parser = argparse.ArgumentParser(description="Report a GPU fault via the NICo online-repair API")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--machine-id", default="", help="Target a specific machine instead of the first eligible one")
+    parser.add_argument(
+        "--skip-restore",
+        action="store_true",
+        help="Leave the node in online repair for debugging (it is cleared by default)",
+    )
+    args = parser.parse_args()
+
+    empty_contract = {"operation": {"requested": False, "repair_state_observed": False, "restored": False}}
+    machines, result = list_site_machines(
+        org=args.org, site_id=args.site_id, api_base=args.api_base, empty_contract=empty_contract
+    )
+    if not machines:
+        return emit(result)
+
+    operation: dict[str, Any] = {"requested": False, "repair_state_observed": False, "restored": False}
+    result["operation"] = operation
+
+    auth = None
+    entered = False
+    instance_id = ""
+
+    try:
+        auth = resolve_auth()
+        candidates = _gpu_machines_with_instances(machines)
+        target = _select_target(candidates, args.org, auth.token, base_url=args.api_base, machine_id=args.machine_id)
+
+        if target is None:
+            result["skipped"] = True
+            result["skip_reason"] = _skip_reason(machines, candidates, args.machine_id)
+            return emit(result)
+
+        machine, instance_id = target
+        machine_id = str(machine.get("id") or "")
+        operation["node_id"] = machine_id
+
+        forge_patch(args.org, f"machine/{machine_id}", auth.token, base_url=args.api_base, body=_enter_body())
+        entered = True
+        operation["requested"] = True
+
+        status = _await_status(
+            args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS
+        )
+        operation["repair_state_observed"] = status == REPAIR_STATUS
+        if not operation["repair_state_observed"]:
+            operation["message"] = (
+                f"Online repair was accepted but the instance stayed in {status or 'an unknown state'} "
+                f"rather than {REPAIR_STATUS} within {POLL_DEADLINE_SECONDS}s"
+            )
+
+    except NicoAuthError as e:
+        result["success"] = False
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["success"] = False
+        result["error"] = f"{type(e).__name__}: {e}"
+    finally:
+        # Clear online repair in the process that entered it, so the node cannot be
+        # left out of the allocatable pool even when teardown never executes.
+        if entered and auth is not None and not args.skip_restore:
+            try:
+                forge_patch(
+                    args.org,
+                    f"machine/{operation['node_id']}",
+                    auth.token,
+                    base_url=args.api_base,
+                    body=_exit_body(),
+                )
+                status = _await_status(
+                    args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS, leaving=True
+                )
+                operation["restored"] = status != REPAIR_STATUS
+                if not operation["restored"]:
+                    raise RuntimeError(f"instance stayed in {REPAIR_STATUS} after clearing online repair")
+            except Exception as e:
+                # A node stranded in repair must fail the step even when the report itself worked.
+                result["cleanup_errors"] = [f"{type(e).__name__}: {e}"]
+                result["success"] = False
+                result["error"] = f"Failed to clear online repair: {e}"
+        elif entered and args.skip_restore:
+            result["cleanup_skipped"] = True
+
+    return emit(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
@@ -53,11 +53,21 @@ makes. ``allowAutoInstanceDeletionOnFailure`` is pinned ``false`` so NICo never
 deletes the tenant's instance on our behalf.
 
 Online repair is cleared in a ``finally``, so the node cannot be left in
-``Repairing`` even when the teardown phase never runs. A failure to clear it fails
-the step (via ``cleanup_errors``) because a node stuck out of the allocatable pool
-must be visible. ``--skip-restore`` leaves it in repair for debugging; recover with
-``PATCH machine`` ``{"onlineRepair": {"enabled": false}}``, or by removing the
-health override at ``DELETE /machine/{id}/health-report/{source}``.
+``Repairing`` even when the teardown phase never runs. Restoration is deliberately
+belt-and-braces, because a node stranded out of the allocatable pool is the worst
+outcome this step can produce:
+
+- it re-mints the access token first (the run can outlive a short-lived token, and
+  a 401 here would strand the node);
+- if clearing online repair does not take effect, it removes the
+  ``request-online-repair`` health override directly;
+- needing that fallback is reported as a ``cleanup_warnings`` finding but does not
+  fail the step, since nothing was left behind. A node still in ``Repairing`` after
+  both attempts sets ``cleanup_errors`` and fails the step.
+
+``--skip-restore`` leaves the node in repair for debugging; recover with
+``PATCH machine`` ``{"onlineRepair": {"enabled": false}}``, or
+``DELETE /machine/{id}/health-report/request-online-repair``.
 
 Required JSON output fields:
   {
@@ -97,6 +107,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from breakfix._common import emit, list_site_machines
 from common.nico_client import (
     NicoAuthError,
+    forge_delete,
     forge_get,
     forge_patch,
     resolve_auth,
@@ -106,8 +117,15 @@ from common.nico_client import (
 REPAIR_STATUS = "Repairing"
 READY_STATUS = "Ready"
 
+# Health override NICo applies while online repair is active. Removing it is the
+# fallback when clearing online repair through update-machine does not take effect.
+ONLINE_REPAIR_OVERRIDE_SOURCE = "request-online-repair"
+
 POLL_INTERVAL_SECONDS = 5
-POLL_DEADLINE_SECONDS = 180
+# Generous because NICo applies the override through a site workflow that may queue
+# behind other work; a false "never entered repair" is worse than waiting. The step
+# timeout in the provider config must leave room for this twice (enter + restore).
+POLL_DEADLINE_SECONDS = 300
 
 # NICo requires a healthIssue when entering online repair. Category must be one of
 # Hardware, Network, Performance, Storage, Software, Other.
@@ -183,9 +201,7 @@ def _await_status(
 def _gpu_machines_with_instances(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return machines that have GPUs and an assigned instance."""
     return [
-        m
-        for m in machines
-        if m.get("instanceId") and sum_capabilities(m.get("machineCapabilities") or [], "GPU") > 0
+        m for m in machines if m.get("instanceId") and sum_capabilities(m.get("machineCapabilities") or [], "GPU") > 0
     ]
 
 
@@ -222,6 +238,72 @@ def _skip_reason(machines: list[dict[str, Any]], candidates: list[dict[str, Any]
         f"{len(candidates)} GPU machine(s) have instances but none is in {READY_STATUS}; "
         "online repair requires a Ready instance"
     )
+
+
+def _restore_token(fallback: str) -> str:
+    """Return a freshly minted token, or ``fallback`` when minting fails.
+
+    The run can outlive a short-lived access token (NICo SSA tokens are minutes,
+    not hours), and a 401 while clearing online repair would strand the node out of
+    the allocatable pool. Re-minting costs one request and removes that failure mode.
+    """
+    try:
+        return resolve_auth().token
+    except NicoAuthError:
+        return fallback
+
+
+def _clear_online_repair(org: str, machine_id: str, instance_id: str, token: str, *, api_base: str) -> tuple[bool, str]:
+    """Clear online repair via update-machine; return (left_repair, detail)."""
+    try:
+        forge_patch(org, f"machine/{machine_id}", token, base_url=api_base, body=_exit_body())
+        status = _await_status(org, instance_id, token, base_url=api_base, target=REPAIR_STATUS, leaving=True)
+        if status != REPAIR_STATUS:
+            return True, ""
+        return False, f"instance stayed in {REPAIR_STATUS} after clearing online repair"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _remove_repair_override(
+    org: str, machine_id: str, instance_id: str, token: str, *, api_base: str
+) -> tuple[bool, str]:
+    """Delete the online-repair health override directly; return (left_repair, detail)."""
+    try:
+        forge_delete(
+            org, f"machine/{machine_id}/health-report/{ONLINE_REPAIR_OVERRIDE_SOURCE}", token, base_url=api_base
+        )
+        status = _await_status(org, instance_id, token, base_url=api_base, target=REPAIR_STATUS, leaving=True)
+        if status != REPAIR_STATUS:
+            return True, ""
+        return False, f"instance stayed in {REPAIR_STATUS} after removing the {ONLINE_REPAIR_OVERRIDE_SOURCE} override"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _restore(org: str, machine_id: str, instance_id: str, *, api_base: str, fallback_token: str) -> dict[str, Any]:
+    """Take the node back out of repair, and report how much effort that took.
+
+    Returns ``{"restored": bool, "warnings": [...], "errors": [...]}``. Clearing
+    online repair the documented way is tried first; if that leaves the node in
+    repair, the health override is removed directly. Only a node still in repair
+    after both attempts is an error -- needing the fallback is a provider finding
+    worth reporting, but nothing was left behind.
+    """
+    token = _restore_token(fallback_token)
+
+    left_repair, detail = _clear_online_repair(org, machine_id, instance_id, token, api_base=api_base)
+    if left_repair:
+        return {"restored": True, "warnings": [], "errors": []}
+
+    recovered, fallback_detail = _remove_repair_override(org, machine_id, instance_id, token, api_base=api_base)
+    if recovered:
+        return {
+            "restored": True,
+            "warnings": [f"Clearing online repair did not take effect ({detail}); removed the override directly"],
+            "errors": [],
+        }
+    return {"restored": False, "warnings": [], "errors": [detail, fallback_detail]}
 
 
 def main() -> int:
@@ -270,9 +352,7 @@ def main() -> int:
         entered = True
         operation["requested"] = True
 
-        status = _await_status(
-            args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS
-        )
+        status = _await_status(args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS)
         operation["repair_state_observed"] = status == REPAIR_STATUS
         if not operation["repair_state_observed"]:
             operation["message"] = (
@@ -288,28 +368,24 @@ def main() -> int:
         result["success"] = False
         result["error"] = f"{type(e).__name__}: {e}"
     finally:
-        # Clear online repair in the process that entered it, so the node cannot be
-        # left out of the allocatable pool even when teardown never executes.
+        # Take the node back out of repair in the process that put it there, so it
+        # cannot be left out of the allocatable pool even when teardown never runs.
         if entered and auth is not None and not args.skip_restore:
-            try:
-                forge_patch(
-                    args.org,
-                    f"machine/{operation['node_id']}",
-                    auth.token,
-                    base_url=args.api_base,
-                    body=_exit_body(),
-                )
-                status = _await_status(
-                    args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS, leaving=True
-                )
-                operation["restored"] = status != REPAIR_STATUS
-                if not operation["restored"]:
-                    raise RuntimeError(f"instance stayed in {REPAIR_STATUS} after clearing online repair")
-            except Exception as e:
-                # A node stranded in repair must fail the step even when the report itself worked.
-                result["cleanup_errors"] = [f"{type(e).__name__}: {e}"]
+            outcome = _restore(
+                args.org,
+                str(operation["node_id"]),
+                instance_id,
+                api_base=args.api_base,
+                fallback_token=auth.token,
+            )
+            operation["restored"] = outcome["restored"]
+            if outcome["warnings"]:
+                result["cleanup_warnings"] = outcome["warnings"]
+            if not outcome["restored"]:
+                # A node stranded in repair must fail the step even when the report worked.
+                result["cleanup_errors"] = outcome["errors"]
                 result["success"] = False
-                result["error"] = f"Failed to clear online repair: {e}"
+                result["error"] = f"Node left in {REPAIR_STATUS}: {'; '.join(outcome['errors'])}"
         elif entered and args.skip_restore:
             result["cleanup_skipped"] = True
 

--- a/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
@@ -47,6 +47,12 @@ Auth:
   - Requires provider admin, or a tenant admin whose tenant has the
     ``TargetedInstanceCreation`` capability. NICo rejects anyone else with 403.
 
+Mutating requires the operator to opt in. A shared site's only eligible machine may
+belong to another tenant, so an auto-discovered target is reported in a structured
+skip rather than moved into repair -- which also makes a plain run a dry run. Confirm
+with ``--machine-id <id>``, or set ``NICO_ALLOW_ONLINE_REPAIR=1`` to accept whichever
+eligible node is found.
+
 Entering online repair requires acknowledging data-corruption and repair-team-access
 risk; those acknowledgements are NICo's required contract, not a choice this step
 makes. ``allowAutoInstanceDeletionOnFailure`` is pinned ``false`` so NICo never
@@ -79,6 +85,7 @@ Reference:
 
 import argparse
 import contextlib
+import os
 import sys
 import time
 from collections.abc import Callable
@@ -106,6 +113,15 @@ READY_STATUS = "Ready"
 # Health override NICo applies while online repair is active. Removing it is the
 # fallback when clearing online repair through update-machine does not take effect.
 ONLINE_REPAIR_OVERRIDE_SOURCE = "request-online-repair"
+
+# A site's only eligible machine may belong to someone else -- shared lab sites
+# routinely carry exactly one tenant instance -- and this step would put it into
+# Repairing. So an auto-selected target is reported, not mutated: the operator opts
+# in by naming the machine, or by setting this to "1" to accept whatever is found.
+# The sibling query_key_access.py mutates by default and opts *out* via
+# --no-provision; the difference is blast radius. Minting a throwaway SSH key
+# affects nobody, whereas moving a stranger's instance into a repair state does.
+AUTO_SELECT_ENV = "NICO_ALLOW_ONLINE_REPAIR"
 
 POLL_INTERVAL_SECONDS = 5
 # Generous because NICo applies the override through a site workflow that may queue
@@ -160,7 +176,7 @@ def _exit_body() -> dict[str, Any]:
 def _instance_status(org: str, instance_id: str, token: str, *, base_url: str) -> str:
     """Return an instance's current status, or an empty string when absent."""
     instance = forge_get(org, f"instance/{instance_id}", token, base_url=base_url)
-    return first_string(instance, "status", "state", "instanceState")
+    return first_string(instance, "status")
 
 
 def _await_status(
@@ -367,6 +383,18 @@ def main() -> int:
         machine, instance_id = target
         machine_id = str(machine.get("id") or "")
         operation["node_id"] = machine_id
+
+        if not args.machine_id and os.environ.get(AUTO_SELECT_ENV) != "1":
+            # Report the target rather than mutating it. This doubles as a dry run:
+            # the operator sees exactly which node would enter repair before allowing it.
+            result["skipped"] = True
+            result["skip_reason"] = (
+                f"Would report a GPU fault against machine {machine_id}, but an auto-selected node "
+                f"is not mutated because it may belong to another tenant. Pass "
+                f"--machine-id {machine_id} to confirm this node, or set {AUTO_SELECT_ENV}=1 to "
+                f"accept whichever eligible node is found"
+            )
+            return emit(result)
 
         forge_patch(args.org, f"machine/{machine_id}", auth.token, base_url=args.api_base, body=_enter_body())
         operation["requested"] = True

--- a/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/request_gpu_repair.py
@@ -53,35 +53,17 @@ makes. ``allowAutoInstanceDeletionOnFailure`` is pinned ``false`` so NICo never
 deletes the tenant's instance on our behalf.
 
 Online repair is cleared in a ``finally``, so the node cannot be left in
-``Repairing`` even when the teardown phase never runs. Restoration is deliberately
-belt-and-braces, because a node stranded out of the allocatable pool is the worst
-outcome this step can produce:
-
-- it re-mints the access token first (the run can outlive a short-lived token, and
-  a 401 here would strand the node);
-- if clearing online repair does not take effect, it removes the
-  ``request-online-repair`` health override directly;
-- needing that fallback is reported as a ``cleanup_warnings`` finding but does not
-  fail the step, since nothing was left behind. A node still in ``Repairing`` after
-  both attempts sets ``cleanup_errors`` and fails the step.
+``Repairing`` even when the teardown phase never runs. See ``_restore`` for how far
+that goes and why -- a node stranded out of the allocatable pool is the worst
+outcome this step can produce.
 
 ``--skip-restore`` leaves the node in repair for debugging; recover with
 ``PATCH machine`` ``{"onlineRepair": {"enabled": false}}``, or
 ``DELETE /machine/{id}/health-report/request-online-repair``.
 
-Required JSON output fields:
-  {
-    "success": true,
-    "platform": "nico",
-    "site_id": "...",
-    "operation": {
-      "requested": true,             // API accepted the GPU fault report
-      "repair_state_observed": true, // provider moved the node into repair
-      "restored": true,              // provider took it back out afterwards
-      "node_id": "fm100...",
-      "message": "..."               // diagnostic detail
-    }
-  }
+The JSON contract is ``operation.{requested, repair_state_observed, restored,
+node_id, message}``, documented alongside the other break-fix steps in
+``isvctl/configs/suites/README.md`` and asserted by ``GpuRepairRequestCheck``.
 
 Usage:
     NICO_BEARER_TOKEN=<token> \
@@ -96,8 +78,10 @@ Reference:
 """
 
 import argparse
+import contextlib
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -105,9 +89,11 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from breakfix._common import emit, list_site_machines
+from common.inventory import first_string
 from common.nico_client import (
+    NicoAuth,
     NicoAuthError,
-    forge_delete,
+    delete_if_present,
     forge_get,
     forge_patch,
     resolve_auth,
@@ -123,9 +109,14 @@ ONLINE_REPAIR_OVERRIDE_SOURCE = "request-online-repair"
 
 POLL_INTERVAL_SECONDS = 5
 # Generous because NICo applies the override through a site workflow that may queue
-# behind other work; a false "never entered repair" is worse than waiting. The step
-# timeout in the provider config must leave room for this twice (enter + restore).
+# behind other work; a false "never entered repair" is worse than waiting. The worst
+# path spends this twice (enter, then clear) plus the shorter fallback below, so the
+# step timeout in the provider config must exceed their sum with room for latency.
 POLL_DEADLINE_SECONDS = 300
+# The override-removal fallback runs only after the primary clear already spent its
+# deadline, so it gets a shorter one: it mutates machine state directly instead of
+# queueing a site workflow, and the two waits together must fit the step timeout.
+FALLBACK_POLL_DEADLINE_SECONDS = 90
 
 # NICo requires a healthIssue when entering online repair. Category must be one of
 # Hardware, Network, Performance, Storage, Software, Other.
@@ -169,8 +160,7 @@ def _exit_body() -> dict[str, Any]:
 def _instance_status(org: str, instance_id: str, token: str, *, base_url: str) -> str:
     """Return an instance's current status, or an empty string when absent."""
     instance = forge_get(org, f"instance/{instance_id}", token, base_url=base_url)
-    status = instance.get("status")
-    return status if isinstance(status, str) else ""
+    return first_string(instance, "status", "state", "instanceState")
 
 
 def _await_status(
@@ -189,13 +179,12 @@ def _await_status(
     status changes shortly after the API returns rather than within it.
     """
     deadline = time.monotonic() + deadline_seconds
-    status = _instance_status(org, instance_id, token, base_url=base_url)
     while True:
+        status = _instance_status(org, instance_id, token, base_url=base_url)
         reached = (status != target) if leaving else (status == target)
         if reached or time.monotonic() >= deadline:
             return status
         time.sleep(POLL_INTERVAL_SECONDS)
-        status = _instance_status(org, instance_id, token, base_url=base_url)
 
 
 def _gpu_machines_with_instances(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -240,43 +229,36 @@ def _skip_reason(machines: list[dict[str, Any]], candidates: list[dict[str, Any]
     )
 
 
-def _restore_token(fallback: str) -> str:
-    """Return a freshly minted token, or ``fallback`` when minting fails.
+def _attempt_exit(
+    org: str,
+    instance_id: str,
+    token: str,
+    *,
+    api_base: str,
+    apply: Callable[[], object],
+    what: str,
+    deadline_seconds: int,
+) -> tuple[bool, str]:
+    """Run one exit attempt and wait for the node to leave repair.
 
-    The run can outlive a short-lived access token (NICo SSA tokens are minutes,
-    not hours), and a 401 while clearing online repair would strand the node out of
-    the allocatable pool. Re-minting costs one request and removes that failure mode.
+    ``apply`` performs the mutation -- clearing online repair, or removing the
+    health override. Returns ``(left_repair, detail)``, where ``detail`` is empty
+    on success and describes the failure otherwise.
     """
     try:
-        return resolve_auth().token
-    except NicoAuthError:
-        return fallback
-
-
-def _clear_online_repair(org: str, machine_id: str, instance_id: str, token: str, *, api_base: str) -> tuple[bool, str]:
-    """Clear online repair via update-machine; return (left_repair, detail)."""
-    try:
-        forge_patch(org, f"machine/{machine_id}", token, base_url=api_base, body=_exit_body())
-        status = _await_status(org, instance_id, token, base_url=api_base, target=REPAIR_STATUS, leaving=True)
-        if status != REPAIR_STATUS:
-            return True, ""
-        return False, f"instance stayed in {REPAIR_STATUS} after clearing online repair"
-    except Exception as e:
-        return False, f"{type(e).__name__}: {e}"
-
-
-def _remove_repair_override(
-    org: str, machine_id: str, instance_id: str, token: str, *, api_base: str
-) -> tuple[bool, str]:
-    """Delete the online-repair health override directly; return (left_repair, detail)."""
-    try:
-        forge_delete(
-            org, f"machine/{machine_id}/health-report/{ONLINE_REPAIR_OVERRIDE_SOURCE}", token, base_url=api_base
+        apply()
+        status = _await_status(
+            org,
+            instance_id,
+            token,
+            base_url=api_base,
+            target=REPAIR_STATUS,
+            leaving=True,
+            deadline_seconds=deadline_seconds,
         )
-        status = _await_status(org, instance_id, token, base_url=api_base, target=REPAIR_STATUS, leaving=True)
         if status != REPAIR_STATUS:
             return True, ""
-        return False, f"instance stayed in {REPAIR_STATUS} after removing the {ONLINE_REPAIR_OVERRIDE_SOURCE} override"
+        return False, f"instance stayed in {REPAIR_STATUS} after {what}"
     except Exception as e:
         return False, f"{type(e).__name__}: {e}"
 
@@ -284,26 +266,53 @@ def _remove_repair_override(
 def _restore(org: str, machine_id: str, instance_id: str, *, api_base: str, fallback_token: str) -> dict[str, Any]:
     """Take the node back out of repair, and report how much effort that took.
 
-    Returns ``{"restored": bool, "warnings": [...], "errors": [...]}``. Clearing
+    Returns ``{"restored": bool, "warning": str, "errors": [...]}``. Clearing
     online repair the documented way is tried first; if that leaves the node in
     repair, the health override is removed directly. Only a node still in repair
     after both attempts is an error -- needing the fallback is a provider finding
     worth reporting, but nothing was left behind.
     """
-    token = _restore_token(fallback_token)
+    token = fallback_token
+    # Re-mint first: the run can outlive a short-lived access token (NICo SSA
+    # tokens last minutes, not hours), and a 401 here would strand the node out of
+    # the allocatable pool. If minting fails, the original token is still worth trying.
+    with contextlib.suppress(NicoAuthError):
+        token = resolve_auth().token
 
-    left_repair, detail = _clear_online_repair(org, machine_id, instance_id, token, api_base=api_base)
+    left_repair, detail = _attempt_exit(
+        org,
+        instance_id,
+        token,
+        api_base=api_base,
+        apply=lambda: forge_patch(org, f"machine/{machine_id}", token, base_url=api_base, body=_exit_body()),
+        what="clearing online repair",
+        deadline_seconds=POLL_DEADLINE_SECONDS,
+    )
     if left_repair:
-        return {"restored": True, "warnings": [], "errors": []}
+        return {"restored": True, "warning": "", "errors": []}
 
-    recovered, fallback_detail = _remove_repair_override(org, machine_id, instance_id, token, api_base=api_base)
+    recovered, fallback_detail = _attempt_exit(
+        org,
+        instance_id,
+        token,
+        api_base=api_base,
+        apply=lambda: delete_if_present(
+            org, f"machine/{machine_id}/health-report/{ONLINE_REPAIR_OVERRIDE_SOURCE}", token, base_url=api_base
+        ),
+        what=f"removing the {ONLINE_REPAIR_OVERRIDE_SOURCE} override",
+        # The override delete mutates state directly rather than queueing a site
+        # workflow, so it needs far less room than entering repair did. Keeping the
+        # full deadline here would let restore alone consume the whole step timeout
+        # and get killed mid-cleanup -- the exact outcome this path exists to prevent.
+        deadline_seconds=FALLBACK_POLL_DEADLINE_SECONDS,
+    )
     if recovered:
         return {
             "restored": True,
-            "warnings": [f"Clearing online repair did not take effect ({detail}); removed the override directly"],
+            "warning": f"Clearing online repair did not take effect ({detail}); removed the override directly",
             "errors": [],
         }
-    return {"restored": False, "warnings": [], "errors": [detail, fallback_detail]}
+    return {"restored": False, "warning": "", "errors": [detail, fallback_detail]}
 
 
 def main() -> int:
@@ -320,22 +329,33 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    empty_contract = {"operation": {"requested": False, "repair_state_observed": False, "restored": False}}
+    operation: dict[str, Any] = {"requested": False, "repair_state_observed": False, "restored": False}
+
+    # Mint the token once and hand it to the listing helper, which would otherwise
+    # mint its own. On failure it stays None and the helper re-resolves, so the
+    # structured auth-error payload is still built in exactly one place.
+    auth: NicoAuth | None = None
+    with contextlib.suppress(NicoAuthError):
+        auth = resolve_auth()
+
     machines, result = list_site_machines(
-        org=args.org, site_id=args.site_id, api_base=args.api_base, empty_contract=empty_contract
+        org=args.org,
+        site_id=args.site_id,
+        api_base=args.api_base,
+        empty_contract={"operation": operation},
+        auth=auth,
+        # Only id, instanceId, and machineCapabilities are read below.
+        include_metadata=False,
     )
     if not machines:
         return emit(result)
 
-    operation: dict[str, Any] = {"requested": False, "repair_state_observed": False, "restored": False}
     result["operation"] = operation
-
-    auth = None
-    entered = False
     instance_id = ""
 
     try:
-        auth = resolve_auth()
+        if auth is None:
+            auth = resolve_auth()
         candidates = _gpu_machines_with_instances(machines)
         target = _select_target(candidates, args.org, auth.token, base_url=args.api_base, machine_id=args.machine_id)
 
@@ -349,7 +369,6 @@ def main() -> int:
         operation["node_id"] = machine_id
 
         forge_patch(args.org, f"machine/{machine_id}", auth.token, base_url=args.api_base, body=_enter_body())
-        entered = True
         operation["requested"] = True
 
         status = _await_status(args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS)
@@ -370,24 +389,28 @@ def main() -> int:
     finally:
         # Take the node back out of repair in the process that put it there, so it
         # cannot be left out of the allocatable pool even when teardown never runs.
-        if entered and auth is not None and not args.skip_restore:
-            outcome = _restore(
-                args.org,
-                str(operation["node_id"]),
-                instance_id,
-                api_base=args.api_base,
-                fallback_token=auth.token,
-            )
-            operation["restored"] = outcome["restored"]
-            if outcome["warnings"]:
-                result["cleanup_warnings"] = outcome["warnings"]
-            if not outcome["restored"]:
-                # A node stranded in repair must fail the step even when the report worked.
-                result["cleanup_errors"] = outcome["errors"]
-                result["success"] = False
-                result["error"] = f"Node left in {REPAIR_STATUS}: {'; '.join(outcome['errors'])}"
-        elif entered and args.skip_restore:
-            result["cleanup_skipped"] = True
+        if operation["requested"]:
+            if args.skip_restore:
+                result["cleanup_skipped"] = True
+            else:
+                outcome = _restore(
+                    args.org,
+                    str(operation["node_id"]),
+                    instance_id,
+                    api_base=args.api_base,
+                    fallback_token=auth.token if auth else "",
+                )
+                operation["restored"] = outcome["restored"]
+                if outcome["warning"]:
+                    # Carried in operation.message so the bound validation surfaces it;
+                    # a provider whose documented exit path did not work is a finding
+                    # worth reading even though nothing was left behind.
+                    operation["message"] = outcome["warning"]
+                if not outcome["restored"]:
+                    # A node stranded in repair must fail the step even when the report worked.
+                    result["cleanup_errors"] = outcome["errors"]
+                    result["success"] = False
+                    result["error"] = f"Node left in {REPAIR_STATUS}: {'; '.join(outcome['errors'])}"
 
     return emit(result)
 

--- a/isvctl/configs/providers/nico/scripts/common/nico_client.py
+++ b/isvctl/configs/providers/nico/scripts/common/nico_client.py
@@ -264,6 +264,20 @@ def forge_delete(org: str, path: str, token: str, *, base_url: str, timeout: int
     return forge_request(org, path, token, base_url=base_url, method="DELETE", timeout=timeout)
 
 
+def delete_if_present(org: str, path: str, token: str, *, base_url: str) -> None:
+    """DELETE a NICo resource, treating 404 as already removed.
+
+    Cleanup paths routinely race with the thing they are removing, so "it is not
+    there" is the desired end state rather than a failure.
+    """
+    try:
+        forge_delete(org, path, token, base_url=base_url)
+    except HTTPError as e:
+        if e.code == 404:
+            return
+        raise
+
+
 def forge_get_all(
     org: str,
     path: str,

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -265,6 +265,7 @@ its plan item is not platform-scoped.
 | `query_repair_history` | test | `providers/nico/scripts/breakfix/query_repair_history.py` | `history_queryable`, `records[].{machine_id,entries}` -- a record needs non-empty `entries` to count (BFX02-03) |
 | `query_switch_firmware` | test | `providers/my-isv/scripts/breakfix/query_switch_firmware.py` | `trays[].{tray_id,firmware_version}` (BFX03-02) |
 | `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,kernel_log_available}` (BFX03-03) |
+| `request_gpu_repair` | test | `providers/nico/scripts/breakfix/request_gpu_repair.py` | `operation.{requested,repair_state_observed,restored,node_id}` -- reports a GPU fault via the break-fix API and watches the node enter a repair state (BFX01-01) |
 | `return_node_maintenance` | test | `providers/my-isv/scripts/breakfix/return_node_maintenance.py` | `operation.{requested,accepted,machine_id,maintenance_mode}` (BFX01-02) |
 | `return_rack_maintenance` | test | `providers/my-isv/scripts/breakfix/return_rack_maintenance.py` | `operation.{requested,accepted,rack_id}` (BFX01-03) |
 | `request_host_replacement` | test | `providers/my-isv/scripts/breakfix/request_host_replacement.py` | `operation.{requested,node_removed_from_pool,machine_id}` (BFX01-05) |
@@ -296,7 +297,7 @@ volume. The three test-phase steps all reuse that fixture.
 |------|-------|--------|
 | `setup` | setup | `providers/my-isv/scripts/k8s/setup.sh` |
 | `teardown` | teardown | `providers/my-isv/scripts/k8s/teardown.sh` |
-| `reset_gpus` | test | `providers/my-isv/scripts/breakfix/reset_gpus.py` (BFX01-01) |
+| `reset_gpus` | test | `providers/my-isv/scripts/breakfix/reset_gpus.py` (BFX01-06, tenant-side) |
 | `cordon_node` | test | `providers/shared/breakfix/cordon_node.py` (BFX01-04) |
 
 Validations use `kubectl` directly (or a custom CLI via the `KUBECTL` env var): node counts, GPU operator, pod health, NCCL/NIM workloads. Break-fix cordon and GPU reset are optional provider steps.

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -836,6 +836,18 @@ tests:
           test_id: "BFX02-03"
           labels: ["bare_metal", "breakfix", "min_req"]
 
+    # BFX01-01 is the provider-API half of BFX01's GPU clause: report a GPU fault
+    # and verify the provider moves the node into a repair state. No break-fix API
+    # offers an on-demand GPU reset, so that state transition is the whole
+    # tenant-observable contract. The tenant's own in-cluster reset is BFX01-06 in
+    # k8s.yaml, which proves nothing about the provider and is scoped accordingly.
+    gpu_repair_request:
+      step: request_gpu_repair
+      checks:
+        GpuRepairRequestCheck:
+          test_id: "BFX01-01"
+          labels: ["bare_metal", "breakfix", "min_req"]
+
     return_node_maintenance:
       step: return_node_maintenance
       checks:

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -836,11 +836,7 @@ tests:
           test_id: "BFX02-03"
           labels: ["bare_metal", "breakfix", "min_req"]
 
-    # BFX01-01 is the provider-API half of BFX01's GPU clause: report a GPU fault
-    # and verify the provider moves the node into a repair state. No break-fix API
-    # offers an on-demand GPU reset, so that state transition is the whole
-    # tenant-observable contract. The tenant's own in-cluster reset is BFX01-06 in
-    # k8s.yaml, which proves nothing about the provider and is scoped accordingly.
+    # Report a GPU fault and verify the provider accepts it and moves the node into repair.
     gpu_repair_request:
       step: request_gpu_repair
       checks:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -389,11 +389,14 @@ tests:
 
     # Break-fix actions that are Kubernetes-shaped (BFX01). Bare-metal
     # BFX checks live in bare_metal.yaml.
+    # BFX01-06, not BFX01-01: this resets GPUs using the tenant's own node access,
+    # so it evidences a tenant capability rather than a provider break-fix API.
+    # The API-based test is BFX01-01 in bare_metal.yaml.
     gpu_reset:
       step: reset_gpus
       checks:
         GpuResetCheck:
-          test_id: "BFX01-01"
+          test_id: "BFX01-06"
           labels: ["kubernetes", "breakfix", "min_req"]
 
     cordon_node:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -387,11 +387,9 @@ tests:
           probe_timeout_s: 10
           api_endpoint: "{{ steps.setup.kubernetes.api_endpoint | default('', true) }}"
 
-    # Break-fix actions that are Kubernetes-shaped (BFX01). Bare-metal
-    # BFX checks live in bare_metal.yaml.
-    # BFX01-06, not BFX01-01: this resets GPUs using the tenant's own node access,
-    # so it evidences a tenant capability rather than a provider break-fix API.
-    # The API-based test is BFX01-01 in bare_metal.yaml.
+    # Break-fix actions that are Kubernetes-shaped (BFX01).
+    # Bare-metal BFX checks live in bare_metal.yaml.
+    # Tenant-side GPU reset via node access (privileged DaemonSet / SSH).
     gpu_reset:
       step: reset_gpus
       checks:

--- a/isvctl/src/isvctl/config/env_catalog.py
+++ b/isvctl/src/isvctl/config/env_catalog.py
@@ -139,6 +139,13 @@ ENV_VARS: tuple[EnvVar, ...] = (
         "skip AWS teardown phase",
         persistable=False,
     ),
+    EnvVar(
+        "NICO_ALLOW_ONLINE_REPAIR",
+        "Flags",
+        Requirement.OPTIONAL,
+        "allow BFX01-01 to move an auto-selected NICo node into repair",
+        persistable=False,
+    ),
     # NICo — optional by default; --provider nico runs strict provider-specific
     # checks for the same variables.
     EnvVar(

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -3921,3 +3921,135 @@ def test_query_key_access_no_provision_never_mutates(
     assert code == 0
     assert out["skipped"] is True
     assert calls == []
+
+
+def _load_gpu_repair_script() -> ModuleType:
+    """Load the request_gpu_repair script as a module for direct unit testing."""
+    return _load_nico_script("breakfix/request_gpu_repair.py", "test_nico_request_gpu_repair")
+
+
+def _gpu_machine(machine_id: str, *, instance: str | None = None, gpus: int = 8) -> dict[str, Any]:
+    """Build a minimal NICo machine record for GPU-repair eligibility tests."""
+    capabilities: list[dict[str, Any]] = [{"type": "CPU", "name": "AMD EPYC", "count": 2}]
+    if gpus:
+        capabilities.append({"type": "GPU", "name": "NVIDIA L40S", "count": gpus})
+    return {"id": machine_id, "instanceId": instance, "machineCapabilities": capabilities}
+
+
+def test_gpu_repair_requires_both_a_gpu_and_an_instance() -> None:
+    """Online repair needs a GPU node that actually has a tenant instance attached."""
+    module = _load_gpu_repair_script()
+    machines = [
+        _gpu_machine("no-instance", instance=None),
+        _gpu_machine("no-gpu", instance="i-1", gpus=0),
+        _gpu_machine("eligible", instance="i-2"),
+    ]
+
+    eligible = module._gpu_machines_with_instances(machines)
+
+    assert [m["id"] for m in eligible] == ["eligible"]
+
+
+def test_gpu_repair_selects_the_first_ready_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Machines whose instance is not Ready are passed over, not attempted."""
+    module = _load_gpu_repair_script()
+    statuses = {"i-busy": "Provisioning", "i-ready": "Ready"}
+    monkeypatch.setattr(module, "forge_get", lambda _org, path, _tok, **_kw: {"status": statuses[path.split("/")[1]]})
+    candidates = [_gpu_machine("m-busy", instance="i-busy"), _gpu_machine("m-ready", instance="i-ready")]
+
+    target = module._select_target(candidates, "org", "tok", base_url="http://x")
+
+    assert target is not None
+    assert target[0]["id"] == "m-ready"
+    assert target[1] == "i-ready"
+
+
+def test_gpu_repair_honours_an_explicit_machine_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An operator-supplied machine id wins over whichever machine is listed first."""
+    module = _load_gpu_repair_script()
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    candidates = [_gpu_machine("m-1", instance="i-1"), _gpu_machine("m-2", instance="i-2")]
+
+    target = module._select_target(candidates, "org", "tok", base_url="http://x", machine_id="m-2")
+
+    assert target is not None
+    assert target[0]["id"] == "m-2"
+
+
+def test_gpu_repair_skip_reason_distinguishes_the_precondition() -> None:
+    """ "No GPU node with an instance" and "none Ready" are different operator problems."""
+    module = _load_gpu_repair_script()
+    machines = [_gpu_machine("m-1", instance=None)]
+
+    no_candidates = module._skip_reason(machines, [], "")
+    none_ready = module._skip_reason(machines, [_gpu_machine("m-2", instance="i-2")], "")
+
+    assert "has both GPUs and an assigned instance" in no_candidates
+    assert "none is in Ready" in none_ready
+    assert "m-9" in module._skip_reason([], [], "m-9")
+
+
+def test_gpu_repair_enter_body_never_authorises_instance_deletion() -> None:
+    """allowAutoInstanceDeletionOnFailure stays false: the instance belongs to the tenant."""
+    module = _load_gpu_repair_script()
+
+    body = module._enter_body()
+
+    assert body["onlineRepair"]["enabled"] is True
+    assert body["onlineRepair"]["policy"]["allowAutoInstanceDeletionOnFailure"] is False
+    assert set(body["healthIssue"]) == {"category", "summary", "details"}
+
+
+def test_gpu_repair_exit_body_carries_only_the_flag() -> None:
+    """NICo rejects an online-repair exit that carries healthIssue, policy, or acknowledgments."""
+    module = _load_gpu_repair_script()
+
+    assert module._exit_body() == {"onlineRepair": {"enabled": False}}
+
+
+def test_gpu_repair_enter_body_does_not_alias_module_state() -> None:
+    """Each call gets its own healthIssue dict, so one run cannot corrupt the next."""
+    module = _load_gpu_repair_script()
+
+    first = module._enter_body()
+    first["healthIssue"]["summary"] = "mutated"
+
+    assert module._enter_body()["healthIssue"]["summary"] != "mutated"
+
+
+def test_gpu_repair_polls_until_the_state_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NICo applies the override through a site workflow, so the state lags the response."""
+    module = _load_gpu_repair_script()
+    seen = iter(["Ready", "Ready", "Repairing"])
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": next(seen)})
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing")
+
+    assert status == "Repairing"
+
+
+def test_gpu_repair_gives_up_at_the_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A node that never transitions returns its last status instead of hanging."""
+    module = _load_gpu_repair_script()
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+
+    status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing", deadline_seconds=0)
+
+    assert status == "Ready"
+
+
+def test_gpu_repair_restore_waits_for_the_state_to_clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restoration watches for the node to leave Repairing, not to equal Ready.
+
+    Exiting online repair need not land back on Ready immediately, so keying on
+    equality would report a false failure.
+    """
+    module = _load_gpu_repair_script()
+    seen = iter(["Repairing", "Updating"])
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": next(seen)})
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing", leaving=True)
+
+    assert status == "Updating"

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -3713,7 +3713,7 @@ def test_remove_deletes_group_before_key_and_restores_flag(monkeypatch: pytest.M
     module = _load_key_access_helpers()
     deletes: list[str] = []
     patched: dict[str, Any] = {}
-    monkeypatch.setattr(module, "forge_delete", lambda org, path, token, **kw: deletes.append(path) or {})
+    monkeypatch.setattr(module, "delete_if_present", lambda org, path, token, **kw: deletes.append(path))
     monkeypatch.setattr(
         module, "forge_patch", lambda org, path, token, *, base_url, body, **kw: patched.update(body) or {}
     )
@@ -3724,24 +3724,36 @@ def test_remove_deletes_group_before_key_and_restores_flag(monkeypatch: pytest.M
     assert patched == {"isSerialConsoleSSHKeysEnabled": False}
 
 
-def test_remove_treats_404_delete_as_already_gone(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DELETE 404 means the resource is already gone; removal reports no error."""
-    module = _load_key_access_helpers()
+def test_delete_if_present_treats_404_as_already_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DELETE 404 means the resource is already gone, which is the desired end state."""
+    module = _load_nico_client()
     monkeypatch.setattr(
         module,
         "forge_delete",
         lambda *a, **k: (_ for _ in ()).throw(HTTPError("http://x", 404, "Not Found", None, None)),
     )
 
-    created = module.ThrowawayKey(sshkey_id="key-1", sshkeygroup_id="kg-1")
-    assert module.remove(org="o", site_id="site-1", api_base="http://x", token="t", created=created) == []
+    assert module.delete_if_present("o", "sshkey/key-1", "t", base_url="http://x") is None
+
+
+def test_delete_if_present_reraises_other_http_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 409 is a real failure; swallowing it would hide a resource that is still there."""
+    module = _load_nico_client()
+    monkeypatch.setattr(
+        module,
+        "forge_delete",
+        lambda *a, **k: (_ for _ in ()).throw(HTTPError("http://x", 409, "Conflict", None, None)),
+    )
+
+    with pytest.raises(HTTPError):
+        module.delete_if_present("o", "sshkey/key-1", "t", base_url="http://x")
 
 
 def test_remove_continues_after_one_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """A stuck group delete must not strand the key; both failures are reported."""
     module = _load_key_access_helpers()
     monkeypatch.setattr(
-        module, "forge_delete", lambda org, path, token, **kw: (_ for _ in ()).throw(RuntimeError(f"boom {path}"))
+        module, "delete_if_present", lambda org, path, token, **kw: (_ for _ in ()).throw(RuntimeError(f"boom {path}"))
     )
 
     created = module.ThrowawayKey(sshkey_id="key-1", sshkeygroup_id="kg-1")
@@ -3756,7 +3768,7 @@ def test_remove_is_noop_without_ids(monkeypatch: pytest.MonkeyPatch) -> None:
     """Nothing created means nothing to remove."""
     module = _load_key_access_helpers()
     calls: list[str] = []
-    monkeypatch.setattr(module, "forge_delete", lambda *a, **k: calls.append("delete") or {})
+    monkeypatch.setattr(module, "delete_if_present", lambda *a, **k: calls.append("delete"))
     monkeypatch.setattr(module, "forge_patch", lambda *a, **k: calls.append("patch") or {})
 
     created = module.ThrowawayKey()
@@ -4055,24 +4067,39 @@ def test_gpu_repair_restore_waits_for_the_state_to_clear(monkeypatch: pytest.Mon
     assert status == "Updating"
 
 
+def _record_restore_token(module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture the bearer token ``_restore`` actually sends on its exit PATCH."""
+    used: list[str] = []
+    monkeypatch.setattr(module, "forge_patch", lambda _org, _path, token, **_kw: used.append(token) or {})
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    monkeypatch.setattr(module, "delete_if_present", lambda *_a, **_kw: None)
+    return used
+
+
 def test_gpu_repair_restore_re_mints_the_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Restoration mints a fresh token: a stale one would 401 and strand the node."""
     module = _load_gpu_repair_script()
+    used = _record_restore_token(module, monkeypatch)
     monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="fresh"))
 
-    assert module._restore_token("stale") == "fresh"
+    module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="stale")
+
+    assert used == ["fresh"]
 
 
 def test_gpu_repair_restore_falls_back_to_the_stale_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """If re-minting fails, the original token is still worth trying."""
     module = _load_gpu_repair_script()
+    used = _record_restore_token(module, monkeypatch)
 
     def _boom() -> None:
         raise module.NicoAuthError("issuer unreachable")
 
     monkeypatch.setattr(module, "resolve_auth", _boom)
 
-    assert module._restore_token("stale") == "stale"
+    module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="stale")
+
+    assert used == ["stale"]
 
 
 def test_gpu_repair_restore_succeeds_on_the_documented_path(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -4082,12 +4109,12 @@ def test_gpu_repair_restore_succeeds_on_the_documented_path(monkeypatch: pytest.
     monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
     monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
     deleted: list[str] = []
-    monkeypatch.setattr(module, "forge_delete", lambda _o, path, *_a, **_kw: deleted.append(path) or {})
+    monkeypatch.setattr(module, "delete_if_present", lambda _o, path, *_a, **_kw: deleted.append(path))
 
     outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
 
     assert outcome["restored"] is True
-    assert outcome["warnings"] == []
+    assert outcome["warning"] == ""
     assert deleted == []
 
 
@@ -4111,11 +4138,10 @@ def test_gpu_repair_restore_removes_the_override_when_clearing_fails(monkeypatch
 
     deleted: list[str] = []
 
-    def _delete(_org: str, path: str, *_a: object, **_kw: object) -> dict[str, Any]:
+    def _delete(_org: str, path: str, *_a: object, **_kw: object) -> None:
         deleted.append(path)
-        return {}
 
-    monkeypatch.setattr(module, "forge_delete", _delete)
+    monkeypatch.setattr(module, "delete_if_present", _delete)
 
     # Repairing until the override is gone, Ready afterwards.
     monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready" if deleted else "Repairing"})
@@ -4124,7 +4150,7 @@ def test_gpu_repair_restore_removes_the_override_when_clearing_fails(monkeypatch
 
     assert outcome["restored"] is True
     assert outcome["errors"] == []
-    assert "removed the override directly" in outcome["warnings"][0]
+    assert "removed the override directly" in outcome["warning"]
     assert deleted == [f"machine/m-1/health-report/{module.ONLINE_REPAIR_OVERRIDE_SOURCE}"]
 
 
@@ -4133,12 +4159,12 @@ def test_gpu_repair_restore_reports_a_stranded_node(monkeypatch: pytest.MonkeyPa
     module = _load_gpu_repair_script()
     monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
     monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
-    monkeypatch.setattr(module, "forge_delete", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "delete_if_present", lambda *_a, **_kw: None)
     monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Repairing"})
     monkeypatch.setattr(module, "time", _fast_clock())
 
     outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
 
     assert outcome["restored"] is False
-    assert outcome["warnings"] == []
+    assert outcome["warning"] == ""
     assert len(outcome["errors"]) == 2

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -4053,3 +4053,92 @@ def test_gpu_repair_restore_waits_for_the_state_to_clear(monkeypatch: pytest.Mon
     status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing", leaving=True)
 
     assert status == "Updating"
+
+
+def test_gpu_repair_restore_re_mints_the_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restoration mints a fresh token: a stale one would 401 and strand the node."""
+    module = _load_gpu_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="fresh"))
+
+    assert module._restore_token("stale") == "fresh"
+
+
+def test_gpu_repair_restore_falls_back_to_the_stale_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If re-minting fails, the original token is still worth trying."""
+    module = _load_gpu_repair_script()
+
+    def _boom() -> None:
+        raise module.NicoAuthError("issuer unreachable")
+
+    monkeypatch.setattr(module, "resolve_auth", _boom)
+
+    assert module._restore_token("stale") == "stale"
+
+
+def test_gpu_repair_restore_succeeds_on_the_documented_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clearing online repair normally needs no fallback and raises no warning."""
+    module = _load_gpu_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    deleted: list[str] = []
+    monkeypatch.setattr(module, "forge_delete", lambda _o, path, *_a, **_kw: deleted.append(path) or {})
+
+    outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
+
+    assert outcome["restored"] is True
+    assert outcome["warnings"] == []
+    assert deleted == []
+
+
+def _fast_clock() -> SimpleNamespace:
+    """A stand-in time module whose monotonic jumps ahead of any poll deadline.
+
+    ``_await_status`` binds its deadline as a default argument, so the module
+    constant cannot be lowered from a test. Advancing the clock instead makes each
+    poll give up after a single fetch rather than spinning for the real deadline.
+    """
+    ticks = iter(range(0, 10_000_000, 1000))
+    return SimpleNamespace(monotonic=lambda: next(ticks), sleep=lambda _s: None)
+
+
+def test_gpu_repair_restore_removes_the_override_when_clearing_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A node still in Repairing gets its override deleted, and that is a finding."""
+    module = _load_gpu_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "time", _fast_clock())
+
+    deleted: list[str] = []
+
+    def _delete(_org: str, path: str, *_a: object, **_kw: object) -> dict[str, Any]:
+        deleted.append(path)
+        return {}
+
+    monkeypatch.setattr(module, "forge_delete", _delete)
+
+    # Repairing until the override is gone, Ready afterwards.
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready" if deleted else "Repairing"})
+
+    outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
+
+    assert outcome["restored"] is True
+    assert outcome["errors"] == []
+    assert "removed the override directly" in outcome["warnings"][0]
+    assert deleted == [f"machine/m-1/health-report/{module.ONLINE_REPAIR_OVERRIDE_SOURCE}"]
+
+
+def test_gpu_repair_restore_reports_a_stranded_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When both attempts fail the node is stranded, which must be an error not a warning."""
+    module = _load_gpu_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "forge_delete", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Repairing"})
+    monkeypatch.setattr(module, "time", _fast_clock())
+
+    outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
+
+    assert outcome["restored"] is False
+    assert outcome["warnings"] == []
+    assert len(outcome["errors"]) == 2

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -4168,3 +4168,82 @@ def test_gpu_repair_restore_reports_a_stranded_node(monkeypatch: pytest.MonkeyPa
     assert outcome["restored"] is False
     assert outcome["warning"] == ""
     assert len(outcome["errors"]) == 2
+
+
+def _gpu_repair_argv(*extra: str) -> list[str]:
+    """Build argv for the request_gpu_repair CLI."""
+    return ["request_gpu_repair.py", "--org", "ncx", "--site-id", "site-1", "--api-base", "http://x", *extra]
+
+
+def _stub_gpu_repair_discovery(module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Wire discovery so one eligible GPU machine with a Ready instance is found.
+
+    Returns the list that records every mutating PATCH, so a test can assert the
+    guard let nothing through.
+    """
+    patched: list[dict[str, Any]] = []
+    machine = _gpu_machine("m-1", instance="i-1")
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(
+        module,
+        "list_site_machines",
+        lambda **kw: ([machine], {"success": True, "platform": "nico", "site_id": "site-1"}),
+    )
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    monkeypatch.setattr(module, "forge_patch", lambda _o, _p, _t, **kw: patched.append(kw.get("body", {})) or {})
+    return patched
+
+
+def test_gpu_repair_does_not_mutate_an_auto_selected_node(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A shared site's only instance may not be ours, so auto-selection must not mutate."""
+    module = _load_gpu_repair_script()
+    patched = _stub_gpu_repair_discovery(module, monkeypatch)
+    monkeypatch.delenv(module.AUTO_SELECT_ENV, raising=False)
+    monkeypatch.setattr(sys, "argv", _gpu_repair_argv())
+
+    code = module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert code == 0
+    assert out["skipped"] is True
+    assert patched == []
+    # The skip has to name the node, so it doubles as a dry run.
+    assert "m-1" in out["skip_reason"]
+    assert module.AUTO_SELECT_ENV in out["skip_reason"]
+
+
+def test_gpu_repair_mutates_when_the_machine_is_named(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Naming the machine is the operator confirming that node, so the step proceeds."""
+    module = _load_gpu_repair_script()
+    patched = _stub_gpu_repair_discovery(module, monkeypatch)
+    monkeypatch.delenv(module.AUTO_SELECT_ENV, raising=False)
+    monkeypatch.setattr(module, "time", _fast_clock())
+    monkeypatch.setattr(sys, "argv", _gpu_repair_argv("--machine-id", "m-1"))
+
+    module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out.get("skipped") is not True
+    assert out["operation"]["requested"] is True
+    assert patched[0]["onlineRepair"]["enabled"] is True
+
+
+def test_gpu_repair_env_opt_in_allows_auto_selection(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The env opt-in accepts whichever eligible node discovery returns."""
+    module = _load_gpu_repair_script()
+    _stub_gpu_repair_discovery(module, monkeypatch)
+    monkeypatch.setenv(module.AUTO_SELECT_ENV, "1")
+    monkeypatch.setattr(module, "time", _fast_clock())
+    monkeypatch.setattr(sys, "argv", _gpu_repair_argv())
+
+    module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out.get("skipped") is not True
+    assert out["operation"]["requested"] is True

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -260,18 +260,52 @@ class _OperationCheck(BaseValidation):
 
 
 class GpuResetCheck(_OperationCheck):
-    """Validate GPU reset via the break-fix API (BFX01-01).
+    """Validate an in-cluster GPU reset using the tenant's own node access (BFX01-06).
+
+    This evidences a *tenant* capability, not a provider one. The reset is performed
+    from inside the cluster (privileged DaemonSet, SSH), so it passes wherever the
+    tenant has root and a working ``nvidia-smi`` -- with or without the provider.
+    The provider-API counterpart is ``GpuRepairRequestCheck`` (BFX01-01).
 
     Step output:
         success, operation: {requested, completed, node_id}
     """
 
-    description: ClassVar[str] = "Reset GPUs on an individual node via the breakfix API"
+    description: ClassVar[str] = "Reset GPUs on a node from inside the cluster (tenant-side)"
 
     completion_key: ClassVar[str] = "completed"
     failure_message: ClassVar[str] = "GPU reset did not complete"
     label_keys: ClassVar[tuple[str, ...]] = ("node_id", "machine_id")
     pass_template: ClassVar[str] = "GPU reset completed for node {label}"
+
+
+class GpuRepairRequestCheck(_OperationCheck):
+    """Validate a GPU fault can be reported through the break-fix API (BFX01-01).
+
+    A provider whose break-fix API exposes no GPU-reset operation still owes a
+    tenant some way to report a GPU fault and have the node moved into a repair
+    state. This checks that path: the request was accepted and the provider acted
+    on it by changing the node's state.
+
+    It deliberately does not claim the GPUs were reset. The provider's repair
+    automation performs the reset asynchronously -- typically minutes to weeks
+    later, out of band from any API response -- so no synchronous check can
+    observe it.
+
+    Step output:
+        success, operation: {requested, repair_state_observed, restored, node_id}
+    """
+
+    description: ClassVar[str] = "Report a GPU fault via the break-fix API and verify the node enters repair"
+
+    completion_key: ClassVar[str] = "repair_state_observed"
+    failure_message: ClassVar[str] = "Provider did not move the node into a repair state after the GPU fault report"
+    label_keys: ClassVar[tuple[str, ...]] = ("node_id", "machine_id")
+    pass_template: ClassVar[str] = "GPU fault report accepted; node {label} entered a repair state"
+
+    def _pass_message(self, label: str, operation: dict[str, Any]) -> str:
+        """Report whether the provider also took the node back out of repair."""
+        return f"{super()._pass_message(label, operation)} (restored={operation.get('restored')})"
 
 
 class ReturnNodeMaintenanceCheck(_OperationCheck):

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -304,8 +304,10 @@ class GpuRepairRequestCheck(_OperationCheck):
     pass_template: ClassVar[str] = "GPU fault report accepted; node {label} entered a repair state"
 
     def _pass_message(self, label: str, operation: dict[str, Any]) -> str:
-        """Report whether the provider also took the node back out of repair."""
-        return f"{super()._pass_message(label, operation)} (restored={operation.get('restored')})"
+        """Append any provider finding raised while the node was taken back out of repair."""
+        message = super()._pass_message(label, operation)
+        detail = operation.get("message")
+        return f"{message} ({detail})" if detail else message
 
 
 class ReturnNodeMaintenanceCheck(_OperationCheck):

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -13,6 +13,7 @@ from isvtest.core.validation import BaseValidation
 from isvtest.validations.breakfix import (
     CordonNodeCheck,
     FailureNotificationCheck,
+    GpuRepairRequestCheck,
     GpuResetCheck,
     HostReplacementCheck,
     MaintenanceEventsCheck,
@@ -144,6 +145,26 @@ class TestOperationChecks:
         check = _run(ReturnNodeMaintenanceCheck, step_output)
         assert check.passed
         assert "maintenance_mode=hw" in check.message
+
+    def test_gpu_repair_request_keys_off_the_observed_state(self) -> None:
+        """An accepted request that never changed the node's state is not a pass.
+
+        The provider returning 200 proves only that the API exists; the check has
+        to see the node actually enter repair.
+        """
+        step_output = {"success": True, "operation": {"requested": True, "repair_state_observed": False}}
+        assert not _run(GpuRepairRequestCheck, step_output).passed
+
+    def test_gpu_repair_request_reports_restoration(self) -> None:
+        """A passing GPU repair request states whether the node came back out of repair."""
+        step_output = {
+            "success": True,
+            "operation": {"requested": True, "repair_state_observed": True, "restored": True, "node_id": "fm-1"},
+        }
+        check = _run(GpuRepairRequestCheck, step_output)
+        assert check.passed
+        assert "fm-1" in check.message
+        assert "restored=True" in check.message
 
 
 class TestNodeHealthAgentCheck:

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -155,8 +155,8 @@ class TestOperationChecks:
         step_output = {"success": True, "operation": {"requested": True, "repair_state_observed": False}}
         assert not _run(GpuRepairRequestCheck, step_output).passed
 
-    def test_gpu_repair_request_reports_restoration(self) -> None:
-        """A passing GPU repair request states whether the node came back out of repair."""
+    def test_gpu_repair_request_names_the_node_it_moved(self) -> None:
+        """A clean pass names the node and carries no extra provider detail."""
         step_output = {
             "success": True,
             "operation": {"requested": True, "repair_state_observed": True, "restored": True, "node_id": "fm-1"},
@@ -164,7 +164,22 @@ class TestOperationChecks:
         check = _run(GpuRepairRequestCheck, step_output)
         assert check.passed
         assert "fm-1" in check.message
-        assert "restored=True" in check.message
+
+    def test_gpu_repair_request_surfaces_a_provider_finding_on_pass(self) -> None:
+        """A cleanup that needed the fallback still passes, but must not do so silently."""
+        step_output = {
+            "success": True,
+            "operation": {
+                "requested": True,
+                "repair_state_observed": True,
+                "restored": True,
+                "node_id": "fm-1",
+                "message": "removed the override directly",
+            },
+        }
+        check = _run(GpuRepairRequestCheck, step_output)
+        assert check.passed
+        assert "removed the override directly" in check.message
 
 
 class TestNodeHealthAgentCheck:


### PR DESCRIPTION
Reworks BFX01-01. Supersedes the approach in #603. Refs #206.

## Why

BFX01-01 asked to reset GPUs "via the Breakfix API", but no provider break-fix API exposes an on-demand GPU reset. NICo's machine sub-resources are only `bmc/reset`, `dpu/reprovision`, `health-report`, `power`, `decommission`, `validation/run` — nothing GPU-scoped, and `power` is `PROVIDER_ADMIN`-only. The repair automation behind it discovers work by polling and then waits on human tickets, so there is no GPU-reset request/response anywhere to test.

What a tenant *can* do synchronously is report a GPU fault and watch the provider move the node into a repair state. That is what this tests.

## What changed

- **BFX01-01 → the provider API.** New `request_gpu_repair` step uses NICo online repair (`PATCH machine` with `onlineRepair` + `healthIssue`) and asserts the instance goes `Ready → Repairing → Ready`. New `GpuRepairRequestCheck` validates it. NICo's own runbook uses a GPU fault as its worked example.
- **Tenant-side reset → BFX01-06.** `GpuResetCheck` keeps its in-cluster SSH behaviour under a new id, with a summary saying what it proves: it exercises the tenant's own node access and passes with or without a provider. The two can't share a `test_id` — coverage requires shared ids to carry identical labels.
- Nothing regresses: BFX01-01's only implementation today is the `my-isv` stub that returns "Not implemented" outside demo mode.

## Safety

Mutating requires an opt-in. An auto-discovered target is reported in a skip naming the node (so a plain run is a dry run); the operator confirms with `--machine-id` or `NICO_ALLOW_ONLINE_REPAIR=1`. Shared lab sites often carry exactly one tenant instance and it usually isn't yours.

Restore is belt-and-braces: re-mint the token first (a long run can outlive it, and a 401 there would strand the node), fall back to deleting the `request-online-repair` override, and report needing that fallback on `operation.message` rather than passing silently. Deadlines are sized so enter + clear + fallback fit the step timeout.

Skips rather than fails when no GPU machine has a `Ready` instance — unmet precondition, not a provider defect.

## Verification

Against a live NICo `v2.2.0-pr-242` deployment: both request bodies accepted (enter, and the flag-only exit), credentials clear the permission gate, the rejection path is side-effect-free (`machine.go` returns on `!machine.IsAssigned` before the transaction opens), and `includeMetadata=false` still returns `machineCapabilities` so GPU detection survives.

`make lint`, `make test`, `isvctl test validate`, plan coverage, suite wiring, and `uvx pre-commit run -a` pass.

**Not verified: the happy-path transition.** It needs a site with a tenant instance; ours has none (no OS registered, `imageBasedOperatingSystem: false`). Skip path, request bodies, polling, and restore are unit-tested — the live transition is not.

## Also here

- `delete_if_present` promoted into `nico_client`, fixing a bug in the fallback: a 404 means the override is already gone (success) but was reported as a cleanup failure.
- `list_site_machines` takes an optional pre-resolved auth and `include_metadata` flag, so the step mints one token instead of two. Defaults keep its three other callers unchanged.
- `my-isv/scripts/breakfix/reset_gpus.py` renumbered to BFX01-06 — the file external ISVs copy.

## Open question

Whether BFX01-06 should exist at all: it has an honest summary but no real implementation, so if #603 is abandoned it's an empty shell. Out of scope here.