### PR TITLE
feat(breakfix): implement BFX01-06 node repair report via the NICo repair API

### DIFF
--- a/docs/requirements/test-requirements-matrix.adoc
+++ b/docs/requirements/test-requirements-matrix.adoc
@@ -1479,6 +1479,15 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | full
 |
 
+| [[BFX01-06]]BFX01-06
+| Infrastructure and Data Services
+| Break-Fix
+| Report an individual node to the provider for maintenance via the API
+| BFX01
+| offtake
+| full
+|
+
 | [[BFX02-01]]BFX02-01
 | Infrastructure and Data Services
 | Break-Fix

--- a/docs/requirements/test-requirements-matrix.yaml
+++ b/docs/requirements/test-requirements-matrix.yaml
@@ -1129,6 +1129,13 @@ mappings:
         coverage: full
     annotations: ''
     notes: ''
+  - test_id: BFX01-06
+    requirements:
+      - req_id: BFX01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
   - test_id: BFX02-01
     requirements:
       - req_id: BFX02

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -311,7 +311,7 @@ a|
 | pending
 |
 
-.142+| Infrastructure and Data Services
+.143+| Infrastructure and Data Services
 .9+| Control Plane accessible
 .9+| Control plane can be accessed
 .9+|
@@ -2183,13 +2183,13 @@ a|
 | approved
 |
 
-.14+| Break-Fix
+.15+| Break-Fix
 .3+| A break-fix service works with a variety of components to detect, triage, remediate, and validate nodes in an AI factory. The critical focus here is on the GPU nodes, but the system can scale beyond.
 .3+| Lazarus, Shoreline
 | [[BFX04-01]]BFX04-01
 | BFX04
 |
-|
+| bare_metal, breakfix
 |
 | P1
 a|
@@ -2203,7 +2203,7 @@ a|
 | [[BFX05-01]]BFX05-01
 | BFX05
 |
-|
+| bare_metal, breakfix
 |
 |
 a|
@@ -2217,7 +2217,7 @@ a|
 | [[BFX06-01]]BFX06-01
 | BFX06
 |
-|
+| bare_metal, breakfix
 |
 |
 a|
@@ -2228,12 +2228,12 @@ a|
 | approved
 |
 
-.5+| Breakfix API Lifecycle
-.5+|
+.6+| Breakfix API Lifecycle
+.6+|
 | [[BFX01-01]]BFX01-01
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
-| min_req
+| breakfix, kubernetes, min_req
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
@@ -2247,7 +2247,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
 | [[BFX01-02]]BFX01-02
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
@@ -2261,7 +2261,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
 | [[BFX01-03]]BFX01-03
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
@@ -2275,7 +2275,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
 | [[BFX01-04]]BFX01-04
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
-| min_req
+| breakfix, kubernetes, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
@@ -2289,7 +2289,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
 | [[BFX01-05]]BFX01-05
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
@@ -2300,12 +2300,26 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
 | pending
 |
 
+| [[BFX01-06]]BFX01-06
+| BFX01
+| https://github.com/NVIDIA/ai-cloud-validation/issues/610[#610]
+| bare_metal, breakfix, min_req
+| The non-destructive counterpart to BFX01-02 - the tenant keeps the node and its workload while flagging that it needs repair eventually. Return relinquishes the node; report does not.
+| P1
+a| https://github.com/NVIDIA/ai-cloud-validation/issues/610[#610]
+|
+| M5
+|
+| Report an individual node to the provider for maintenance via the API
+| pending
+|
+
 .3+| Breakfix Events Query
 .3+|
 | [[BFX02-01]]BFX02-01
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
@@ -2319,7 +2333,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
 | [[BFX02-02]]BFX02-02
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
@@ -2333,7 +2347,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
 | [[BFX02-03]]BFX02-03
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
@@ -2363,7 +2377,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
 | [[BFX03-02]]BFX03-02
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
@@ -2377,7 +2391,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
 | [[BFX03-03]]BFX03-03
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]
-| min_req
+| bare_metal, breakfix, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2100,6 +2100,19 @@ domains:
                 req_id: BFX01
                 test_id: BFX01-05
                 status: pending
+              - summary: Report an individual node to the provider for maintenance via the API
+                labels:
+                  - bare_metal
+                  - breakfix
+                  - min_req
+                priority: P1
+                milestone: M5
+                notes: The non-destructive counterpart to BFX01-02 - the tenant keeps the node and its workload while flagging that it needs repair eventually. Return relinquishes the node; report does not.
+                github_issues:
+                  - "#610"
+                req_id: BFX01
+                test_id: BFX01-06
+                status: pending
           - description: Breakfix Events Query
             tests:
               - summary: Query upcoming/current maintenance events for a node

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -436,6 +436,28 @@ commands:
           - "{{nico_api_base}}"
         timeout: 120
 
+      # Reports a node for repair via NICo online repair and watches the assigned
+      # instance move Ready -> Repairing -> Ready. Online repair is cleared in a
+      # finally, so a node cannot be stranded out of the pool. Skips when the site
+      # has no machine with a Ready instance.
+      #
+      # Skips by default even when a target exists: it names the node it would use
+      # and waits for the operator to confirm, because a shared site's only tenant
+      # instance may not be ours. Allow it with NICO_ALLOW_ONLINE_REPAIR=1, or add
+      # --machine-id <id> here to pin a node you own.
+      - name: report_node_repair
+        phase: test
+        continue_on_failure: true
+        command: "python ../scripts/breakfix/report_node_repair.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 900
+
       - name: return_node_maintenance
         phase: test
         continue_on_failure: true

--- a/isvctl/configs/providers/nico/scripts/auth/_key_access.py
+++ b/isvctl/configs/providers/nico/scripts/auth/_key_access.py
@@ -45,10 +45,9 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.error import HTTPError
 
 from common.nico_client import (
-    forge_delete,
+    delete_if_present,
     forge_get,
     forge_patch,
     forge_post,
@@ -151,16 +150,6 @@ def provision(*, org: str, site_id: str, api_base: str, token: str, created: Thr
             pass
 
 
-def _delete_if_present(org: str, path: str, token: str, *, base_url: str) -> None:
-    """DELETE a NICo resource; treat 404 as already removed."""
-    try:
-        forge_delete(org, path, token, base_url=base_url)
-    except HTTPError as e:
-        if e.code == 404:
-            return
-        raise
-
-
 def remove(*, org: str, site_id: str, api_base: str, token: str, created: ThrowawayKey) -> list[str]:
     """Remove what ``provision`` created; return a list of cleanup failures.
 
@@ -175,7 +164,7 @@ def remove(*, org: str, site_id: str, api_base: str, token: str, created: Throwa
         if not resource_id:
             continue
         try:
-            _delete_if_present(org, f"{resource}/{resource_id}", token, base_url=api_base)
+            delete_if_present(org, f"{resource}/{resource_id}", token, base_url=api_base)
         except Exception as e:
             errors.append(f"{resource} {resource_id}: {type(e).__name__}: {e}")
 

--- a/isvctl/configs/providers/nico/scripts/breakfix/_common.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/_common.py
@@ -9,28 +9,39 @@ import json
 from typing import Any
 from urllib.error import URLError
 
-from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+from common.nico_client import NicoAuth, NicoAuthError, forge_get_all, resolve_auth
 
 
 def list_site_machines(
-    *, org: str, site_id: str, api_base: str, empty_contract: dict[str, Any] | None = None
+    *,
+    org: str,
+    site_id: str,
+    api_base: str,
+    empty_contract: dict[str, Any] | None = None,
+    auth: NicoAuth | None = None,
+    include_metadata: bool = True,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Fetch machines for a site, or build the structured failure/skip payload.
 
     Returns ``(machines, result)``. When ``machines`` is empty the caller must
     emit ``result`` and stop: it already carries the skip or the error, plus the
     zeroed ``empty_contract`` fields the bound validation still expects to read.
+
+    A caller that already holds credentials passes ``auth`` so the token is minted
+    once per run rather than once per helper. ``include_metadata`` can be turned
+    off by callers that only read a machine's identity and capabilities, which
+    keeps the listing and its per-page parsing small.
     """
     result: dict[str, Any] = {"success": False, "platform": "nico", "site_id": site_id}
     result.update(empty_contract or {})
     try:
-        auth = resolve_auth()
+        auth = auth or resolve_auth()
         machines = forge_get_all(
             org,
             "machine",
             auth.token,
             base_url=api_base,
-            params={"siteId": site_id, "includeMetadata": "true"},
+            params={"siteId": site_id, "includeMetadata": "true" if include_metadata else "false"},
             result_key="machines",
         )
     except NicoAuthError as exc:

--- a/isvctl/configs/providers/nico/scripts/breakfix/report_node_repair.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/report_node_repair.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report a node to the provider for maintenance and observe the repair state (BFX01-06).
+
+BFX01-06 is the non-destructive half of the break-fix lifecycle: "this node needs
+repair eventually, but I am still using it". The tenant keeps the node and its
+workload; only the provider's view of the node changes. Relinquishing the node so
+the provider can drain and repair it is the destructive counterpart, BFX01-02.
+
+The mechanism is NICo's *online repair*: a privileged tenant reports a
+``healthIssue`` against a machine, NICo applies a site health override and moves
+the assigned instance from ``Ready`` to ``Repairing``, and clearing online repair
+takes it back out again. The instance keeps its tenant assignment throughout, so
+the round trip is reversible -- unlike release-for-repair (``DELETE instance``
+with ``machineHealthIssue``), which hands the node back.
+
+The report is deliberately node-scoped rather than component-scoped. A tenant may
+well be reporting a bad GPU, but NICo manages machines, not GPUs, and its own
+online-repair documentation treats a GPU fault as something a tenant *reports*
+against the node. So there is one report path for any hardware complaint.
+
+Online repair requires a machine with an assigned instance in ``Ready``. A site
+with no such machine emits a structured skip rather than a failure: nothing is
+broken, the precondition simply is not met.
+
+NICo API endpoints used (the ``/carbide/`` segment is the current deployed name
+for what newer docs call ``/nico/``; the other NICo scripts use it too):
+  GET   /{org}/carbide/machine?siteId={site_id}
+  GET   /{org}/carbide/instance/{instance_id}
+  PATCH /{org}/carbide/machine/{machine_id}   (operationId update-machine)
+
+Auth:
+  - NICO_BEARER_TOKEN, or OIDC client_credentials
+    (NICO_SSA_ISSUER / NICO_CLIENT_ID / NICO_CLIENT_SECRET).
+  - Requires provider admin, or a tenant admin whose tenant has the
+    ``TargetedInstanceCreation`` capability. NICo rejects anyone else with 403.
+
+Mutating requires the operator to opt in. A shared site's only eligible machine may
+belong to another tenant, so an auto-discovered target is reported in a structured
+skip rather than moved into repair -- which also makes a plain run a dry run. Confirm
+with ``--machine-id <id>``, or set ``NICO_ALLOW_ONLINE_REPAIR=1`` to accept whichever
+eligible node is found.
+
+Entering online repair requires acknowledging data-corruption and repair-team-access
+risk; those acknowledgements are NICo's required contract, not a choice this step
+makes. ``allowAutoInstanceDeletionOnFailure`` is pinned ``false`` so NICo never
+deletes the tenant's instance on our behalf.
+
+Online repair is cleared in a ``finally``, so the node cannot be left in
+``Repairing`` even when the teardown phase never runs. See ``_restore`` for how far
+that goes and why -- a node stranded out of the allocatable pool is the worst
+outcome this step can produce.
+
+``--skip-restore`` leaves the node in repair for debugging; recover with
+``PATCH machine`` ``{"onlineRepair": {"enabled": false}}``, or
+``DELETE /machine/{id}/health-report/request-online-repair``.
+
+The JSON contract is ``operation.{requested, repair_state_observed, restored,
+node_id, message}``, documented alongside the other break-fix steps in
+``isvctl/configs/suites/README.md`` and asserted by ``ReportNodeRepairCheck``.
+
+Usage:
+    NICO_BEARER_TOKEN=<token> \
+        python report_node_repair.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    infra-controller docs/manuals/repair/online_repair.md
+    infra-controller rest-api/openapi/spec.yaml (update-machine, MachineUpdateRequest)
+"""
+
+import argparse
+import contextlib
+import os
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breakfix._common import emit, list_site_machines
+from common.inventory import first_string
+from common.nico_client import (
+    NicoAuth,
+    NicoAuthError,
+    delete_if_present,
+    forge_get,
+    forge_patch,
+    resolve_auth,
+)
+
+REPAIR_STATUS = "Repairing"
+READY_STATUS = "Ready"
+
+# Health override NICo applies while online repair is active. Removing it is the
+# fallback when clearing online repair through update-machine does not take effect.
+ONLINE_REPAIR_OVERRIDE_SOURCE = "request-online-repair"
+
+# A site's only eligible machine may belong to someone else -- shared lab sites
+# routinely carry exactly one tenant instance -- and this step would put it into
+# Repairing. So an auto-selected target is reported, not mutated: the operator opts
+# in by naming the machine, or by setting this to "1" to accept whatever is found.
+# The sibling query_key_access.py mutates by default and opts *out* via
+# --no-provision; the difference is blast radius. Minting a throwaway SSH key
+# affects nobody, whereas moving a stranger's instance into a repair state does.
+AUTO_SELECT_ENV = "NICO_ALLOW_ONLINE_REPAIR"
+
+POLL_INTERVAL_SECONDS = 5
+# Generous because NICo applies the override through a site workflow that may queue
+# behind other work; a false "never entered repair" is worse than waiting. The worst
+# path spends this twice (enter, then clear) plus the shorter fallback below, so the
+# step timeout in the provider config must exceed their sum with room for latency.
+POLL_DEADLINE_SECONDS = 300
+# The override-removal fallback runs only after the primary clear already spent its
+# deadline, so it gets a shorter one: it mutates machine state directly instead of
+# queueing a site workflow, and the two waits together must fit the step timeout.
+FALLBACK_POLL_DEADLINE_SECONDS = 90
+
+# NICo requires a healthIssue when entering online repair. Category must be one of
+# Hardware, Network, Performance, Storage, Software, Other.
+NODE_HEALTH_ISSUE: dict[str, str] = {
+    "category": "Hardware",
+    "summary": "Validation suite node repair report (BFX01-06)",
+    "details": (
+        "Reported by the NVIDIA AI Cloud Validation Suite to verify that a tenant can flag a node "
+        "as needing repair and have the provider move it into a repair state. No physical fault is "
+        "implied and no repair action is expected; online repair is cleared again immediately."
+    ),
+}
+
+
+def _enter_body() -> dict[str, Any]:
+    """Build the update-machine body that enters online repair."""
+    return {
+        "onlineRepair": {
+            "enabled": True,
+            # Pinned false: NICo must never delete the tenant's instance on our behalf.
+            "policy": {"allowAutoInstanceDeletionOnFailure": False},
+            "acknowledgments": {
+                "acceptDataCorruptionRisk": True,
+                "acceptRepairTeamAccess": True,
+                "acceptInstanceDeletionRisk": True,
+            },
+        },
+        "healthIssue": dict(NODE_HEALTH_ISSUE),
+    }
+
+
+def _exit_body() -> dict[str, Any]:
+    """Build the update-machine body that clears online repair.
+
+    NICo rejects the exit request if it carries healthIssue, policy, or
+    acknowledgments, so it must contain nothing but the flag.
+    """
+    return {"onlineRepair": {"enabled": False}}
+
+
+def _instance_status(org: str, instance_id: str, token: str, *, base_url: str) -> str:
+    """Return an instance's current status, or an empty string when absent."""
+    instance = forge_get(org, f"instance/{instance_id}", token, base_url=base_url)
+    return first_string(instance, "status")
+
+
+def _await_status(
+    org: str,
+    instance_id: str,
+    token: str,
+    *,
+    base_url: str,
+    target: str,
+    leaving: bool = False,
+    deadline_seconds: int = POLL_DEADLINE_SECONDS,
+) -> str:
+    """Poll an instance until it reaches (or leaves) ``target``; return the last status.
+
+    NICo applies the health override through a site workflow, so the instance
+    status changes shortly after the API returns rather than within it.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    while True:
+        status = _instance_status(org, instance_id, token, base_url=base_url)
+        reached = (status != target) if leaving else (status == target)
+        if reached or time.monotonic() >= deadline:
+            return status
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def _machines_with_instances(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return machines that have an assigned instance."""
+    return [m for m in machines if m.get("instanceId")]
+
+
+def _select_target(
+    candidates: list[dict[str, Any]], org: str, token: str, *, base_url: str, machine_id: str = ""
+) -> tuple[dict[str, Any], str] | None:
+    """Return the first (machine, instance_id) whose instance is ``Ready``.
+
+    ``machine_id`` restricts the search to one machine, so an operator can target
+    a known node instead of whichever the site happens to offer first.
+    """
+    for machine in candidates:
+        if machine_id and machine.get("id") != machine_id:
+            continue
+        instance_id = str(machine.get("instanceId") or "")
+        if _instance_status(org, instance_id, token, base_url=base_url) == READY_STATUS:
+            return machine, instance_id
+    return None
+
+
+def _skip_reason(machines: list[dict[str, Any]], candidates: list[dict[str, Any]], machine_id: str) -> str:
+    """Explain why no machine at the site can exercise online repair."""
+    if machine_id:
+        return f"Machine {machine_id} does not have an assigned instance in {READY_STATUS}; online repair requires one"
+    if not candidates:
+        return (
+            f"None of the {len(machines)} machine(s) at the site has an assigned instance; "
+            "online repair requires a node with a tenant instance"
+        )
+    return (
+        f"{len(candidates)} machine(s) have instances but none is in {READY_STATUS}; "
+        "online repair requires a Ready instance"
+    )
+
+
+def _attempt_exit(
+    org: str,
+    instance_id: str,
+    token: str,
+    *,
+    api_base: str,
+    apply: Callable[[], object],
+    what: str,
+    deadline_seconds: int,
+) -> tuple[bool, str]:
+    """Run one exit attempt and wait for the node to leave repair.
+
+    ``apply`` performs the mutation -- clearing online repair, or removing the
+    health override. Returns ``(left_repair, detail)``, where ``detail`` is empty
+    on success and describes the failure otherwise.
+    """
+    try:
+        apply()
+        status = _await_status(
+            org,
+            instance_id,
+            token,
+            base_url=api_base,
+            target=REPAIR_STATUS,
+            leaving=True,
+            deadline_seconds=deadline_seconds,
+        )
+        if status != REPAIR_STATUS:
+            return True, ""
+        return False, f"instance stayed in {REPAIR_STATUS} after {what}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _restore(org: str, machine_id: str, instance_id: str, *, api_base: str, fallback_token: str) -> dict[str, Any]:
+    """Take the node back out of repair, and report how much effort that took.
+
+    Returns ``{"restored": bool, "warning": str, "errors": [...]}``. Clearing
+    online repair the documented way is tried first; if that leaves the node in
+    repair, the health override is removed directly. Only a node still in repair
+    after both attempts is an error -- needing the fallback is a provider finding
+    worth reporting, but nothing was left behind.
+    """
+    token = fallback_token
+    # Re-mint first: the run can outlive a short-lived access token (NICo SSA
+    # tokens last minutes, not hours), and a 401 here would strand the node out of
+    # the allocatable pool. If minting fails, the original token is still worth trying.
+    with contextlib.suppress(NicoAuthError):
+        token = resolve_auth().token
+
+    left_repair, detail = _attempt_exit(
+        org,
+        instance_id,
+        token,
+        api_base=api_base,
+        apply=lambda: forge_patch(org, f"machine/{machine_id}", token, base_url=api_base, body=_exit_body()),
+        what="clearing online repair",
+        deadline_seconds=POLL_DEADLINE_SECONDS,
+    )
+    if left_repair:
+        return {"restored": True, "warning": "", "errors": []}
+
+    recovered, fallback_detail = _attempt_exit(
+        org,
+        instance_id,
+        token,
+        api_base=api_base,
+        apply=lambda: delete_if_present(
+            org, f"machine/{machine_id}/health-report/{ONLINE_REPAIR_OVERRIDE_SOURCE}", token, base_url=api_base
+        ),
+        what=f"removing the {ONLINE_REPAIR_OVERRIDE_SOURCE} override",
+        # The override delete mutates state directly rather than queueing a site
+        # workflow, so it needs far less room than entering repair did. Keeping the
+        # full deadline here would let restore alone consume the whole step timeout
+        # and get killed mid-cleanup -- the exact outcome this path exists to prevent.
+        deadline_seconds=FALLBACK_POLL_DEADLINE_SECONDS,
+    )
+    if recovered:
+        return {
+            "restored": True,
+            "warning": f"Clearing online repair did not take effect ({detail}); removed the override directly",
+            "errors": [],
+        }
+    return {"restored": False, "warning": "", "errors": [detail, fallback_detail]}
+
+
+def main() -> int:
+    """Report a node for repair, observe the repair state, and print the JSON contract."""
+    parser = argparse.ArgumentParser(description="Report a node for repair via the NICo online-repair API")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--machine-id", default="", help="Target a specific machine instead of the first eligible one")
+    parser.add_argument(
+        "--skip-restore",
+        action="store_true",
+        help="Leave the node in online repair for debugging (it is cleared by default)",
+    )
+    args = parser.parse_args()
+
+    operation: dict[str, Any] = {"requested": False, "repair_state_observed": False, "restored": False}
+
+    # Mint the token once and hand it to the listing helper, which would otherwise
+    # mint its own. On failure it stays None and the helper re-resolves, so the
+    # structured auth-error payload is still built in exactly one place.
+    auth: NicoAuth | None = None
+    with contextlib.suppress(NicoAuthError):
+        auth = resolve_auth()
+
+    machines, result = list_site_machines(
+        org=args.org,
+        site_id=args.site_id,
+        api_base=args.api_base,
+        empty_contract={"operation": operation},
+        auth=auth,
+        # Only id and instanceId are read below.
+        include_metadata=False,
+    )
+    if not machines:
+        return emit(result)
+
+    result["operation"] = operation
+    instance_id = ""
+
+    try:
+        if auth is None:
+            auth = resolve_auth()
+        candidates = _machines_with_instances(machines)
+        target = _select_target(candidates, args.org, auth.token, base_url=args.api_base, machine_id=args.machine_id)
+
+        if target is None:
+            result["skipped"] = True
+            result["skip_reason"] = _skip_reason(machines, candidates, args.machine_id)
+            return emit(result)
+
+        machine, instance_id = target
+        machine_id = str(machine.get("id") or "")
+        operation["node_id"] = machine_id
+
+        if not args.machine_id and os.environ.get(AUTO_SELECT_ENV) != "1":
+            # Report the target rather than mutating it. This doubles as a dry run:
+            # the operator sees exactly which node would enter repair before allowing it.
+            result["skipped"] = True
+            result["skip_reason"] = (
+                f"Would report machine {machine_id} for repair, but an auto-selected node "
+                f"is not mutated because it may belong to another tenant. Pass "
+                f"--machine-id {machine_id} to confirm this node, or set {AUTO_SELECT_ENV}=1 to "
+                f"accept whichever eligible node is found"
+            )
+            return emit(result)
+
+        forge_patch(args.org, f"machine/{machine_id}", auth.token, base_url=args.api_base, body=_enter_body())
+        operation["requested"] = True
+
+        status = _await_status(args.org, instance_id, auth.token, base_url=args.api_base, target=REPAIR_STATUS)
+        operation["repair_state_observed"] = status == REPAIR_STATUS
+        if not operation["repair_state_observed"]:
+            operation["message"] = (
+                f"Online repair was accepted but the instance stayed in {status or 'an unknown state'} "
+                f"rather than {REPAIR_STATUS} within {POLL_DEADLINE_SECONDS}s"
+            )
+
+    except NicoAuthError as e:
+        result["success"] = False
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["success"] = False
+        result["error"] = f"{type(e).__name__}: {e}"
+    finally:
+        # Take the node back out of repair in the process that put it there, so it
+        # cannot be left out of the allocatable pool even when teardown never runs.
+        if operation["requested"]:
+            if args.skip_restore:
+                result["cleanup_skipped"] = True
+            else:
+                outcome = _restore(
+                    args.org,
+                    str(operation["node_id"]),
+                    instance_id,
+                    api_base=args.api_base,
+                    fallback_token=auth.token if auth else "",
+                )
+                operation["restored"] = outcome["restored"]
+                if outcome["warning"]:
+                    # Carried in operation.message so the bound validation surfaces it;
+                    # a provider whose documented exit path did not work is a finding
+                    # worth reading even though nothing was left behind.
+                    operation["message"] = outcome["warning"]
+                if not outcome["restored"]:
+                    # A node stranded in repair must fail the step even when the report worked.
+                    result["cleanup_errors"] = outcome["errors"]
+                    result["success"] = False
+                    result["error"] = f"Node left in {REPAIR_STATUS}: {'; '.join(outcome['errors'])}"
+
+    return emit(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/common/nico_client.py
+++ b/isvctl/configs/providers/nico/scripts/common/nico_client.py
@@ -264,6 +264,20 @@ def forge_delete(org: str, path: str, token: str, *, base_url: str, timeout: int
     return forge_request(org, path, token, base_url=base_url, method="DELETE", timeout=timeout)
 
 
+def delete_if_present(org: str, path: str, token: str, *, base_url: str) -> None:
+    """DELETE a NICo resource, treating 404 as already removed.
+
+    Cleanup paths routinely race with the thing they are removing, so "it is not
+    there" is the desired end state rather than a failure.
+    """
+    try:
+        forge_delete(org, path, token, base_url=base_url)
+    except HTTPError as e:
+        if e.code == 404:
+            return
+        raise
+
+
 def forge_get_all(
     org: str,
     path: str,

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -265,6 +265,7 @@ its plan item is not platform-scoped.
 | `query_repair_history` | test | `providers/nico/scripts/breakfix/query_repair_history.py` | `history_queryable`, `records[].{machine_id,entries}` -- a record needs non-empty `entries` to count (BFX02-03) |
 | `query_switch_firmware` | test | `providers/my-isv/scripts/breakfix/query_switch_firmware.py` | `trays[].{tray_id,firmware_version}` (BFX03-02) |
 | `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,kernel_log_available}` (BFX03-03) |
+| `report_node_repair` | test | `providers/nico/scripts/breakfix/report_node_repair.py` | `operation.{requested,repair_state_observed,restored,node_id}` -- reports a node as needing repair while keeping it, and watches the node enter a repair state (BFX01-06) |
 | `return_node_maintenance` | test | `providers/my-isv/scripts/breakfix/return_node_maintenance.py` | `operation.{requested,accepted,machine_id,maintenance_mode}` (BFX01-02) |
 | `return_rack_maintenance` | test | `providers/my-isv/scripts/breakfix/return_rack_maintenance.py` | `operation.{requested,accepted,rack_id}` (BFX01-03) |
 | `request_host_replacement` | test | `providers/my-isv/scripts/breakfix/request_host_replacement.py` | `operation.{requested,node_removed_from_pool,machine_id}` (BFX01-05) |

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -836,6 +836,15 @@ tests:
           test_id: "BFX02-03"
           labels: ["bare_metal", "breakfix", "min_req"]
 
+    # Report a node as needing repair while keeping it, and verify the provider
+    # moves it into a repair state. The destructive counterpart is BFX01-02 below.
+    report_node_repair:
+      step: report_node_repair
+      checks:
+        ReportNodeRepairCheck:
+          test_id: "BFX01-06"
+          labels: ["bare_metal", "breakfix", "min_req"]
+
     return_node_maintenance:
       step: return_node_maintenance
       checks:

--- a/isvctl/src/isvctl/config/env_catalog.py
+++ b/isvctl/src/isvctl/config/env_catalog.py
@@ -139,6 +139,13 @@ ENV_VARS: tuple[EnvVar, ...] = (
         "skip AWS teardown phase",
         persistable=False,
     ),
+    EnvVar(
+        "NICO_ALLOW_ONLINE_REPAIR",
+        "Flags",
+        Requirement.OPTIONAL,
+        "allow BFX01-06 to move an auto-selected NICo node into repair",
+        persistable=False,
+    ),
     # NICo — optional by default; --provider nico runs strict provider-specific
     # checks for the same variables.
     EnvVar(

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -3933,3 +3933,317 @@ def test_query_key_access_no_provision_never_mutates(
     assert code == 0
     assert out["skipped"] is True
     assert calls == []
+
+
+def _load_node_repair_script() -> ModuleType:
+    """Load the report_node_repair script as a module for direct unit testing."""
+    return _load_nico_script("breakfix/report_node_repair.py", "test_nico_report_node_repair")
+
+
+def _repair_machine(machine_id: str, *, instance: str | None = None) -> dict[str, Any]:
+    """Build a minimal NICo machine record for node-repair eligibility tests."""
+    return {"id": machine_id, "instanceId": instance}
+
+
+def test_node_repair_requires_an_assigned_instance() -> None:
+    """Online repair is node-generic but still needs a tenant instance attached."""
+    module = _load_node_repair_script()
+    machines = [_repair_machine("no-instance", instance=None), _repair_machine("eligible", instance="i-1")]
+
+    eligible = module._machines_with_instances(machines)
+
+    assert [m["id"] for m in eligible] == ["eligible"]
+
+
+def test_node_repair_does_not_require_gpus() -> None:
+    """BFX01-06 reports a node, not a component, so a GPU-less node is eligible."""
+    module = _load_node_repair_script()
+
+    assert module._machines_with_instances([{"id": "cpu-only", "instanceId": "i-1"}])
+
+
+def test_node_repair_selects_the_first_ready_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Machines whose instance is not Ready are passed over, not attempted."""
+    module = _load_node_repair_script()
+    statuses = {"i-busy": "Provisioning", "i-ready": "Ready"}
+    monkeypatch.setattr(module, "forge_get", lambda _org, path, _tok, **_kw: {"status": statuses[path.split("/")[1]]})
+    candidates = [_repair_machine("m-busy", instance="i-busy"), _repair_machine("m-ready", instance="i-ready")]
+
+    target = module._select_target(candidates, "org", "tok", base_url="http://x")
+
+    assert target is not None
+    assert target[0]["id"] == "m-ready"
+    assert target[1] == "i-ready"
+
+
+def test_node_repair_honours_an_explicit_machine_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An operator-supplied machine id wins over whichever machine is listed first."""
+    module = _load_node_repair_script()
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    candidates = [_repair_machine("m-1", instance="i-1"), _repair_machine("m-2", instance="i-2")]
+
+    target = module._select_target(candidates, "org", "tok", base_url="http://x", machine_id="m-2")
+
+    assert target is not None
+    assert target[0]["id"] == "m-2"
+
+
+def test_node_repair_skip_reason_distinguishes_the_precondition() -> None:
+    """ "No node with an instance" and "none Ready" are different operator problems."""
+    module = _load_node_repair_script()
+    machines = [_repair_machine("m-1", instance=None)]
+
+    no_candidates = module._skip_reason(machines, [], "")
+    none_ready = module._skip_reason(machines, [_repair_machine("m-2", instance="i-2")], "")
+
+    assert "has an assigned instance" in no_candidates
+    assert "none is in Ready" in none_ready
+    assert "m-9" in module._skip_reason([], [], "m-9")
+
+
+def test_node_repair_enter_body_never_authorises_instance_deletion() -> None:
+    """allowAutoInstanceDeletionOnFailure stays false: the instance belongs to the tenant."""
+    module = _load_node_repair_script()
+
+    body = module._enter_body()
+
+    assert body["onlineRepair"]["enabled"] is True
+    assert body["onlineRepair"]["policy"]["allowAutoInstanceDeletionOnFailure"] is False
+    assert set(body["healthIssue"]) == {"category", "summary", "details"}
+
+
+def test_node_repair_exit_body_carries_only_the_flag() -> None:
+    """NICo rejects an online-repair exit that carries healthIssue, policy, or acknowledgments."""
+    module = _load_node_repair_script()
+
+    assert module._exit_body() == {"onlineRepair": {"enabled": False}}
+
+
+def test_node_repair_enter_body_does_not_alias_module_state() -> None:
+    """Each call gets its own healthIssue dict, so one run cannot corrupt the next."""
+    module = _load_node_repair_script()
+
+    first = module._enter_body()
+    first["healthIssue"]["summary"] = "mutated"
+
+    assert module._enter_body()["healthIssue"]["summary"] != "mutated"
+
+
+def test_node_repair_polls_until_the_state_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NICo applies the override through a site workflow, so the state lags the response."""
+    module = _load_node_repair_script()
+    seen = iter(["Ready", "Ready", "Repairing"])
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": next(seen)})
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing")
+
+    assert status == "Repairing"
+
+
+def test_node_repair_gives_up_at_the_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A node that never transitions returns its last status instead of hanging."""
+    module = _load_node_repair_script()
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+
+    status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing", deadline_seconds=0)
+
+    assert status == "Ready"
+
+
+def test_node_repair_restore_waits_for_the_state_to_clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restoration watches for the node to leave Repairing, not to equal Ready.
+
+    Exiting online repair need not land back on Ready immediately, so keying on
+    equality would report a false failure.
+    """
+    module = _load_node_repair_script()
+    seen = iter(["Repairing", "Updating"])
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": next(seen)})
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    status = module._await_status("org", "i-1", "tok", base_url="http://x", target="Repairing", leaving=True)
+
+    assert status == "Updating"
+
+
+def _record_restore_token(module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture the bearer token ``_restore`` actually sends on its exit PATCH."""
+    used: list[str] = []
+    monkeypatch.setattr(module, "forge_patch", lambda _org, _path, token, **_kw: used.append(token) or {})
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    monkeypatch.setattr(module, "delete_if_present", lambda *_a, **_kw: None)
+    return used
+
+
+def test_node_repair_restore_re_mints_the_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restoration mints a fresh token: a stale one would 401 and strand the node."""
+    module = _load_node_repair_script()
+    used = _record_restore_token(module, monkeypatch)
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="fresh"))
+
+    module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="stale")
+
+    assert used == ["fresh"]
+
+
+def test_node_repair_restore_falls_back_to_the_stale_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If re-minting fails, the original token is still worth trying."""
+    module = _load_node_repair_script()
+    used = _record_restore_token(module, monkeypatch)
+
+    def _boom() -> None:
+        raise module.NicoAuthError("issuer unreachable")
+
+    monkeypatch.setattr(module, "resolve_auth", _boom)
+
+    module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="stale")
+
+    assert used == ["stale"]
+
+
+def test_node_repair_restore_succeeds_on_the_documented_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clearing online repair normally needs no fallback and raises no warning."""
+    module = _load_node_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    deleted: list[str] = []
+    monkeypatch.setattr(module, "delete_if_present", lambda _o, path, *_a, **_kw: deleted.append(path))
+
+    outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
+
+    assert outcome["restored"] is True
+    assert outcome["warning"] == ""
+    assert deleted == []
+
+
+def _fast_clock() -> SimpleNamespace:
+    """A stand-in time module whose monotonic jumps ahead of any poll deadline.
+
+    ``_await_status`` binds its deadline as a default argument, so the module
+    constant cannot be lowered from a test. Advancing the clock instead makes each
+    poll give up after a single fetch rather than spinning for the real deadline.
+    """
+    ticks = iter(range(0, 10_000_000, 1000))
+    return SimpleNamespace(monotonic=lambda: next(ticks), sleep=lambda _s: None)
+
+
+def test_node_repair_restore_removes_the_override_when_clearing_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A node still in Repairing gets its override deleted, and that is a finding."""
+    module = _load_node_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "time", _fast_clock())
+
+    deleted: list[str] = []
+
+    def _delete(_org: str, path: str, *_a: object, **_kw: object) -> None:
+        deleted.append(path)
+
+    monkeypatch.setattr(module, "delete_if_present", _delete)
+
+    # Repairing until the override is gone, Ready afterwards.
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready" if deleted else "Repairing"})
+
+    outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
+
+    assert outcome["restored"] is True
+    assert outcome["errors"] == []
+    assert "removed the override directly" in outcome["warning"]
+    assert deleted == [f"machine/m-1/health-report/{module.ONLINE_REPAIR_OVERRIDE_SOURCE}"]
+
+
+def test_node_repair_restore_reports_a_stranded_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When both attempts fail the node is stranded, which must be an error not a warning."""
+    module = _load_node_repair_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(module, "forge_patch", lambda *_a, **_kw: {})
+    monkeypatch.setattr(module, "delete_if_present", lambda *_a, **_kw: None)
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Repairing"})
+    monkeypatch.setattr(module, "time", _fast_clock())
+
+    outcome = module._restore("org", "m-1", "i-1", api_base="http://x", fallback_token="t")
+
+    assert outcome["restored"] is False
+    assert outcome["warning"] == ""
+    assert len(outcome["errors"]) == 2
+
+
+def _node_repair_argv(*extra: str) -> list[str]:
+    """Build argv for the report_node_repair CLI."""
+    return ["report_node_repair.py", "--org", "ncx", "--site-id", "site-1", "--api-base", "http://x", *extra]
+
+
+def _stub_node_repair_discovery(module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Wire discovery so one eligible machine with a Ready instance is found.
+
+    Returns the list that records every mutating PATCH, so a test can assert the
+    guard let nothing through.
+    """
+    patched: list[dict[str, Any]] = []
+    machine = _repair_machine("m-1", instance="i-1")
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="t"))
+    monkeypatch.setattr(
+        module,
+        "list_site_machines",
+        lambda **kw: ([machine], {"success": True, "platform": "nico", "site_id": "site-1"}),
+    )
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Ready"})
+    monkeypatch.setattr(module, "forge_patch", lambda _o, _p, _t, **kw: patched.append(kw.get("body", {})) or {})
+    return patched
+
+
+def test_node_repair_does_not_mutate_an_auto_selected_node(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A shared site's only instance may not be ours, so auto-selection must not mutate."""
+    module = _load_node_repair_script()
+    patched = _stub_node_repair_discovery(module, monkeypatch)
+    monkeypatch.delenv(module.AUTO_SELECT_ENV, raising=False)
+    monkeypatch.setattr(sys, "argv", _node_repair_argv())
+
+    code = module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert code == 0
+    assert out["skipped"] is True
+    assert patched == []
+    # The skip has to name the node, so it doubles as a dry run.
+    assert "m-1" in out["skip_reason"]
+    assert module.AUTO_SELECT_ENV in out["skip_reason"]
+
+
+def test_node_repair_mutates_when_the_machine_is_named(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Naming the machine is the operator confirming that node, so the step proceeds."""
+    module = _load_node_repair_script()
+    patched = _stub_node_repair_discovery(module, monkeypatch)
+    monkeypatch.delenv(module.AUTO_SELECT_ENV, raising=False)
+    monkeypatch.setattr(module, "time", _fast_clock())
+    monkeypatch.setattr(sys, "argv", _node_repair_argv("--machine-id", "m-1"))
+
+    module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out.get("skipped") is not True
+    assert out["operation"]["requested"] is True
+    assert patched[0]["onlineRepair"]["enabled"] is True
+
+
+def test_node_repair_env_opt_in_allows_auto_selection(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The env opt-in accepts whichever eligible node discovery returns."""
+    module = _load_node_repair_script()
+    _stub_node_repair_discovery(module, monkeypatch)
+    monkeypatch.setenv(module.AUTO_SELECT_ENV, "1")
+    monkeypatch.setattr(module, "time", _fast_clock())
+    monkeypatch.setattr(sys, "argv", _node_repair_argv())
+
+    module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out.get("skipped") is not True
+    assert out["operation"]["requested"] is True

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -4247,3 +4247,30 @@ def test_node_repair_env_opt_in_allows_auto_selection(
 
     assert out.get("skipped") is not True
     assert out["operation"]["requested"] is True
+
+
+def test_node_repair_skip_restore_leaves_the_node_reported_as_unrestored(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--skip-restore strands the node by design, so it must not look restored.
+
+    The step keeps exit code 0 -- the report itself worked -- so the contract has
+    to carry the truth. ReportNodeRepairCheck fails on restored=False, which is
+    what stops a debugging run from being read as a clean pass.
+    """
+    module = _load_node_repair_script()
+    entered = _stub_node_repair_discovery(module, monkeypatch)
+    # Ready while the target is selected, Repairing once the report lands.
+    monkeypatch.setattr(module, "forge_get", lambda *_a, **_kw: {"status": "Repairing" if entered else "Ready"})
+    deleted: list[str] = []
+    monkeypatch.setattr(module, "delete_if_present", lambda _o, path, *_a, **_kw: deleted.append(path))
+    monkeypatch.setattr(module, "time", _fast_clock())
+    monkeypatch.setattr(sys, "argv", _node_repair_argv("--machine-id", "m-1", "--skip-restore"))
+
+    module.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out["cleanup_skipped"] is True
+    assert out["operation"]["repair_state_observed"] is True
+    assert out["operation"]["restored"] is False
+    assert deleted == []

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -3713,7 +3713,7 @@ def test_remove_deletes_group_before_key_and_restores_flag(monkeypatch: pytest.M
     module = _load_key_access_helpers()
     deletes: list[str] = []
     patched: dict[str, Any] = {}
-    monkeypatch.setattr(module, "forge_delete", lambda org, path, token, **kw: deletes.append(path) or {})
+    monkeypatch.setattr(module, "delete_if_present", lambda org, path, token, **kw: deletes.append(path))
     monkeypatch.setattr(
         module, "forge_patch", lambda org, path, token, *, base_url, body, **kw: patched.update(body) or {}
     )
@@ -3724,24 +3724,36 @@ def test_remove_deletes_group_before_key_and_restores_flag(monkeypatch: pytest.M
     assert patched == {"isSerialConsoleSSHKeysEnabled": False}
 
 
-def test_remove_treats_404_delete_as_already_gone(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DELETE 404 means the resource is already gone; removal reports no error."""
-    module = _load_key_access_helpers()
+def test_delete_if_present_treats_404_as_already_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DELETE 404 means the resource is already gone, which is the desired end state."""
+    module = _load_nico_client()
     monkeypatch.setattr(
         module,
         "forge_delete",
         lambda *a, **k: (_ for _ in ()).throw(HTTPError("http://x", 404, "Not Found", None, None)),
     )
 
-    created = module.ThrowawayKey(sshkey_id="key-1", sshkeygroup_id="kg-1")
-    assert module.remove(org="o", site_id="site-1", api_base="http://x", token="t", created=created) == []
+    assert module.delete_if_present("o", "sshkey/key-1", "t", base_url="http://x") is None
+
+
+def test_delete_if_present_reraises_other_http_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 409 is a real failure; swallowing it would hide a resource that is still there."""
+    module = _load_nico_client()
+    monkeypatch.setattr(
+        module,
+        "forge_delete",
+        lambda *a, **k: (_ for _ in ()).throw(HTTPError("http://x", 409, "Conflict", None, None)),
+    )
+
+    with pytest.raises(HTTPError):
+        module.delete_if_present("o", "sshkey/key-1", "t", base_url="http://x")
 
 
 def test_remove_continues_after_one_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """A stuck group delete must not strand the key; both failures are reported."""
     module = _load_key_access_helpers()
     monkeypatch.setattr(
-        module, "forge_delete", lambda org, path, token, **kw: (_ for _ in ()).throw(RuntimeError(f"boom {path}"))
+        module, "delete_if_present", lambda org, path, token, **kw: (_ for _ in ()).throw(RuntimeError(f"boom {path}"))
     )
 
     created = module.ThrowawayKey(sshkey_id="key-1", sshkeygroup_id="kg-1")
@@ -3756,7 +3768,7 @@ def test_remove_is_noop_without_ids(monkeypatch: pytest.MonkeyPatch) -> None:
     """Nothing created means nothing to remove."""
     module = _load_key_access_helpers()
     calls: list[str] = []
-    monkeypatch.setattr(module, "forge_delete", lambda *a, **k: calls.append("delete") or {})
+    monkeypatch.setattr(module, "delete_if_present", lambda *a, **k: calls.append("delete"))
     monkeypatch.setattr(module, "forge_patch", lambda *a, **k: calls.append("patch") or {})
 
     created = module.ThrowawayKey()

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -324,6 +324,40 @@ class HostReplacementCheck(_OperationCheck):
     pass_template: ClassVar[str] = "Host replacement removed {label} from the pool"
 
 
+class ReportNodeRepairCheck(_OperationCheck):
+    """Validate reporting a node to the provider for maintenance (BFX01-06).
+
+    The non-destructive counterpart to ``ReturnNodeMaintenanceCheck`` (BFX01-02):
+    the tenant keeps the node and its workload while flagging that it needs repair
+    eventually. So the pass condition is that the provider *acted* on the report by
+    moving the node into a repair state, not that the node was handed back.
+
+    Keying on the state change rather than on acceptance is deliberate. A 200 proves
+    only that the endpoint exists; the tenant-visible contract is that the provider
+    records the complaint against the node.
+
+    It claims nothing about the repair itself. Providers run repair automation
+    asynchronously -- typically minutes to weeks later, out of band from any API
+    response -- so no synchronous check can observe a fix.
+
+    Step output:
+        success, operation: {requested, repair_state_observed, restored, node_id}
+    """
+
+    description: ClassVar[str] = "Report an individual node to the provider for maintenance via the API"
+
+    completion_key: ClassVar[str] = "repair_state_observed"
+    failure_message: ClassVar[str] = "Provider did not move the node into a repair state after the report"
+    label_keys: ClassVar[tuple[str, ...]] = ("node_id", "machine_id")
+    pass_template: ClassVar[str] = "Node {label} reported for repair; provider moved it into a repair state"
+
+    def _pass_message(self, label: str, operation: dict[str, Any]) -> str:
+        """Append any provider finding raised while the node was taken back out of repair."""
+        message = super()._pass_message(label, operation)
+        detail = operation.get("message")
+        return f"{message} ({detail})" if detail else message
+
+
 class CordonNodeCheck(BaseValidation):
     """Validate cordon: unschedulable with existing workloads continuing (BFX01-04).
 

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -340,6 +340,11 @@ class ReportNodeRepairCheck(_OperationCheck):
     asynchronously -- typically minutes to weeks later, out of band from any API
     response -- so no synchronous check can observe a fix.
 
+    Reporting a node is only non-destructive if the node comes back, so ``restored``
+    is part of the pass condition rather than incidental cleanup. This is the only
+    BFX01 check whose step is expected to undo itself, hence the extra condition on
+    top of ``_OperationCheck``.
+
     Step output:
         success, operation: {requested, repair_state_observed, restored, node_id}
     """
@@ -350,6 +355,27 @@ class ReportNodeRepairCheck(_OperationCheck):
     failure_message: ClassVar[str] = "Provider did not move the node into a repair state after the report"
     label_keys: ClassVar[tuple[str, ...]] = ("node_id", "machine_id")
     pass_template: ClassVar[str] = "Node {label} reported for repair; provider moved it into a repair state"
+
+    not_restored_message: ClassVar[str] = (
+        "Node was left in a repair state; the report was accepted but the node was not returned to the pool"
+    )
+
+    def run(self) -> None:
+        """Assert the node entered a repair state *and* was taken back out of it."""
+        step_output = _step_output(self)
+        if step_output is None:
+            return
+        operation = step_output.get("operation") or {}
+        if not operation.get(self.completion_key):
+            self.set_failed(operation.get("message") or self.failure_message)
+            return
+        if not operation.get("restored"):
+            # A step that reports its own restore failure already fails via
+            # ``success``. This catches the cases that do not: a provider whose
+            # step forgot to, and --skip-restore, which strands the node by design.
+            self.set_failed(self.not_restored_message)
+            return
+        self.set_passed(self._pass_message(_record_label(operation, *self.label_keys), operation))
 
     def _pass_message(self, label: str, operation: dict[str, Any]) -> str:
         """Append any provider finding raised while the node was taken back out of repair."""

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -155,6 +155,32 @@ class TestOperationChecks:
         step_output = {"success": True, "operation": {"requested": True, "repair_state_observed": False}}
         assert not _run(ReportNodeRepairCheck, step_output).passed
 
+    def test_node_repair_report_fails_a_node_left_in_repair(self) -> None:
+        """Reporting a node is only non-destructive if the node comes back.
+
+        A step that fails its own restore already reports ``success: False``. This
+        covers the shapes that do not: a provider whose step forgot to, and
+        ``--skip-restore``, which strands the node deliberately.
+        """
+        step_output = {
+            "success": True,
+            "operation": {"requested": True, "repair_state_observed": True, "restored": False, "node_id": "fm-1"},
+        }
+        check = _run(ReportNodeRepairCheck, step_output)
+        assert not check.passed
+        assert "left in a repair state" in check.message
+
+    def test_node_repair_report_surfaces_a_failed_restore_from_the_step(self) -> None:
+        """The script fails itself when restore fails, and that error reaches the reader."""
+        step_output = {
+            "success": False,
+            "error": "Node left in Repairing: timeout; override delete failed",
+            "operation": {"requested": True, "repair_state_observed": True, "restored": False},
+        }
+        check = _run(ReportNodeRepairCheck, step_output)
+        assert not check.passed
+        assert "Node left in Repairing" in check.message
+
     def test_node_repair_report_names_the_node_it_moved(self) -> None:
         """A clean pass names the node and carries no extra provider detail."""
         step_output = {

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -19,6 +19,7 @@ from isvtest.validations.breakfix import (
     NodeHealthAgentCheck,
     PlannedMaintenanceNotificationCheck,
     RepairHistoryCheck,
+    ReportNodeRepairCheck,
     RetirementNoticesCheck,
     ReturnNodeMaintenanceCheck,
 )
@@ -144,6 +145,41 @@ class TestOperationChecks:
         check = _run(ReturnNodeMaintenanceCheck, step_output)
         assert check.passed
         assert "maintenance_mode=hw" in check.message
+
+    def test_node_repair_report_keys_off_the_observed_state(self) -> None:
+        """An accepted report that never changed the node's state is not a pass.
+
+        The provider returning 200 proves only that the API exists; the check has
+        to see the node actually enter repair.
+        """
+        step_output = {"success": True, "operation": {"requested": True, "repair_state_observed": False}}
+        assert not _run(ReportNodeRepairCheck, step_output).passed
+
+    def test_node_repair_report_names_the_node_it_moved(self) -> None:
+        """A clean pass names the node and carries no extra provider detail."""
+        step_output = {
+            "success": True,
+            "operation": {"requested": True, "repair_state_observed": True, "restored": True, "node_id": "fm-1"},
+        }
+        check = _run(ReportNodeRepairCheck, step_output)
+        assert check.passed
+        assert "fm-1" in check.message
+
+    def test_node_repair_report_surfaces_a_provider_finding_on_pass(self) -> None:
+        """A cleanup that needed the fallback still passes, but must not do so silently."""
+        step_output = {
+            "success": True,
+            "operation": {
+                "requested": True,
+                "repair_state_observed": True,
+                "restored": True,
+                "node_id": "fm-1",
+                "message": "removed the override directly",
+            },
+        }
+        check = _run(ReportNodeRepairCheck, step_output)
+        assert check.passed
+        assert "removed the override directly" in check.message
 
 
 class TestNodeHealthAgentCheck:


### PR DESCRIPTION
Closes #610.

## Summary

BFX01-06 is the non-destructive half of the break-fix lifecycle: the tenant flags a node as needing repair eventually while keeping it and its workload. BFX01-02 (return, #207) is the destructive counterpart.

NICo's *online repair* maps onto this directly. A privileged tenant `PATCH`es a machine with `onlineRepair.enabled` and a `healthIssue`, NICo applies a site health override, and the assigned instance moves `Ready` → `Repairing`; clearing online repair takes it back out. The instance keeps its tenant assignment throughout, so the round trip is reversible.

- New step `report_node_repair` (`providers/nico/scripts/breakfix/report_node_repair.py`), wired into the nico `bare_metal` config.
- New check `ReportNodeRepairCheck`, wired in `suites/bare_metal.yaml` as `BFX01-06`.
- New `BFX01-06` test-plan item — the plan had no entry for the report half of BFX01.
- `delete_if_present` moves into `nico_client`; `list_site_machines` gains `auth` / `include_metadata`.

## What the check asserts

The observed state change, not the API accepting the request — a 200 proves only that the endpoint exists. It also requires the node to come back out of repair, since that is what makes the report non-destructive. It claims nothing about the repair itself, which providers run asynchronously, out of band from any API response.

The report is node-scoped rather than component-scoped: NICo manages machines, not GPUs.

## Safety

- Online repair is cleared in a `finally`, with health-override removal as a fallback, so a node cannot be left out of the allocatable pool even when teardown never runs.
- An auto-selected node is never mutated — it is named in a structured skip, which makes a plain run a dry run. A shared site's only eligible machine routinely belongs to another tenant. Opt in with `--machine-id <id>` or `NICO_ALLOW_ONLINE_REPAIR=1`.

## Verification status

Both request bodies are verified against a live NICo `v2.2.0`. The `Ready` → `Repairing` → `Ready` transition is **not** — no site available to us has a tenant instance we own, so that path is unit-tested only.

## Notes

Supersedes #608 and #603, both closed: their premise (BFX01-01, a GPU reset via the break-fix API) was overturned at the 2026-08-27 requirements meeting, since no provider break-fix API exposes an on-demand GPU reset. The step is generalised here from GPU-specific to node-generic.

The check ships unreleased, so it is a no-op until a release commit adds it to `released_tests.json`. To exercise it: `ISVTEST_INCLUDE_UNRELEASED=1`.

`docs/test-plan.adoc` carries 13 lines of unrelated churn — the committed file had already drifted from its generator on `main`, and `make plan` rewrites the whole file.

## Test plan

- [x] `make lint`, `make test`, `make demo-test`
- [x] `uv run isvctl test validate -f isvctl/configs/providers/nico/config/bare_metal.yaml`
- [x] `uv run python scripts/test_plan_coverage.py --check`
- [x] `uv run python scripts/reqtrace.py validate`
- [x] `uv run python scripts/validate_suite_wiring.py`
- [x] `uvx pre-commit run -a`
- [x] `make plan` is idempotent on the committed tree