### PR TITLE
fix(breakfix): name the BFX empty shells and make their contracts real

### DIFF
--- a/docs/requirements/test-requirements-matrix.adoc
+++ b/docs/requirements/test-requirements-matrix.adoc
@@ -1437,7 +1437,7 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | [[BFX01-01]]BFX01-01
 | Infrastructure and Data Services
 | Break-Fix
-| Reset GPUs on an individual node via the Breakfix API
+| Request a reset of GPUs on an operator-managed node
 | BFX01
 | offtake
 | full
@@ -1536,7 +1536,7 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | [[BFX03-03]]BFX03-03
 | Infrastructure and Data Services
 | Break-Fix
-| Obtain BMC kernel log messages for a node
+| Query a node's log history through a telemetry endpoint
 | BFX03
 | offtake
 | full

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -2202,11 +2202,11 @@ a|
 
 | [[BFX05-01]]BFX05-01
 | BFX05
-|
+| https://github.com/NVIDIA/ai-cloud-validation/issues/556[#556]
 | bare_metal, breakfix
 |
 |
-a|
+a| https://github.com/NVIDIA/ai-cloud-validation/issues/556[#556]
 | LimitedEnv
 |
 |
@@ -2216,11 +2216,11 @@ a|
 
 | [[BFX06-01]]BFX06-01
 | BFX06
-|
+| https://github.com/NVIDIA/ai-cloud-validation/issues/557[#557]
 | bare_metal, breakfix
 |
 |
-a|
+a| https://github.com/NVIDIA/ai-cloud-validation/issues/557[#557]
 | LimitedEnv
 |
 |
@@ -2240,7 +2240,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
 |
 | M5
 |
-| Reset GPUs on an individual node via the Breakfix API
+| Request a reset of GPUs on an operator-managed node
 | pending
 |
 
@@ -2398,7 +2398,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]
 |
 | M5
 |
-| Obtain BMC kernel log messages for a node
+| Query a node's log history through a telemetry endpoint
 | pending
 |
 

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2018,6 +2018,8 @@ domains:
                 legacy_ids: [BFX-XX-02]
                 status: approved
                 notes: ""
+                github_issues:
+                  - "#556"
                 priority: ""
                 milestone: ""
               - summary: Verify that Tenants can be notified, by some communication system, of immediate node failure
@@ -2031,11 +2033,13 @@ domains:
                 legacy_ids: [BFX-XX-03]
                 status: approved
                 notes: ""
+                github_issues:
+                  - "#557"
                 priority: ""
                 milestone: ""
           - description: Breakfix API Lifecycle
             tests:
-              - summary: Reset GPUs on an individual node via the Breakfix API
+              - summary: Request a reset of GPUs on an operator-managed node
                 labels:
                   - breakfix
                   - kubernetes
@@ -2182,7 +2186,7 @@ domains:
                 req_id: BFX03
                 test_id: BFX03-02
                 status: pending
-              - summary: Obtain BMC kernel log messages for a node
+              - summary: Query a node's log history through a telemetry endpoint
                 labels:
                   - bare_metal
                   - breakfix

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
@@ -2,7 +2,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Query BMC kernel logs (BFX03-03) - my-isv template."""
+"""Query a node's log history (BFX03-03) - my-isv template.
+
+Empty shell: the requirement is a queryable log history or stream, not
+serial-over-LAN console access, and the ``kernel_log_available`` field name is a
+leftover from that original BMC framing.
+"""
 
 from __future__ import annotations
 

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
@@ -5,8 +5,8 @@
 """Query a node's log history (BFX03-03) - my-isv template.
 
 Empty shell: the requirement is a queryable log history or stream, not
-serial-over-LAN console access, and the ``kernel_log_available`` field name is a
-leftover from that original BMC framing.
+serial-over-LAN console access. This script's name and ``BmcKernelLogCheck`` are
+leftovers from that original BMC framing; the payload below is not.
 """
 
 from __future__ import annotations

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_bmc_kernel_logs.py
@@ -26,10 +26,19 @@ def main() -> int:
     parser.add_argument("--region", default="", help="Cloud region")
     _ = parser.parse_args()
 
+    # The window is what makes this a log *history*: a provider must answer for
+    # a period the tenant chose, not just tail whatever is happening now.
     return emit_stub(
         "query_bmc_kernel_logs",
-        hint="BMC kernel log query",
-        hosts=[{"host_id": "demo-host-001", "kernel_log_available": True}],
+        hint="node log history query (OTEL, OpenSearch, or equivalent)",
+        hosts=[
+            {
+                "host_id": "demo-host-001",
+                "window_start": "2026-06-24T00:00:00Z",
+                "window_end": "2026-06-24T12:00:00Z",
+                "entries_returned": 128,
+            }
+        ],
     )
 
 

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_failure_notifications.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_failure_notifications.py
@@ -25,11 +25,13 @@ def main() -> int:
         "query_failure_notifications",
         hint="immediate failure notification channel",
         notification_channel_observable=True,
+        # detected_at to notified_at is the latency "immediate" is measured by.
         notifications=[
             {
                 "machine_id": "demo-machine-001",
                 "type": "node_failure",
                 "message": "Node became unreachable; GPU fault detected",
+                "detected_at": "2026-06-24T11:59:30Z",
                 "notified_at": "2026-06-24T12:00:00Z",
             }
         ],

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/query_planned_notifications.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/query_planned_notifications.py
@@ -25,12 +25,14 @@ def main() -> int:
         "query_planned_notifications",
         hint="planned maintenance notification channel",
         notification_channel_observable=True,
+        # notified_at must precede window_start: the lead time is the point.
         notifications=[
             {
                 "machine_id": "demo-machine-001",
                 "type": "planned_maintenance",
                 "message": "Scheduled firmware update (demo)",
                 "notified_at": "2026-06-24T12:00:00Z",
+                "window_start": "2026-07-01T02:00:00Z",
             }
         ],
     )

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/reset_gpus.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/reset_gpus.py
@@ -20,17 +20,25 @@ from common.stub import emit_stub
 
 
 def main() -> int:
-    """Emit the GPU reset template result (BFX01-01)."""
-    parser = argparse.ArgumentParser(description="Reset GPUs via breakfix API (template)")
+    """Emit the GPU reset request template result (BFX01-01)."""
+    parser = argparse.ArgumentParser(description="Request a GPU reset via the breakfix API (template)")
     parser.add_argument("--region", default="", help="Cloud region")
     parser.add_argument("--machine-id", default="", help="Target machine/node id")
     args = parser.parse_args()
 
     node_id = args.machine_id or "demo-node-001"
+    # request_id is the handle the tenant polls: the reset itself completes
+    # asynchronously, so the step reports acceptance rather than completion.
     return emit_stub(
         "reset_gpus",
-        hint="GPU reset breakfix API",
-        operation={"requested": True, "completed": True, "node_id": node_id},
+        hint="GPU reset request API",
+        operation={
+            "requested": True,
+            "accepted": True,
+            "node_id": node_id,
+            "gpu_ids": ["GPU-00000000-0000-0000-0000-000000000000"],
+            "request_id": "demo-reset-request-001",
+        },
     )
 
 

--- a/isvctl/configs/providers/my-isv/scripts/breakfix/reset_gpus.py
+++ b/isvctl/configs/providers/my-isv/scripts/breakfix/reset_gpus.py
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reset GPUs on a node (BFX01-01) - my-isv template."""
+"""Request a GPU reset on an operator-managed node (BFX01-01) - my-isv template.
+
+Empty shell: no provider exposes an on-demand GPU reset, so there is no working
+implementation to copy here yet.
+"""
 
 from __future__ import annotations
 

--- a/isvctl/configs/providers/nico/scripts/breakfix/query_bmc_kernel_logs.py
+++ b/isvctl/configs/providers/nico/scripts/breakfix/query_bmc_kernel_logs.py
@@ -2,11 +2,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Query BMC kernel logs (BFX03-03) for NICo machines.
+"""Query a node's log history (BFX03-03) for NICo machines.
 
-Inspects machine health probes for BMC log/sel/kernel signals. NICo aggregates
-BMC telemetry into the health report rather than exposing raw kernel log
-streams on the tenant REST API.
+BFX03-03 asks for a queryable log history or stream -- OTEL, or an
+OpenSearch/Kibana equivalent -- over a window the tenant chooses. NICo has no
+such endpoint: it folds BMC telemetry into per-machine health probes, which
+report that a signal exists, not what it said or when.
+
+So this always emits a structured skip. It still inspects the probes and
+reports which hosts carry a BMC log signal, because "NICo sees something here"
+is useful context for whoever implements the real endpoint -- but that is
+diagnostic output, deliberately named apart from the ``hosts`` contract
+``BmcKernelLogCheck`` reads, so it cannot be mistaken for satisfying it.
 """
 
 from __future__ import annotations
@@ -38,8 +45,8 @@ def _has_kernel_log_signal(health: dict[str, Any]) -> bool:
 
 
 def main() -> int:
-    """Report per-host BMC kernel-log availability from NICo health probes as JSON."""
-    parser = argparse.ArgumentParser(description="Query BMC kernel logs (NICo)")
+    """Emit the BFX03-03 gap, with per-host BMC probe signals as context."""
+    parser = argparse.ArgumentParser(description="Query a node's log history (NICo)")
     parser.add_argument("--org", required=True)
     parser.add_argument("--site-id", required=True)
     parser.add_argument("--api-base", required=True)
@@ -54,27 +61,25 @@ def main() -> int:
     if not machines:
         return emit(result)
 
-    hosts: list[dict[str, Any]] = []
+    probes: list[dict[str, Any]] = []
     for machine in machines:
         health = machine.get("health") or {}
-        hosts.append(
+        probes.append(
             {
                 "host_id": machine.get("id", ""),
-                "kernel_log_available": _has_kernel_log_signal(health if isinstance(health, dict) else {}),
+                "bmc_log_probe_present": _has_kernel_log_signal(health if isinstance(health, dict) else {}),
             }
         )
 
-    if not any(host["kernel_log_available"] for host in hosts):
-        skip = skip_result(
-            args.site_id,
-            "NICo health API does not expose BMC kernel log messages on the tenant REST surface (BFX03-03 gap)",
-            gap="BFX03-03",
-        )
-        skip["hosts"] = hosts
-        return emit(skip)
-
-    result["hosts"] = hosts
-    return emit(result)
+    skip = skip_result(
+        args.site_id,
+        "NICo exposes no queryable log history or streaming endpoint on the tenant REST surface; "
+        "BMC telemetry is only summarised into health probes (BFX03-03 gap)",
+        gap="BFX03-03",
+    )
+    skip["hosts"] = []
+    skip["bmc_probe_signals"] = probes
+    return emit(skip)
 
 
 if __name__ == "__main__":

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -264,14 +264,14 @@ its plan item is not platform-scoped.
 | `query_retirement_notices` | test | `providers/my-isv/scripts/breakfix/query_retirement_notices.py` | `notices_queryable`, `notices` (BFX02-02) |
 | `query_repair_history` | test | `providers/nico/scripts/breakfix/query_repair_history.py` | `history_queryable`, `records[].{machine_id,entries}` -- a record needs non-empty `entries` to count (BFX02-03) |
 | `query_switch_firmware` | test | `providers/my-isv/scripts/breakfix/query_switch_firmware.py` | `trays[].{tray_id,firmware_version}` (BFX03-02) |
-| `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,kernel_log_available}` (BFX03-03) |
+| `query_bmc_kernel_logs` | test | `providers/nico/scripts/breakfix/query_bmc_kernel_logs.py` | `hosts[].{host_id,window_start,window_end,entries_returned}` -- a windowed query that returns entries, not a "logs available" boolean (BFX03-03) |
 | `report_node_repair` | test | `providers/nico/scripts/breakfix/report_node_repair.py` | `operation.{requested,repair_state_observed,restored,node_id}` -- reports a node as needing repair while keeping it, and watches the node enter a repair state (BFX01-06) |
 | `return_node_maintenance` | test | `providers/my-isv/scripts/breakfix/return_node_maintenance.py` | `operation.{requested,accepted,machine_id,maintenance_mode}` (BFX01-02) |
 | `return_rack_maintenance` | test | `providers/my-isv/scripts/breakfix/return_rack_maintenance.py` | `operation.{requested,accepted,rack_id}` (BFX01-03) |
 | `request_host_replacement` | test | `providers/my-isv/scripts/breakfix/request_host_replacement.py` | `operation.{requested,node_removed_from_pool,machine_id}` (BFX01-05) |
 | `query_node_health_agents` | test | `providers/my-isv/scripts/breakfix/query_node_health_agents.py` | `agents_observable`, `agents[].{node_id,agent_name,running}` (BFX04-01) |
-| `query_planned_notifications` | test | `providers/my-isv/scripts/breakfix/query_planned_notifications.py` | `notification_channel_observable`, `notifications[].{machine_id,type,message,notified_at}` (BFX05-01) |
-| `query_failure_notifications` | test | `providers/my-isv/scripts/breakfix/query_failure_notifications.py` | `notification_channel_observable`, `notifications[].{machine_id,type,message,notified_at}` (BFX06-01) |
+| `query_planned_notifications` | test | `providers/my-isv/scripts/breakfix/query_planned_notifications.py` | `notification_channel_observable`, `notifications[].{machine_id,type,message,notified_at,window_start}` -- `notified_at` must precede `window_start` (the lead time) (BFX05-01) |
+| `query_failure_notifications` | test | `providers/my-isv/scripts/breakfix/query_failure_notifications.py` | `notification_channel_observable`, `notifications[].{machine_id,type,message,detected_at,notified_at}` -- `detected_at` to `notified_at` is the latency (BFX06-01) |
 
 ### Storage (`storage.yaml`)
 
@@ -297,7 +297,7 @@ volume. The three test-phase steps all reuse that fixture.
 |------|-------|--------|
 | `setup` | setup | `providers/my-isv/scripts/k8s/setup.sh` |
 | `teardown` | teardown | `providers/my-isv/scripts/k8s/teardown.sh` |
-| `reset_gpus` | test | `providers/my-isv/scripts/breakfix/reset_gpus.py` (BFX01-01) |
+| `reset_gpus` | test | `providers/my-isv/scripts/breakfix/reset_gpus.py` -- `operation.{accepted,node_id,gpu_ids,request_id}`; the reset is asynchronous, so the step reports acceptance plus a handle to poll (BFX01-01) |
 | `cordon_node` | test | `providers/shared/breakfix/cordon_node.py` (BFX01-04) |
 
 Validations use `kubectl` directly (or a custom CLI via the `KUBECTL` env var): node counts, GPU operator, pod health, NCCL/NIM workloads. Break-fix cordon and GPU reset are optional provider steps.

--- a/isvctl/tests/test_breakfix_stub_contracts.py
+++ b/isvctl/tests/test_breakfix_stub_contracts.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract test that a break-fix scaffold satisfies the check wired to it.
+
+``test_stub_contracts.py`` guards the *CLI* edge -- the ``--flags`` a YAML step
+passes must exist in the script's argparse. This guards the other edge: the JSON
+a scaffold prints must satisfy the validation the suite binds to that step.
+
+Nothing else covers it. ``make demo-test`` exercises the pairing only as a side
+effect of running whole suites, and it does not run the ``k8s`` config at all --
+that suite's setup requires a live cluster -- so a break-fix contract change
+could sail through green while ``reset_gpus`` silently stopped matching
+``GpuResetCheck``. Running the scaffold directly needs no cluster and no cloud.
+
+Scope is the my-isv break-fix scaffolds: they exist to be copied by an ISV, so
+their output is the worked example of each contract. Shared and provider scripts
+are excluded because they do real work rather than emitting a fixed payload.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from isvtest.core.discovery import discover_all_tests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIGS_DIR = REPO_ROOT / "isvctl" / "configs"
+SCAFFOLD_DIR = CONFIGS_DIR / "providers" / "my-isv" / "scripts" / "breakfix"
+
+# Scaffolds print a fixed payload and exit, so anything approaching this is a
+# hang rather than slow work.
+SCRIPT_TIMEOUT_SECONDS = 30
+
+# Wiring keys that configure coverage reporting rather than the check itself.
+NON_CHECK_PARAMS = frozenset({"test_id", "labels"})
+
+JINJA_RE = re.compile(r"\{\{.*?\}\}")
+
+
+@dataclass(frozen=True)
+class ScaffoldCheck:
+    """One scaffold-to-validation pairing to exercise."""
+
+    config_name: str
+    step_name: str
+    script: Path
+    args: tuple[str, ...]
+    check_name: str
+    params: tuple[tuple[str, Any], ...]
+
+    def id(self) -> str:
+        return f"{self.step_name}->{self.check_name}"
+
+
+def _suite_wiring() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``step name -> {check class: wiring params}`` across every suite."""
+    wiring: dict[str, dict[str, dict[str, Any]]] = {}
+    for path in sorted(CONFIGS_DIR.glob("suites/*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        validations = (doc.get("tests") or {}).get("validations") or {}
+        for entry in validations.values():
+            if isinstance(entry, dict) and entry.get("step"):
+                wiring.setdefault(entry["step"], {}).update(entry.get("checks") or {})
+    return wiring
+
+
+def _collect() -> list[ScaffoldCheck]:
+    """Pair every my-isv break-fix scaffold with the checks its step is wired to."""
+    wiring = _suite_wiring()
+    found: list[ScaffoldCheck] = []
+    for path in sorted(CONFIGS_DIR.glob("providers/my-isv/config/*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for entry in (doc.get("commands") or {}).values():
+            for step in (entry.get("steps") or []) if isinstance(entry, dict) else []:
+                if not isinstance(step, dict) or step.get("skip"):
+                    continue
+                command = step.get("command") or ""
+                name = step.get("name")
+                script_token = next((t for t in command.split() if t.endswith(".py")), None)
+                if script_token is None or name not in wiring:
+                    continue
+                script = (path.parent / script_token).resolve()
+                if script.parent != SCAFFOLD_DIR:
+                    continue
+                for check_name, params in wiring[name].items():
+                    found.append(
+                        ScaffoldCheck(
+                            config_name=path.name,
+                            step_name=name,
+                            script=script,
+                            args=tuple(step.get("args") or []),
+                            check_name=check_name,
+                            params=tuple((params or {}).items()),
+                        )
+                    )
+    return found
+
+
+def _run_scaffold(case: ScaffoldCheck) -> dict[str, Any]:
+    """Run a scaffold in demo mode and return the JSON it printed."""
+    # Templates resolve from live run context that does not exist here. The value
+    # never matters: a scaffold echoes it back at most, and the contract under
+    # test is the payload's shape.
+    argv = [sys.executable, str(case.script), *(JINJA_RE.sub("demo", a) for a in case.args)]
+    result = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        cwd=case.script.parent,
+        env={**os.environ, "ISVCTL_DEMO_MODE": "1"},
+        stdin=subprocess.DEVNULL,
+        timeout=SCRIPT_TIMEOUT_SECONDS,
+        check=False,
+    )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        pytest.fail(
+            f"{case.id()}: {case.script.relative_to(REPO_ROOT)} printed no JSON "
+            f"(exit {result.returncode})\n  stdout: {result.stdout[:300]!r}\n  stderr: {result.stderr[:300]!r}"
+        )
+
+
+@pytest.fixture(scope="module")
+def validation_classes() -> dict[str, type]:
+    """Return every discoverable validation class by name (discovery is slow)."""
+    return {cls.__name__: cls for cls in discover_all_tests()}
+
+
+@pytest.mark.parametrize("case", _collect(), ids=lambda c: c.id() if isinstance(c, ScaffoldCheck) else "")
+def test_scaffold_output_satisfies_its_check(case: ScaffoldCheck, validation_classes: dict[str, type]) -> None:
+    """A scaffold's demo payload must pass the validation its step is wired to.
+
+    Demo mode exists to make the wiring pass end to end, so a skip here is a
+    failure too: it means the payload no longer carries what the check reads.
+    """
+    check_class = validation_classes.get(case.check_name)
+    assert check_class is not None, f"{case.id()}: no validation class named {case.check_name!r}"
+
+    step_output = _run_scaffold(case)
+    params = {k: v for k, v in case.params if k not in NON_CHECK_PARAMS}
+    check = check_class(config={"step_output": step_output, **params})
+
+    try:
+        check.run()
+    except pytest.skip.Exception as exc:
+        pytest.fail(
+            f"{case.id()}: scaffold payload made the check skip rather than pass ({exc}).\n"
+            f"  scaffold: {case.script.relative_to(REPO_ROOT)}\n  payload: {json.dumps(step_output)[:300]}"
+        )
+
+    assert check.passed, (
+        f"{case.id()}: scaffold payload does not satisfy the check.\n"
+        f"  scaffold: {case.script.relative_to(REPO_ROOT)}\n"
+        f"  message:  {check.message}\n  payload:  {json.dumps(step_output)[:300]}"
+    )
+
+
+def test_every_breakfix_scaffold_is_covered() -> None:
+    """Every scaffold in the break-fix directory must be reachable by this test.
+
+    A scaffold nobody wires is dead weight, and one wired under a name this test
+    does not resolve is worse: it looks covered and is not.
+    """
+    exercised = {c.script.name for c in _collect()}
+    on_disk = {p.name for p in SCAFFOLD_DIR.glob("*.py")}
+    assert on_disk - exercised == set(), (
+        f"break-fix scaffolds not reached by any wired step: {sorted(on_disk - exercised)}"
+    )

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -34,6 +34,7 @@ deliverable -- it is what an ISV would implement against.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any, ClassVar
 
 import pytest
@@ -57,6 +58,29 @@ def _has_fields(record: Any, *fields: str) -> bool:
     if not isinstance(record, dict):
         return False
     return all(str(record.get(field) or "").strip() for field in fields)
+
+
+def _timestamp(record: dict[str, Any], field: str) -> datetime | None:
+    """Parse an ISO 8601 timestamp from ``record``, or None when absent/malformed.
+
+    A timestamp that cannot be parsed is treated as missing rather than as an
+    error: these fields exist to be compared, and one that cannot be compared
+    evidences nothing.
+    """
+    try:
+        parsed = datetime.fromisoformat(str(record.get(field) or ""))
+    except ValueError:
+        return None
+    # Mixed offset-aware and naive values cannot be compared; normalise to UTC.
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def _ordered(record: Any, earlier: str, later: str) -> bool:
+    """Return whether ``record`` carries both timestamps and they are in order."""
+    if not isinstance(record, dict):
+        return False
+    first, second = _timestamp(record, earlier), _timestamp(record, later)
+    return first is not None and second is not None and first <= second
 
 
 def _step_output(check: BaseValidation) -> dict[str, Any] | None:
@@ -233,11 +257,17 @@ class BmcKernelLogCheck(BaseValidation):
 
     Empty shell: reframed from serial-over-LAN BMC console access to a queryable
     log history or stream (OTEL, or an OpenSearch/Kibana equivalent), which no
-    provider exposes -- the class name and ``kernel_log_available`` field are
-    leftovers from the original framing, kept because the check is released.
+    provider exposes. The class name is a leftover from the original framing,
+    kept because the check is released.
+
+    The contract asks a provider to prove it can answer a question, not to
+    declare that it could. A boolean "logs are available" is satisfiable by any
+    provider that returns ``true`` and builds nothing, so instead a host must
+    report the window it was asked about and how many entries came back -- the
+    window is what makes it a *history* rather than a live tail.
 
     Step output:
-        success, hosts: list[{host_id, kernel_log_available: bool}]
+        success, hosts: list[{host_id, window_start, window_end, entries_returned: int}]
     """
 
     description: ClassVar[str] = "Query a node's log history through a telemetry endpoint"
@@ -263,12 +293,20 @@ class BmcKernelLogCheck(BaseValidation):
         if unidentified:
             self.set_failed(f"{len(unidentified)} host record(s) missing host_id")
             return
-        unavailable = [h for h in hosts if not h.get("kernel_log_available")]
-        if unavailable:
-            labels = ", ".join(_record_label(h, "host_id", "machine_id") for h in unavailable[:3])
-            self.set_failed(f"BMC kernel logs unavailable for {len(unavailable)} host(s): {labels}")
+        unwindowed = [h for h in hosts if not _ordered(h, "window_start", "window_end")]
+        if unwindowed:
+            labels = ", ".join(_record_label(h, "host_id", "machine_id") for h in unwindowed[:3])
+            self.set_failed(
+                f"{len(unwindowed)} host(s) did not report an ordered query window (window_start, window_end): {labels}"
+            )
             return
-        self.set_passed(f"BMC kernel logs obtainable for {len(hosts)} host(s)")
+        empty = [h for h in hosts if not isinstance(h.get("entries_returned"), int) or h["entries_returned"] < 1]
+        if empty:
+            labels = ", ".join(_record_label(h, "host_id", "machine_id") for h in empty[:3])
+            self.set_failed(f"No log entries returned for {len(empty)} host(s) over the queried window: {labels}")
+            return
+        total = sum(h["entries_returned"] for h in hosts)
+        self.set_passed(f"Log history queryable for {len(hosts)} host(s); {total} entries returned")
 
 
 class _OperationCheck(BaseValidation):
@@ -326,16 +364,38 @@ class GpuResetCheck(_OperationCheck):
     synchronous request to make; reporting the node as needing repair instead is
     BFX01-06 (``ReportNodeRepairCheck``).
 
+    The contract is deliberately asynchronous. A reset runs through provider
+    automation that polls for work and can then wait on human intervention, so
+    a synchronous ``completed`` flag would be asserting something no provider
+    can honour. What a tenant can be owed is that the request is accepted, is
+    scoped to named GPUs, and comes back with a handle to poll -- completion is
+    observed later, out of band, and is not this check's business.
+
     Step output:
-        success, operation: {requested, completed, node_id}
+        success, operation: {accepted, node_id, gpu_ids: list[str], request_id}
     """
 
     description: ClassVar[str] = "Request a reset of GPUs on an operator-managed node"
 
-    completion_key: ClassVar[str] = "completed"
-    failure_message: ClassVar[str] = "GPU reset did not complete"
+    completion_key: ClassVar[str] = "accepted"
+    failure_message: ClassVar[str] = "GPU reset request was not accepted"
     label_keys: ClassVar[tuple[str, ...]] = ("node_id", "machine_id")
-    pass_template: ClassVar[str] = "GPU reset completed for node {label}"
+    pass_template: ClassVar[str] = "GPU reset requested for node {label}"
+
+    def _finish(self, operation: dict[str, Any]) -> None:
+        """Require the request be trackable and scoped before calling it accepted."""
+        if not _has_fields(operation, "request_id"):
+            self.set_failed("GPU reset was accepted without a request_id; the tenant cannot poll it to completion")
+            return
+        if not [g for g in (operation.get("gpu_ids") or []) if str(g).strip()]:
+            self.set_failed("GPU reset was accepted without naming any GPU in gpu_ids")
+            return
+        super()._finish(operation)
+
+    def _pass_message(self, label: str, operation: dict[str, Any]) -> str:
+        """Name the GPUs the request covered and the handle that tracks it."""
+        gpus = [g for g in (operation.get("gpu_ids") or []) if str(g).strip()]
+        return f"{super()._pass_message(label, operation)}: {len(gpus)} GPU(s), request {operation['request_id']}"
 
 
 class ReturnNodeMaintenanceCheck(_OperationCheck):
@@ -519,7 +579,7 @@ class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
 
     Step output:
         success, notification_channel_observable: bool
-        notifications: list[{machine_id, type, message, notified_at}]
+        notifications: list[{machine_id, type, message, notified_at, window_start}]
 
     Requires a real notification record, not just the observable flag: the flag
     alone is the provider asserting its own capability.
@@ -527,8 +587,11 @@ class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
     Empty shell: no provider exposes a maintenance notification channel, which
     needs to arrive far enough ahead of the window to drain workloads first.
 
-    ``notified_at`` is required because lead time is the whole value here: a
-    notification with no timestamp cannot be shown to have arrived in advance.
+    Lead time is the whole value here, and it takes two timestamps to show:
+    ``notified_at`` alone proves only that something arrived. ``window_start``
+    is what it has to arrive before. How much warning is *enough* is a number
+    nobody has set yet, so the check demands only that the notice precede the
+    window; a minimum lead time is the natural parameter to add once agreed.
     """
 
     description: ClassVar[str] = "Verify tenants can be notified of planned future node maintenance"
@@ -539,7 +602,11 @@ class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "planned maintenance notifications"
     api_label: ClassVar[str] = "Planned maintenance notification"
     record_noun: ClassVar[str] = "notification"
-    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id", "notified_at")
+    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id",)
+
+    def _is_evidence(self, record: Any) -> bool:
+        """A notice must name a machine and land before the window it warns about."""
+        return super()._is_evidence(record) and _ordered(record, "notified_at", "window_start")
 
 
 class FailureNotificationCheck(_QueryableRecordsCheck):
@@ -547,7 +614,7 @@ class FailureNotificationCheck(_QueryableRecordsCheck):
 
     Step output:
         success, notification_channel_observable: bool
-        notifications: list[{machine_id, type, message, notified_at}]
+        notifications: list[{machine_id, type, message, detected_at, notified_at}]
 
     Requires a real notification record, for the same reason as
     PlannedMaintenanceNotificationCheck.
@@ -555,8 +622,10 @@ class FailureNotificationCheck(_QueryableRecordsCheck):
     Empty shell: no provider exposes a failure notification channel, where the
     contract is latency rather than lead time, there being no window to plan for.
 
-    ``notified_at`` carries that latency, so it is required for the same reason
-    as BFX05-01 even though what it has to be measured against differs.
+    Latency also takes two timestamps, but the pair differs: a failure is
+    measured from ``detected_at``, when the provider knew, to ``notified_at``,
+    when it said so. Without the first, "immediate" is unfalsifiable. As with
+    BFX05-01 the acceptable bound is unset, so only the ordering is enforced.
     """
 
     description: ClassVar[str] = "Verify tenants can be notified of immediate node failure"
@@ -567,4 +636,8 @@ class FailureNotificationCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "immediate failure notifications"
     api_label: ClassVar[str] = "Immediate failure notification"
     record_noun: ClassVar[str] = "notification"
-    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id", "notified_at")
+    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id",)
+
+    def _is_evidence(self, record: Any) -> bool:
+        """A failure notice must name a machine and be sent after detection."""
+        return super()._is_evidence(record) and _ordered(record, "detected_at", "notified_at")

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -40,6 +40,8 @@ import pytest
 
 from isvtest.core.validation import BaseValidation
 
+UNKNOWN_LABEL = "unknown"
+
 
 def _record_label(record: dict[str, Any], *keys: str) -> str:
     """Return the first non-blank string value among ``keys``, or ``"unknown"``."""
@@ -47,7 +49,14 @@ def _record_label(record: dict[str, Any], *keys: str) -> str:
         value = record.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
-    return "unknown"
+    return UNKNOWN_LABEL
+
+
+def _has_fields(record: Any, *fields: str) -> bool:
+    """Return whether ``record`` carries every field with a non-empty value."""
+    if not isinstance(record, dict):
+        return False
+    return all(str(record.get(field) or "").strip() for field in fields)
 
 
 def _step_output(check: BaseValidation) -> dict[str, Any] | None:
@@ -87,14 +96,20 @@ class _QueryableRecordsCheck(BaseValidation):
     absent_noun: ClassVar[str]
     api_label: ClassVar[str]
     record_noun: ClassVar[str]
+    # Fields a record must carry to count. Empty means "any non-empty record",
+    # which only suits signals whose mere existence is the evidence.
+    evidence_fields: ClassVar[tuple[str, ...]] = ()
 
     def _is_evidence(self, record: Any) -> bool:
         """Return whether one record demonstrates the signal.
 
-        Defaults to "any non-empty record". Subclasses tighten this when the
-        record needs specific content to prove anything.
+        A record missing the fields that make it actionable is not evidence that
+        the API works -- it is evidence that something answered. Subclasses
+        override instead when the rule is not a flat list of required fields.
         """
-        return bool(record)
+        if not record:
+            return False
+        return _has_fields(record, *self.evidence_fields) if self.evidence_fields else True
 
     def run(self) -> None:
         """Assert the signal is reported observable and backed by real records."""
@@ -135,7 +150,8 @@ class RetirementNoticesCheck(_QueryableRecordsCheck):
     time for the tenant to migrate off the hardware to be worth anything.
 
     Step output:
-        success, notices_queryable: bool, notices: list[dict]
+        success, notices_queryable: bool
+        notices: list[{machine_id | rack_id, retire_after, status?, message?}]
     """
 
     description: ClassVar[str] = "Query retirement notices for a node or rack"
@@ -146,6 +162,17 @@ class RetirementNoticesCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "retirement notices"
     api_label: ClassVar[str] = "Retirement notice"
     record_noun: ClassVar[str] = "notice"
+
+    def _is_evidence(self, record: Any) -> bool:
+        """A notice needs a subject and a date, or the tenant cannot act on it.
+
+        Either identifier will do -- providers retire whole racks as readily as
+        single machines -- but ``retire_after`` is what makes it a notice rather
+        than a statement that something will be retired eventually.
+        """
+        if not _has_fields(record, "retire_after"):
+            return False
+        return _has_fields(record, "machine_id") or _has_fields(record, "rack_id")
 
 
 class RepairHistoryCheck(_QueryableRecordsCheck):
@@ -231,6 +258,11 @@ class BmcKernelLogCheck(BaseValidation):
         if len(hosts) < min_hosts:
             self.set_failed(f"Expected at least {min_hosts} host(s), got {len(hosts)}")
             return
+        # A host that cannot name itself gives the tenant nothing to go and read.
+        unidentified = [h for h in hosts if not _has_fields(h, "host_id")]
+        if unidentified:
+            self.set_failed(f"{len(unidentified)} host record(s) missing host_id")
+            return
         unavailable = [h for h in hosts if not h.get("kernel_log_available")]
         if unavailable:
             labels = ", ".join(_record_label(h, "host_id", "machine_id") for h in unavailable[:3])
@@ -259,6 +291,22 @@ class _OperationCheck(BaseValidation):
         """Return the success message for a completed operation."""
         return self.pass_template.format(label=label)
 
+    def _finish(self, operation: dict[str, Any]) -> None:
+        """Pass the check, unless the operation cannot say what it acted on.
+
+        A provider that reports success without naming the resource has not
+        demonstrated the operation reached anything in particular, and the
+        message would read "... for node unknown", which is not a result.
+        """
+        label = _record_label(operation, *self.label_keys)
+        if label == UNKNOWN_LABEL:
+            self.set_failed(
+                "Operation reported success without identifying what it acted on "
+                f"(expected one of: {', '.join(self.label_keys)})"
+            )
+            return
+        self.set_passed(self._pass_message(label, operation))
+
     def run(self) -> None:
         """Assert the provider reported the operation as having taken effect."""
         step_output = _step_output(self)
@@ -268,7 +316,7 @@ class _OperationCheck(BaseValidation):
         if not operation.get(self.completion_key):
             self.set_failed(operation.get("message") or self.failure_message)
             return
-        self.set_passed(self._pass_message(_record_label(operation, *self.label_keys), operation))
+        self._finish(operation)
 
 
 class GpuResetCheck(_OperationCheck):
@@ -398,7 +446,7 @@ class ReportNodeRepairCheck(_OperationCheck):
             # step forgot to, and --skip-restore, which strands the node by design.
             self.set_failed(self.not_restored_message)
             return
-        self.set_passed(self._pass_message(_record_label(operation, *self.label_keys), operation))
+        self._finish(operation)
 
     def _pass_message(self, label: str, operation: dict[str, Any]) -> str:
         """Append any provider finding raised while the node was taken back out of repair."""
@@ -478,6 +526,9 @@ class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
 
     Empty shell: no provider exposes a maintenance notification channel, which
     needs to arrive far enough ahead of the window to drain workloads first.
+
+    ``notified_at`` is required because lead time is the whole value here: a
+    notification with no timestamp cannot be shown to have arrived in advance.
     """
 
     description: ClassVar[str] = "Verify tenants can be notified of planned future node maintenance"
@@ -488,6 +539,7 @@ class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "planned maintenance notifications"
     api_label: ClassVar[str] = "Planned maintenance notification"
     record_noun: ClassVar[str] = "notification"
+    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id", "notified_at")
 
 
 class FailureNotificationCheck(_QueryableRecordsCheck):
@@ -502,6 +554,9 @@ class FailureNotificationCheck(_QueryableRecordsCheck):
 
     Empty shell: no provider exposes a failure notification channel, where the
     contract is latency rather than lead time, there being no window to plan for.
+
+    ``notified_at`` carries that latency, so it is required for the same reason
+    as BFX05-01 even though what it has to be measured against differs.
     """
 
     description: ClassVar[str] = "Verify tenants can be notified of immediate node failure"
@@ -512,3 +567,4 @@ class FailureNotificationCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "immediate failure notifications"
     api_label: ClassVar[str] = "Immediate failure notification"
     record_noun: ClassVar[str] = "notification"
+    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id", "notified_at")

--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -26,6 +26,10 @@ the signal as observable *and* return at least one record demonstrating it. A
 self-declared boolean is not evidence -- a provider could emit it for an API it
 never called -- so a capability claimed with no records skips rather than
 passes, and the requirement stays visibly unproven.
+
+Several checks here are *empty shells*: the class and its JSON contract exist,
+but no provider implements the capability yet, so the contract is the whole
+deliverable -- it is what an ISV would implement against.
 """
 
 from __future__ import annotations
@@ -127,6 +131,9 @@ class MaintenanceEventsCheck(_QueryableRecordsCheck):
 class RetirementNoticesCheck(_QueryableRecordsCheck):
     """Validate retirement notices for a node/rack are queryable (BFX02-02).
 
+    Empty shell: no provider exposes retirement notices, which need enough lead
+    time for the tenant to migrate off the hardware to be worth anything.
+
     Step output:
         success, notices_queryable: bool, notices: list[dict]
     """
@@ -195,13 +202,18 @@ class NvSwitchFirmwareCheck(BaseValidation):
 
 
 class BmcKernelLogCheck(BaseValidation):
-    """Validate BMC kernel log messages are obtainable for a node (BFX03-03).
+    """Validate a node's log history is queryable through a telemetry endpoint (BFX03-03).
+
+    Empty shell: reframed from serial-over-LAN BMC console access to a queryable
+    log history or stream (OTEL, or an OpenSearch/Kibana equivalent), which no
+    provider exposes -- the class name and ``kernel_log_available`` field are
+    leftovers from the original framing, kept because the check is released.
 
     Step output:
         success, hosts: list[{host_id, kernel_log_available: bool}]
     """
 
-    description: ClassVar[str] = "Obtain BMC kernel log messages for a node"
+    description: ClassVar[str] = "Query a node's log history through a telemetry endpoint"
     timeout: ClassVar[int] = 120
 
     def run(self) -> None:
@@ -260,13 +272,17 @@ class _OperationCheck(BaseValidation):
 
 
 class GpuResetCheck(_OperationCheck):
-    """Validate GPU reset via the break-fix API (BFX01-01).
+    """Validate a requested GPU reset on an operator-managed node (BFX01-01).
+
+    Empty shell: no provider exposes an on-demand GPU reset, so there is no
+    synchronous request to make; reporting the node as needing repair instead is
+    BFX01-06 (``ReportNodeRepairCheck``).
 
     Step output:
         success, operation: {requested, completed, node_id}
     """
 
-    description: ClassVar[str] = "Reset GPUs on an individual node via the breakfix API"
+    description: ClassVar[str] = "Request a reset of GPUs on an operator-managed node"
 
     completion_key: ClassVar[str] = "completed"
     failure_message: ClassVar[str] = "GPU reset did not complete"
@@ -296,6 +312,9 @@ class ReturnNodeMaintenanceCheck(_OperationCheck):
 class ReturnRackMaintenanceCheck(_OperationCheck):
     """Validate returning a rack for maintenance (BFX01-03).
 
+    Empty shell: no provider exposes rack-level maintenance handover, which has
+    to return every node in the rack as one operation to mean anything.
+
     Step output:
         success, operation: {requested, accepted, rack_id}
     """
@@ -310,6 +329,10 @@ class ReturnRackMaintenanceCheck(_OperationCheck):
 
 class HostReplacementCheck(_OperationCheck):
     """Validate host replacement when health thresholds are breached (BFX01-05).
+
+    Empty shell, and the missing piece is the trigger rather than the API: no
+    provider publishes the health thresholds that are supposed to be breached,
+    so there is no condition to induce.
 
     Step output:
         success, operation: {requested, node_removed_from_pool, machine_id}
@@ -452,6 +475,9 @@ class PlannedMaintenanceNotificationCheck(_QueryableRecordsCheck):
 
     Requires a real notification record, not just the observable flag: the flag
     alone is the provider asserting its own capability.
+
+    Empty shell: no provider exposes a maintenance notification channel, which
+    needs to arrive far enough ahead of the window to drain workloads first.
     """
 
     description: ClassVar[str] = "Verify tenants can be notified of planned future node maintenance"
@@ -473,6 +499,9 @@ class FailureNotificationCheck(_QueryableRecordsCheck):
 
     Requires a real notification record, for the same reason as
     PlannedMaintenanceNotificationCheck.
+
+    Empty shell: no provider exposes a failure notification channel, where the
+    contract is latency rather than lead time, there being no window to plan for.
     """
 
     description: ClassVar[str] = "Verify tenants can be notified of immediate node failure"

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -50,13 +50,23 @@ _QUERYABLE_CASES = [
         PlannedMaintenanceNotificationCheck,
         "notification_channel_observable",
         "notifications",
-        {"machine_id": "m-1", "type": "planned_maintenance", "notified_at": "2026-06-24T12:00:00Z"},
+        {
+            "machine_id": "m-1",
+            "type": "planned_maintenance",
+            "notified_at": "2026-06-24T12:00:00Z",
+            "window_start": "2026-07-01T02:00:00Z",
+        },
     ),
     (
         FailureNotificationCheck,
         "notification_channel_observable",
         "notifications",
-        {"machine_id": "m-1", "type": "node_failure", "notified_at": "2026-06-24T12:00:00Z"},
+        {
+            "machine_id": "m-1",
+            "type": "node_failure",
+            "detected_at": "2026-06-24T11:59:30Z",
+            "notified_at": "2026-06-24T12:00:00Z",
+        },
     ),
 ]
 
@@ -129,12 +139,16 @@ class TestQueryableRecordChecks:
         assert _run(RetirementNoticesCheck, step_output).passed
 
     @pytest.mark.parametrize(("check_class", "_label"), _NOTIFICATION_CASES)
-    def test_notification_needs_a_timestamp(self, check_class: type[BaseValidation], _label: str) -> None:
-        """A notification with no notified_at cannot evidence lead time or latency."""
+    def test_notification_needs_both_timestamps(self, check_class: type[BaseValidation], _label: str) -> None:
+        """One timestamp cannot evidence an interval, and the interval is the contract.
+
+        ``notified_at`` alone shows only that something arrived: BFX05-01 needs
+        the window it preceded, BFX06-01 the detection it followed.
+        """
         step_output = {
             "success": True,
             "notification_channel_observable": True,
-            "notifications": [{"machine_id": "m-1", "type": "x"}],
+            "notifications": [{"machine_id": "m-1", "type": "x", "notified_at": "2026-06-24T12:00:00Z"}],
         }
         with pytest.raises(pytest.skip.Exception):
             _run(check_class, step_output)
@@ -145,10 +159,48 @@ class TestQueryableRecordChecks:
         step_output = {
             "success": True,
             "notification_channel_observable": True,
-            "notifications": [{"notified_at": "2026-06-24T12:00:00Z"}],
+            "notifications": [
+                {
+                    "detected_at": "2026-06-24T11:59:30Z",
+                    "notified_at": "2026-06-24T12:00:00Z",
+                    "window_start": "2026-07-01T02:00:00Z",
+                }
+            ],
         }
         with pytest.raises(pytest.skip.Exception):
             _run(check_class, step_output)
+
+    def test_planned_notice_must_precede_the_window(self) -> None:
+        """A warning that arrives after maintenance starts is not a warning."""
+        step_output = {
+            "success": True,
+            "notification_channel_observable": True,
+            "notifications": [
+                {
+                    "machine_id": "m-1",
+                    "notified_at": "2026-07-01T03:00:00Z",
+                    "window_start": "2026-07-01T02:00:00Z",
+                }
+            ],
+        }
+        with pytest.raises(pytest.skip.Exception):
+            _run(PlannedMaintenanceNotificationCheck, step_output)
+
+    def test_failure_notice_must_follow_detection(self) -> None:
+        """Being told before the provider knew is a malformed record, not low latency."""
+        step_output = {
+            "success": True,
+            "notification_channel_observable": True,
+            "notifications": [
+                {
+                    "machine_id": "m-1",
+                    "detected_at": "2026-06-24T12:00:00Z",
+                    "notified_at": "2026-06-24T11:59:30Z",
+                }
+            ],
+        }
+        with pytest.raises(pytest.skip.Exception):
+            _run(FailureNotificationCheck, step_output)
 
     def test_repair_history_needs_entries_not_just_a_machine_record(self) -> None:
         """BFX02-03 counts a machine record only when it carries history entries."""
@@ -171,21 +223,42 @@ class TestQueryableRecordChecks:
 class TestOperationChecks:
     """Cover the BFX01 mutating-operation checks that share _OperationCheck."""
 
-    def test_fails_when_not_completed(self) -> None:
-        """An operation that never completed fails with the provider's message."""
-        check = _run(GpuResetCheck, {"success": True, "operation": {"completed": False, "message": "timeout"}})
+    def test_fails_when_not_accepted(self) -> None:
+        """An operation the provider refused fails with the provider's message."""
+        check = _run(GpuResetCheck, {"success": True, "operation": {"accepted": False, "message": "timeout"}})
         assert not check.passed
 
-    def test_passes_when_completed(self) -> None:
-        """A completed operation passes and names the target node."""
-        check = _run(GpuResetCheck, {"success": True, "operation": {"completed": True, "node_id": "n-1"}})
+    def test_passes_when_accepted(self) -> None:
+        """An accepted request passes and names the target node."""
+        step_output = {
+            "success": True,
+            "operation": {"accepted": True, "node_id": "n-1", "gpu_ids": ["GPU-0"], "request_id": "req-1"},
+        }
+        check = _run(GpuResetCheck, step_output)
         assert check.passed
         assert "n-1" in check.message
+
+    def test_gpu_reset_needs_a_handle_to_poll(self) -> None:
+        """A reset completes asynchronously, so acceptance without a handle is a dead end."""
+        step_output = {"success": True, "operation": {"accepted": True, "node_id": "n-1", "gpu_ids": ["GPU-0"]}}
+        check = _run(GpuResetCheck, step_output)
+        assert not check.passed
+        assert "request_id" in check.message
+
+    def test_gpu_reset_needs_to_name_the_gpus(self) -> None:
+        """A node has many GPUs, so a request that names none has not been scoped."""
+        step_output = {
+            "success": True,
+            "operation": {"accepted": True, "node_id": "n-1", "gpu_ids": [], "request_id": "req-1"},
+        }
+        check = _run(GpuResetCheck, step_output)
+        assert not check.passed
+        assert "gpu_ids" in check.message
 
     @pytest.mark.parametrize(
         ("check_class", "operation"),
         [
-            (GpuResetCheck, {"completed": True}),
+            (GpuResetCheck, {"accepted": True, "gpu_ids": ["GPU-0"], "request_id": "req-1"}),
             (ReturnRackMaintenanceCheck, {"accepted": True}),
             (HostReplacementCheck, {"node_removed_from_pool": True}),
             (ReturnNodeMaintenanceCheck, {"accepted": True}),
@@ -277,25 +350,52 @@ class TestOperationChecks:
         assert "removed the override directly" in check.message
 
 
+def _log_host(**overrides: Any) -> dict[str, Any]:
+    """Build a host record that satisfies the BFX03-03 log-history contract."""
+    return {
+        "host_id": "h-1",
+        "window_start": "2026-06-24T00:00:00Z",
+        "window_end": "2026-06-24T12:00:00Z",
+        "entries_returned": 128,
+        **overrides,
+    }
+
+
 class TestBmcKernelLogCheck:
     """Cover the BFX03-03 log-history check."""
 
-    def test_passes_when_every_host_reports_a_log(self) -> None:
-        """A named host with logs available is the passing case."""
-        step_output = {"success": True, "hosts": [{"host_id": "h-1", "kernel_log_available": True}]}
-        assert _run(BmcKernelLogCheck, step_output).passed
+    def test_passes_when_a_windowed_query_returns_entries(self) -> None:
+        """Entries returned over a stated window is what makes it a history."""
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": [_log_host()]})
+        assert check.passed
+        assert "128 entries" in check.message
 
     def test_fails_when_a_host_cannot_name_itself(self) -> None:
         """A host record with no host_id gives the tenant nothing to go and read."""
-        step_output = {"success": True, "hosts": [{"kernel_log_available": True}]}
-        check = _run(BmcKernelLogCheck, step_output)
+        host = _log_host()
+        del host["host_id"]
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": [host]})
         assert not check.passed
         assert "missing host_id" in check.message
 
-    def test_fails_when_logs_are_unavailable(self) -> None:
-        """Reporting a host whose logs cannot be read is a failure, not a pass."""
-        step_output = {"success": True, "hosts": [{"host_id": "h-1", "kernel_log_available": False}]}
-        assert not _run(BmcKernelLogCheck, step_output).passed
+    def test_fails_without_a_query_window(self) -> None:
+        """Entries with no window could be a live tail rather than a history."""
+        host = _log_host()
+        del host["window_start"]
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": [host]})
+        assert not check.passed
+        assert "query window" in check.message
+
+    def test_fails_when_the_window_is_inverted(self) -> None:
+        """A window ending before it starts was not a real query."""
+        host = _log_host(window_start="2026-06-24T12:00:00Z", window_end="2026-06-24T00:00:00Z")
+        assert not _run(BmcKernelLogCheck, {"success": True, "hosts": [host]}).passed
+
+    def test_fails_when_no_entries_come_back(self) -> None:
+        """A provider that answers with nothing has not demonstrated it can answer."""
+        check = _run(BmcKernelLogCheck, {"success": True, "hosts": [_log_host(entries_returned=0)]})
+        assert not check.passed
+        assert "No log entries" in check.message
 
 
 class TestNodeHealthAgentCheck:
@@ -328,7 +428,15 @@ class TestNotificationChecks:
         step_output = {
             "success": True,
             "notification_channel_observable": True,
-            "notifications": [{"machine_id": "m-1", "message": "scheduled", "notified_at": "2026-06-24T12:00:00Z"}],
+            "notifications": [
+                {
+                    "machine_id": "m-1",
+                    "message": "scheduled",
+                    "detected_at": "2026-06-24T11:59:30Z",
+                    "notified_at": "2026-06-24T12:00:00Z",
+                    "window_start": "2026-07-01T02:00:00Z",
+                }
+            ],
         }
         check = _run(check_class, step_output)
         assert check.passed

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -11,6 +11,7 @@ import pytest
 
 from isvtest.core.validation import BaseValidation
 from isvtest.validations.breakfix import (
+    BmcKernelLogCheck,
     CordonNodeCheck,
     FailureNotificationCheck,
     GpuResetCheck,
@@ -22,6 +23,7 @@ from isvtest.validations.breakfix import (
     ReportNodeRepairCheck,
     RetirementNoticesCheck,
     ReturnNodeMaintenanceCheck,
+    ReturnRackMaintenanceCheck,
 )
 
 
@@ -37,19 +39,24 @@ def _run(check_class: type[BaseValidation], step_output: dict[str, Any]) -> Base
 # bar as the BFX02 query APIs, so the flag alone cannot pass the check.
 _QUERYABLE_CASES = [
     (MaintenanceEventsCheck, "events_queryable", "events", {"machine_id": "m-1", "status": "maintenance"}),
-    (RetirementNoticesCheck, "notices_queryable", "notices", {"machine_id": "m-1", "status": "scheduled"}),
+    (
+        RetirementNoticesCheck,
+        "notices_queryable",
+        "notices",
+        {"machine_id": "m-1", "status": "scheduled", "retire_after": "2027-01-15T00:00:00Z"},
+    ),
     (RepairHistoryCheck, "history_queryable", "records", {"machine_id": "m-1", "entries": [{"status": "x"}]}),
     (
         PlannedMaintenanceNotificationCheck,
         "notification_channel_observable",
         "notifications",
-        {"machine_id": "m-1", "type": "planned_maintenance"},
+        {"machine_id": "m-1", "type": "planned_maintenance", "notified_at": "2026-06-24T12:00:00Z"},
     ),
     (
         FailureNotificationCheck,
         "notification_channel_observable",
         "notifications",
-        {"machine_id": "m-1", "type": "node_failure"},
+        {"machine_id": "m-1", "type": "node_failure", "notified_at": "2026-06-24T12:00:00Z"},
     ),
 ]
 
@@ -102,6 +109,47 @@ class TestQueryableRecordChecks:
         with pytest.raises(pytest.skip.Exception):
             _run(check_class, {"success": True, flag: True, key: [{}]})
 
+    def test_retirement_notice_needs_a_date_not_just_a_subject(self) -> None:
+        """Without retire_after a notice says something will be retired, not when.
+
+        Lead time is the whole value of a retirement notice, so a record that
+        cannot demonstrate any is not evidence the API works.
+        """
+        step_output = {"success": True, "notices_queryable": True, "notices": [{"machine_id": "m-1"}]}
+        with pytest.raises(pytest.skip.Exception):
+            _run(RetirementNoticesCheck, step_output)
+
+    def test_retirement_notice_accepts_a_rack_as_the_subject(self) -> None:
+        """Providers retire whole racks as readily as single machines."""
+        step_output = {
+            "success": True,
+            "notices_queryable": True,
+            "notices": [{"rack_id": "r-1", "retire_after": "2027-01-15T00:00:00Z"}],
+        }
+        assert _run(RetirementNoticesCheck, step_output).passed
+
+    @pytest.mark.parametrize(("check_class", "_label"), _NOTIFICATION_CASES)
+    def test_notification_needs_a_timestamp(self, check_class: type[BaseValidation], _label: str) -> None:
+        """A notification with no notified_at cannot evidence lead time or latency."""
+        step_output = {
+            "success": True,
+            "notification_channel_observable": True,
+            "notifications": [{"machine_id": "m-1", "type": "x"}],
+        }
+        with pytest.raises(pytest.skip.Exception):
+            _run(check_class, step_output)
+
+    @pytest.mark.parametrize(("check_class", "_label"), _NOTIFICATION_CASES)
+    def test_notification_needs_a_subject(self, check_class: type[BaseValidation], _label: str) -> None:
+        """A notification that does not say which machine is not actionable."""
+        step_output = {
+            "success": True,
+            "notification_channel_observable": True,
+            "notifications": [{"notified_at": "2026-06-24T12:00:00Z"}],
+        }
+        with pytest.raises(pytest.skip.Exception):
+            _run(check_class, step_output)
+
     def test_repair_history_needs_entries_not_just_a_machine_record(self) -> None:
         """BFX02-03 counts a machine record only when it carries history entries."""
         step_output = {"success": True, "history_queryable": True, "records": [{"machine_id": "m-1", "entries": []}]}
@@ -133,6 +181,27 @@ class TestOperationChecks:
         check = _run(GpuResetCheck, {"success": True, "operation": {"completed": True, "node_id": "n-1"}})
         assert check.passed
         assert "n-1" in check.message
+
+    @pytest.mark.parametrize(
+        ("check_class", "operation"),
+        [
+            (GpuResetCheck, {"completed": True}),
+            (ReturnRackMaintenanceCheck, {"accepted": True}),
+            (HostReplacementCheck, {"node_removed_from_pool": True}),
+            (ReturnNodeMaintenanceCheck, {"accepted": True}),
+        ],
+    )
+    def test_operation_must_identify_what_it_acted_on(
+        self, check_class: type[BaseValidation], operation: dict[str, Any]
+    ) -> None:
+        """Success without an identifier is not a result, it is an assertion.
+
+        The message would otherwise read "... for node unknown", which tells a
+        reader nothing about whether the operation reached anything.
+        """
+        check = _run(check_class, {"success": True, "operation": operation})
+        assert not check.passed
+        assert "without identifying what it acted on" in check.message
 
     def test_host_replacement_uses_its_own_flag(self) -> None:
         """BFX01-05 keys off node_removed_from_pool, not the generic completed flag."""
@@ -208,6 +277,27 @@ class TestOperationChecks:
         assert "removed the override directly" in check.message
 
 
+class TestBmcKernelLogCheck:
+    """Cover the BFX03-03 log-history check."""
+
+    def test_passes_when_every_host_reports_a_log(self) -> None:
+        """A named host with logs available is the passing case."""
+        step_output = {"success": True, "hosts": [{"host_id": "h-1", "kernel_log_available": True}]}
+        assert _run(BmcKernelLogCheck, step_output).passed
+
+    def test_fails_when_a_host_cannot_name_itself(self) -> None:
+        """A host record with no host_id gives the tenant nothing to go and read."""
+        step_output = {"success": True, "hosts": [{"kernel_log_available": True}]}
+        check = _run(BmcKernelLogCheck, step_output)
+        assert not check.passed
+        assert "missing host_id" in check.message
+
+    def test_fails_when_logs_are_unavailable(self) -> None:
+        """Reporting a host whose logs cannot be read is a failure, not a pass."""
+        step_output = {"success": True, "hosts": [{"host_id": "h-1", "kernel_log_available": False}]}
+        assert not _run(BmcKernelLogCheck, step_output).passed
+
+
 class TestNodeHealthAgentCheck:
     """Cover the BFX04-01 GPUd/Sentinel health-agent check."""
 
@@ -238,7 +328,7 @@ class TestNotificationChecks:
         step_output = {
             "success": True,
             "notification_channel_observable": True,
-            "notifications": [{"machine_id": "m-1", "message": "scheduled"}],
+            "notifications": [{"machine_id": "m-1", "message": "scheduled", "notified_at": "2026-06-24T12:00:00Z"}],
         }
         check = _run(check_class, step_output)
         assert check.passed


### PR DESCRIPTION
Follow-up to #611, from the 2026-08-27 requirements meeting.

Seven BFX tests were settled as empty shells: the check and its JSON contract exist, but no provider implements the capability. The shells themselves were already built in #562 — this is what the meeting added on top.

- **Named them.** Each check docstring says it is a shell, in a sentence.
- **Reframed two** whose wording named something that does not exist: BFX01-01 (GPU reset "via the Breakfix API" → request a reset on an operator-managed node) and BFX03-03 (BMC logs over serial-over-LAN → query a node's log history via telemetry).
- **Made the contracts real.** They were documented in docstrings but never enforced, so `{"zzz": 1}` passed as a retirement notice. Three also could not express what the requirement asks: BFX01-01 asserted synchronous completion of an inherently asynchronous operation, BFX03-03 a boolean satisfiable by returning `true` and building nothing, and the notification pair one timestamp where the contract is an interval (lead time, latency).
- **Guarded them.** A new test runs each `my-isv` break-fix scaffold and asserts its JSON satisfies the check the suite wires it to. Nothing covered that edge, and `make demo-test` cannot: `MY_ISV_SUITES` omits `k8s`, whose setup needs a live cluster, so `reset_gpus` and `GpuResetCheck` were wired to each other and covered by nothing.

Class names and `released_tests.json` are untouched — all seven checks are released, so renaming is release-owned work. Nothing implements these shells, so changing the contracts now costs only our own scaffolds, updated here alongside. #214 (BFX03-02, partial) is separate.

## Test plan

- [x] `make lint`, `make test`, `make demo-test`, `uvx pre-commit run -a`
- [x] `test_plan_coverage.py --check`, `reqtrace.py validate`, `validate_suite_wiring.py`, `make plan` idempotent
- [x] Contract test verified to fail on drift by dropping `request_id` from the `reset_gpus` scaffold

Closes #206
Closes #208
Closes #210
Closes #212
Closes #215
Closes #556
Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU reset requests now support asynchronous acceptance with request tracking, targeted GPUs, and polling details.
  * Node log checks now use time-windowed log history results instead of BMC kernel-log availability flags.
  * Notification checks include timestamps for validating lead time and delivery latency.
  * Unavailable provider capabilities now report clear diagnostic information.

* **Bug Fixes**
  * Strengthened validation for timestamps, identifiers, resource scope, log results, and operation evidence.

* **Tests**
  * Added comprehensive contract and validation coverage for break-fix scaffolds and updated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->