### PR TITLE
fix(security): quote SSH env values, avoid NGC key on cmdline, warn on TLS bypass

### DIFF
--- a/isvctl/configs/providers/vast/scripts/storage/vast/api.py
+++ b/isvctl/configs/providers/vast/scripts/storage/vast/api.py
@@ -95,6 +95,7 @@ import ssl
 import urllib.error
 import urllib.parse
 import urllib.request
+import warnings
 from base64 import b64encode
 from datetime import UTC, datetime
 from typing import Any
@@ -177,6 +178,11 @@ def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
     """Build the TLS context for provider API calls."""
     ctx = ssl.create_default_context()
     if insecure:
+        warnings.warn(
+            "VAST_INSECURE_SKIP_VERIFY is enabled: TLS certificate verification is "
+            "disabled and credentials may be exposed to MITM attacks. Dev/test only.",
+            stacklevel=2,
+        )
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
     return ctx

--- a/isvctl/configs/providers/weka/scripts/storage/weka/api.py
+++ b/isvctl/configs/providers/weka/scripts/storage/weka/api.py
@@ -102,6 +102,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import warnings
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Any
@@ -187,6 +188,11 @@ def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
     """Build the TLS context for provider API calls."""
     ctx = ssl.create_default_context()
     if insecure:
+        warnings.warn(
+            "WEKA_INSECURE_SKIP_VERIFY is enabled: TLS certificate verification is "
+            "disabled and credentials may be exposed to MITM attacks. Dev/test only.",
+            stacklevel=2,
+        )
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
     return ctx

--- a/isvctl/src/isvctl/remote/ssh.py
+++ b/isvctl/src/isvctl/remote/ssh.py
@@ -20,6 +20,7 @@ compatibility with SSH agents, certificates, and complex authentication setups.
 """
 
 import logging
+import shlex
 import subprocess
 import sys
 import threading
@@ -142,7 +143,7 @@ class SSHClient:
         # Build the remote command with optional env vars
         remote_cmd = command
         if env:
-            env_prefix = " ".join(f'{k}="{v}"' for k, v in env.items())
+            env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
             remote_cmd = f"{env_prefix} {command}"
 
         # Use bash -l -s to run script from stdin (like heredoc)

--- a/isvctl/src/isvctl/remote/ssh.py
+++ b/isvctl/src/isvctl/remote/ssh.py
@@ -20,6 +20,7 @@ compatibility with SSH agents, certificates, and complex authentication setups.
 """
 
 import logging
+import re
 import shlex
 import subprocess
 import sys
@@ -28,6 +29,8 @@ from dataclasses import dataclass
 from typing import IO
 
 logger = logging.getLogger(__name__)
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @dataclass
@@ -143,6 +146,9 @@ class SSHClient:
         # Build the remote command with optional env vars
         remote_cmd = command
         if env:
+            for key in env:
+                if not _ENV_NAME_RE.match(key):
+                    raise ValueError(f"Invalid environment variable name: {key!r}")
             env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
             remote_cmd = f"{env_prefix} {command}"
 

--- a/isvtest/src/isvtest/core/ngc.py
+++ b/isvtest/src/isvtest/core/ngc.py
@@ -20,6 +20,7 @@ This module provides shared functionality for:
 - NIM inference validation
 """
 
+import base64
 import json
 import os
 import subprocess
@@ -46,6 +47,23 @@ def get_ngc_api_key() -> str:
         The API key string, or empty string if neither variable is set.
     """
     return os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
+
+
+def build_ngc_dockerconfigjson(ngc_api_key: str, registry: str = "nvcr.io") -> str:
+    """Build a .dockerconfigjson payload for authenticating to the NGC registry.
+
+    Used to create docker-registry secrets via stdin (--from-file=/dev/stdin)
+    instead of passing the API key as a command-line argument.
+
+    Args:
+        ngc_api_key: NGC API key.
+        registry: Docker registry hostname.
+
+    Returns:
+        JSON string suitable for a kubernetes.io/dockerconfigjson secret.
+    """
+    auth = base64.b64encode(f"$oauthtoken:{ngc_api_key}".encode()).decode()
+    return json.dumps({"auths": {registry: {"username": "$oauthtoken", "password": ngc_api_key, "auth": auth}}})
 
 
 def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[bool, str]:
@@ -92,21 +110,22 @@ def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[
     if result.returncode != 0:
         logger.info(f"Creating NGC image pull secret ({NGC_IMAGE_SECRET_NAME})...")
         try:
-            # Pass API key directly as command argument (no shell interpretation needed)
-            # Note: Key may be visible in /proc/cmdline briefly during execution
+            # Build the dockerconfigjson and pass it via stdin so the API key
+            # never appears in the process command line (visible via /proc/<pid>/cmdline).
+            dockerconfigjson = build_ngc_dockerconfigjson(ngc_api_key)
             cmd = kubectl_parts + [
                 "create",
                 "secret",
-                "docker-registry",
+                "generic",
                 NGC_IMAGE_SECRET_NAME,
-                "--docker-server=nvcr.io",
-                "--docker-username=$oauthtoken",
-                f"--docker-password={ngc_api_key}",
+                "--type=kubernetes.io/dockerconfigjson",
+                "--from-file=.dockerconfigjson=/dev/stdin",
                 "-n",
                 namespace,
             ]
             subprocess.run(
                 cmd,
+                input=dockerconfigjson,
                 capture_output=True,
                 text=True,
                 timeout=30,

--- a/isvtest/src/isvtest/core/ngc.py
+++ b/isvtest/src/isvtest/core/ngc.py
@@ -49,23 +49,6 @@ def get_ngc_api_key() -> str:
     return os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
 
 
-def build_ngc_dockerconfigjson(ngc_api_key: str, registry: str = "nvcr.io") -> str:
-    """Build a .dockerconfigjson payload for authenticating to the NGC registry.
-
-    Used to create docker-registry secrets via stdin (--from-file=/dev/stdin)
-    instead of passing the API key as a command-line argument.
-
-    Args:
-        ngc_api_key: NGC API key.
-        registry: Docker registry hostname.
-
-    Returns:
-        JSON string suitable for a kubernetes.io/dockerconfigjson secret.
-    """
-    auth = base64.b64encode(f"$oauthtoken:{ngc_api_key}".encode()).decode()
-    return json.dumps({"auths": {registry: {"username": "$oauthtoken", "password": ngc_api_key, "auth": auth}}})
-
-
 def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[bool, str]:
     """Ensure NGC secrets exist in the namespace, creating them if needed.
 
@@ -112,7 +95,7 @@ def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[
         try:
             # Build the dockerconfigjson and pass it via stdin so the API key
             # never appears in the process command line (visible via /proc/<pid>/cmdline).
-            dockerconfigjson = build_ngc_dockerconfigjson(ngc_api_key)
+            dockerconfigjson = json.dumps(create_ngc_docker_config(ngc_api_key))
             cmd = kubectl_parts + [
                 "create",
                 "secret",
@@ -321,8 +304,6 @@ def create_ngc_docker_config(ngc_api_key: str) -> dict[str, Any]:
     Returns:
         Docker config dictionary suitable for .dockerconfigjson.
     """
-    import base64
-
     return {
         "auths": {
             "nvcr.io": {

--- a/isvtest/src/isvtest/workloads/k8s_nim_helm.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim_helm.py
@@ -24,6 +24,7 @@ Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.
 """
 
 import base64
+import json
 import os
 import re
 import shlex
@@ -39,7 +40,7 @@ import pytest
 
 from isvtest.config.settings import get_k8s_namespace
 from isvtest.core.k8s import get_gpu_nodes, get_kubectl_base_shell, get_kubectl_command
-from isvtest.core.ngc import build_ngc_dockerconfigjson, get_ngc_api_key, validate_nim_inference
+from isvtest.core.ngc import create_ngc_docker_config, get_ngc_api_key, validate_nim_inference
 from isvtest.core.workload import BaseWorkloadCheck
 
 
@@ -320,7 +321,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
         try:
             # Build the dockerconfigjson and pass it via stdin so the API key never
             # appears in the process command line (visible via /proc/<pid>/cmdline).
-            dockerconfigjson = build_ngc_dockerconfigjson(ngc_api_key)
+            dockerconfigjson = json.dumps(create_ngc_docker_config(ngc_api_key))
             cmd = kubectl_parts + [
                 "create",
                 "secret",
@@ -353,18 +354,20 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
             self.log.info("Creating NGC API secret (ngc-api)...")
 
         try:
-            # Use list form (no shell) to pass credentials directly and securely
+            # Pass the key via stdin so it never appears in the process command
+            # line (visible via /proc/<pid>/cmdline).
             cmd = kubectl_parts + [
                 "create",
                 "secret",
                 "generic",
                 "ngc-api",
-                f"--from-literal=NGC_API_KEY={ngc_api_key}",  # Key name required by NIM Helm chart
+                "--from-file=NGC_API_KEY=/dev/stdin",  # Key name required by NIM Helm chart
                 "-n",
                 namespace,
             ]
             subprocess.run(
                 cmd,
+                input=ngc_api_key,
                 capture_output=True,
                 text=True,
                 timeout=30,

--- a/isvtest/src/isvtest/workloads/k8s_nim_helm.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim_helm.py
@@ -23,11 +23,14 @@ This workload will:
 Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html
 """
 
+import base64
 import os
 import re
 import shlex
 import subprocess
 import time
+import urllib.error
+import urllib.request
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -36,7 +39,7 @@ import pytest
 
 from isvtest.config.settings import get_k8s_namespace
 from isvtest.core.k8s import get_gpu_nodes, get_kubectl_base_shell, get_kubectl_command
-from isvtest.core.ngc import get_ngc_api_key, validate_nim_inference
+from isvtest.core.ngc import build_ngc_dockerconfigjson, get_ngc_api_key, validate_nim_inference
 from isvtest.core.workload import BaseWorkloadCheck
 
 
@@ -315,20 +318,22 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
             self.log.info("Creating NGC image pull secret (ngc-secret)...")
 
         try:
-            # Use list form (no shell) to pass credentials directly and securely
+            # Build the dockerconfigjson and pass it via stdin so the API key never
+            # appears in the process command line (visible via /proc/<pid>/cmdline).
+            dockerconfigjson = build_ngc_dockerconfigjson(ngc_api_key)
             cmd = kubectl_parts + [
                 "create",
                 "secret",
-                "docker-registry",
+                "generic",
                 "ngc-secret",
-                "--docker-server=nvcr.io",
-                "--docker-username=$oauthtoken",  # Literal string - NGC special username
-                f"--docker-password={ngc_api_key}",
+                "--type=kubernetes.io/dockerconfigjson",
+                "--from-file=.dockerconfigjson=/dev/stdin",
                 "-n",
                 namespace,
             ]
             subprocess.run(
                 cmd,
+                input=dockerconfigjson,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -389,35 +394,22 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
 
         self.log.info(f"Downloading NIM Helm chart: {chart_url}")
 
-        # Use helm pull to download the chart with authentication
-        # helm fetch/pull supports --username and --password for authenticated downloads
+        # Fetch directly over HTTPS with a Basic Authorization header instead of
+        # `helm pull --username --password`, so the API key never appears in the
+        # process command line (visible via /proc/<pid>/cmdline).
+        auth = base64.b64encode(f"$oauthtoken:{ngc_api_key}".encode()).decode()
+        request = urllib.request.Request(chart_url, headers={"Authorization": f"Basic {auth}"})
         try:
-            result = subprocess.run(
-                [
-                    "helm",
-                    "pull",
-                    chart_url,
-                    "--username",
-                    "$oauthtoken",
-                    "--password",
-                    ngc_api_key,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-
-            if result.returncode != 0:
-                self.set_failed(f"Failed to download Helm chart: {result.stderr}")
-                return False
+            with urllib.request.urlopen(request, timeout=120) as response, open(chart_filename, "wb") as chart_file:
+                chart_file.write(response.read())
 
             # Store the chart path for later use
             self._chart_path = chart_filename
             self.log.info(f"Helm chart downloaded: {chart_filename}")
             return True
 
-        except subprocess.TimeoutExpired:
-            self.set_failed("Helm chart download timed out")
+        except (urllib.error.URLError, OSError) as e:
+            self.set_failed(f"Failed to download Helm chart: {e}")
             return False
         except Exception as e:
             self.set_failed(f"Failed to download Helm chart: {e}")


### PR DESCRIPTION
## Summary
- `SSHClient.execute()` now shell-quotes env values passed to the remote command, preventing shell injection via a value containing a double quote.
- NGC API key is no longer passed as a `--docker-password`/`--password` CLI argument to `kubectl`/`helm` (visible via `/proc/<pid>/cmdline`): docker-registry secrets are built as a `dockerconfigjson` and piped over stdin, and the NIM Helm chart is downloaded via a direct HTTPS request with a Basic auth header.
- WEKA/VAST storage shims now emit a runtime warning when `*_INSECURE_SKIP_VERIFY` disables TLS certificate verification, so the exposure is visible instead of silent.

## Test plan
- [x] `uv run pytest isvctl/tests -k ssh` — 31 passed
- [x] `cd isvtest && uv run pytest -k "ngc or nim_helm or weka or vast"` — pre-existing unrelated failures only (verified they also fail on `main`)
- [x] `make lint` — all packages pass
- [x] Manually verified `build_ngc_dockerconfigjson()` output shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added clear warnings when TLS certificate verification is disabled, highlighting the risk of credential exposure.
  - Improved registry credential handling so API keys are not exposed in command-line arguments.
  - Added validation for remote environment-variable names and preserved safe value quoting.

- **Bug Fixes**
  - Improved NGC image-pull secret generation and Helm workload credential handling.
  - Invalid environment-variable names now produce a clear error instead of being sent remotely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->