### PR TITLE
fix(breakfix): require a subject and a state from a BFX02-01 maintenance event

### DIFF
--- a/isvtest/src/isvtest/validations/breakfix.py
+++ b/isvtest/src/isvtest/validations/breakfix.py
@@ -152,8 +152,15 @@ class _QueryableRecordsCheck(BaseValidation):
 class MaintenanceEventsCheck(_QueryableRecordsCheck):
     """Validate upcoming/current maintenance events are queryable (BFX02-01).
 
+    An event has to say which node and what is happening to it. Those two are
+    what make it an event a tenant can act on rather than a row that came back:
+    without ``machine_id`` there is nothing to go and look at, and without
+    ``status`` there is no way to tell an upcoming window from one underway.
+    ``message`` stays optional -- a provider that schedules maintenance without
+    prose has still reported the event.
+
     Step output:
-        success, events: list[{machine_id, status, message}]
+        success, events: list[{machine_id, status, message?}]
         events_queryable: bool -- API exposes maintenance event records
     """
 
@@ -165,6 +172,7 @@ class MaintenanceEventsCheck(_QueryableRecordsCheck):
     absent_noun: ClassVar[str] = "maintenance events"
     api_label: ClassVar[str] = "Maintenance event"
     record_noun: ClassVar[str] = "event"
+    evidence_fields: ClassVar[tuple[str, ...]] = ("machine_id", "status")
 
 
 class RetirementNoticesCheck(_QueryableRecordsCheck):

--- a/isvtest/tests/test_breakfix.py
+++ b/isvtest/tests/test_breakfix.py
@@ -120,6 +120,35 @@ class TestQueryableRecordChecks:
         with pytest.raises(pytest.skip.Exception):
             _run(check_class, {"success": True, flag: True, key: [{}]})
 
+    @pytest.mark.parametrize(
+        "event",
+        [
+            {"zzz": 1},
+            {"status": "maintenance"},
+            {"machine_id": "m-1"},
+            {"machine_id": "", "status": "maintenance"},
+        ],
+    )
+    def test_maintenance_event_needs_a_subject_and_a_state(self, event: dict[str, Any]) -> None:
+        """An event must say which node and what is happening to it.
+
+        Without ``machine_id`` there is nothing to go and look at; without
+        ``status`` there is no telling an upcoming window from one underway. This
+        check was the only ``_QueryableRecordsCheck`` left with no evidence bar,
+        so any non-empty record used to pass.
+        """
+        with pytest.raises(pytest.skip.Exception):
+            _run(MaintenanceEventsCheck, {"success": True, "events_queryable": True, "events": [event]})
+
+    def test_maintenance_event_does_not_require_prose(self) -> None:
+        """A provider that schedules maintenance without a message still reported it."""
+        step_output = {
+            "success": True,
+            "events_queryable": True,
+            "events": [{"machine_id": "m-1", "status": "maintenance"}],
+        }
+        assert _run(MaintenanceEventsCheck, step_output).passed
+
     def test_retirement_notice_needs_a_date_not_just_a_subject(self) -> None:
         """Without retire_after a notice says something will be retired, not when.
 


### PR DESCRIPTION
## Summary

`MaintenanceEventsCheck` was the last `_QueryableRecordsCheck` with no evidence bar — no `evidence_fields`, no `_is_evidence` override — so it inherited the "any non-empty record counts" default and `{"zzz": 1}` passed as a maintenance event.

#612 closed exactly this gap across the rest of the family (retirement notices need a date and a subject, repair history needs entries, both notification checks need a machine and an ordered pair of timestamps) and missed this one.

An event now has to carry `machine_id` and `status`. Those are the two that make it actionable: without `machine_id` there is nothing to go and look at, and without `status` there is no telling an upcoming window from one already underway. `message` stays optional — a provider that schedules maintenance without prose has still reported the event.

## Notes for review

- **No producer changes needed.** The NICo step emits `machine_id` from the machine id and defaults `status` to `"maintenance"`; the my-isv scaffold carries both.
- **One behavioural consequence:** a machine whose `id` came back empty now drops out of the evidence rather than counting. That is the intended reading — an event that cannot name its node is not one a tenant can act on.
- **This does not change what the NICo step observes.** It keys on the `Maintenance` machine status, which NICo genuinely models — the same status `return_node_maintenance.py` and `query_metrics.py` treat as out of service. A site with no machine in that state skips as "cannot be demonstrated", which is honest rather than a defect. Whether an `Error` machine with a health-probe alert should also count as a *current* maintenance event is a separate requirements question, and it overlaps BFX02-03, which already consumes `statusHistory`.
- Tightens a released check, so `released_tests.json` is untouched and this lands enabled. An ISV emitting events without either field would skip rather than pass, but both fields were already in the documented contract.

## Validation

`make test`, `make lint`, `make demo-test` and all 13 pre-commit hooks pass. Demo run reports `MaintenanceEventsCheck: PASSED - Maintenance event query API returned 1 event(s)`.

Five new tests in the file's existing style: a parametrised set over `{"zzz": 1}`, each field alone, and an empty `machine_id`; plus one asserting a message-less event still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance event evidence now requires both a machine ID and status.
  * Explanatory messages are optional when the required fields are provided.
* **Documentation**
  * Updated the documented event schema to reflect the required fields.
* **Tests**
  * Added coverage for valid and invalid maintenance event records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->