### PR TITLE
docs: add contributor on-ramps to README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,40 +9,49 @@ Thank you for your interest in contributing! This project is a **Python monorepo
 
 ## Table of Contents
 
-- [Issues Management] (#issues-management)
+- [Issues Management](#issues-management)
+- [Find Something to Work On](#find-something-to-work-on)
 - [About This Codebase](#about-this-codebase)
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
 - [Development](#development)
 - [Testing](#testing)
 - [Pull Request Process](#pull-request-process)
+- [Review Process](#review-process)
 - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
 - [Releasing](#releasing)
 
 ## Issues Management
 
-Read the README.md to understand the project
-Check existing issues to avoid duplicates
-Browse discussions for questions
-Review the security policy for security-related contributions
+- Read the `README.md` to understand the project.
+- Check existing issues to avoid duplicates.
+- Browse [Discussions](https://github.com/NVIDIA/ai-cloud-validation/discussions) for questions.
+- Review the [security policy](SECURITY.md) for security-related contributions.
 
 Ways to contribute:
 
-🐛 Report bugs via GitHub issues
-💡 Suggest features through feature requests
-📝 Improve documentation
-🧪 Add tests to increase coverage
-🔧 Fix issues with code contributions
-💬 Help others in discussions
+- 🐛 Report bugs via GitHub issues
+- 💡 Suggest features through feature requests
+- 📝 Improve documentation
+- 🧪 Add tests to increase coverage
+- 🔧 Fix issues with code contributions
+- 💬 Help others in discussions
 
-Reporting Issues
+### Reporting Issues
+
 When reporting issues:
 
-Use the issue templates when available
-Provide clear reproduction steps
-Include environment details (OS, Kubernetes version, etc.)
-Add relevant logs or error messages
-Search existing issues first to avoid duplicates
+- Use the issue templates when available.
+- Provide clear reproduction steps.
+- Include environment details (OS, Kubernetes version, etc.).
+- Add relevant logs or error messages.
+- Search existing issues first to avoid duplicates.
+
+## Find Something to Work On
+
+- Browse [`good first issue`](https://github.com/NVIDIA/ai-cloud-validation/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for beginner-friendly tasks, or [`help wanted`](https://github.com/NVIDIA/ai-cloud-validation/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for slightly larger ones.
+- **Claiming an issue:** comment on it to let others know you're taking it, so effort isn't duplicated.
+- Not sure where to start? Adding a provider stub via the [my-isv scaffold](isvctl/configs/providers/my-isv/scripts/README.md) with `make demo-test` is a self-contained first contribution that needs no real cloud hardware.
 
 ## About This Codebase
 
@@ -184,6 +193,14 @@ workflow). Without it the orchestrator logs `Skipping unreleased validation
 - Ensure all CI checks pass before requesting review.
 - Be responsive to feedback and code review comments.
 - Assign reviewer as `NCP ISV Lab Maintainer` - at least one engineer will review the PR.
+
+## Review Process
+
+Maintainers review PRs on a best-effort basis. Reviews are collaborative — suggested
+changes are meant to help your contribution land, not to criticize. Once approved, a
+maintainer will merge your PR. If you haven't heard back, feel free to ping the PR.
+
+[PLACEHOLDER: team to confirm timeline] — e.g., an initial response within N business days.
 
 ## Developer Certificate of Origin (DCO)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ It consists of a very flexible set of tests, which ensure that a system is able 
 
 This validation suite is meant to be run against an existing cloud system, specifically one that is running NVIDIA hardware. This suite is not itself a cloud software platform, nor does it target a single specific cloud platform. Instead, it maps high-level requirements to a set of *stub* functions, which allow you to run high-level operations (like "Create a Virtual Machine") which you can then use for direct validation, or as steps in validating more complex specifications.
 
+## Get Involved
+
+Contributions of all sizes are welcome — bug reports, docs, new provider stubs, and tests. New here? Start with a [`good first issue`](https://github.com/NVIDIA/ai-cloud-validation/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), then read the [Contributing Guide](CONTRIBUTING.md).
+
 ## Quick Start
 
 The fastest way to try running parts of the validation suite is against an existing cloud service, such as AWS. This can be run by setting up your environment with your AWS keys and running a simple test, as follows:
@@ -121,6 +125,20 @@ Instead of exporting these every session, run `isvctl configure` to persist them
 (non-secrets in `config.yml`, secrets in a `0600` `secrets.yml` under
 `${XDG_CONFIG_HOME:-~/.config}/isvctl/`). An exported variable always overrides
 the saved value. See the [isvctl README](isvctl/README.md#configuration).
+
+## Roadmap
+
+This project is an experimental (pre-1.0) preview and is evolving quickly. Track direction via [GitHub Milestones](https://github.com/NVIDIA/ai-cloud-validation/milestones) and open a [Discussion](https://github.com/NVIDIA/ai-cloud-validation/discussions) to help shape priorities.
+
+[PLACEHOLDER: maintainers to confirm the current roadmap items.]
+
+## Getting Help
+
+- **Questions & ideas:** [GitHub Discussions](https://github.com/NVIDIA/ai-cloud-validation/discussions)
+- **Bug reports & feature requests:** [GitHub Issues](https://github.com/NVIDIA/ai-cloud-validation/issues) (use the issue templates)
+- **Security vulnerabilities:** see [Security](#security) — do **not** open a public issue
+
+Maintainers watch Issues and Discussions on a best-effort basis. [PLACEHOLDER: team to confirm response expectation.]
 
 ## Security
 


### PR DESCRIPTION
## Summary
- Add a top-of-README "Get Involved" pointer to CONTRIBUTING.md and the good-first-issue filter
- Add "Getting Help" (Discussions/Issues/Security) and "Roadmap" sections to the README
- Add good-first-issue claiming guidance and a "Review Process" note to CONTRIBUTING
- Fix a broken TOC anchor and restore dropped bullet formatting in CONTRIBUTING's Issues Management section

Two `[PLACEHOLDER: ...]` markers are left intentionally (response-time expectation, roadmap contents) since those need maintainer sign-off rather than a fabricated number/list.

## Test plan
- [x] Maintainers confirm/replace the two placeholders
- [x] Reviewed rendered Markdown for broken links/anchors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance with clearer issue-reporting instructions, contribution options, review expectations, and links.
  - Added a section to help contributors find suitable tasks.
  - Expanded the README with contributor resources, starter issues, project roadmap information, and ways to get help.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->