### PR TITLE
feat(network): add IMEX domain operational + connectivity check (SDN21-01)

### DIFF
--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -1910,7 +1910,7 @@ a|
 | [[SDN21-01]]SDN21-01
 | SDN21
 |
-|
+| min_req, network
 | tenant
 |
 |

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -1788,6 +1788,9 @@ domains:
                 notes: ""
                 priority: ""
               - summary: "IMEX: After all nodes start IMEX, query domain state via nvidia-imex-ctl -N and assert state is UP, fully connected matrix"
+                labels:
+                  - min_req
+                  - network
                 dependencies:
                   - LimitedEnv
                 milestone: M4

--- a/isvctl/configs/providers/aws/config/network.yaml
+++ b/isvctl/configs/providers/aws/config/network.yaml
@@ -378,6 +378,27 @@ commands:
         timeout: 900
         output_schema: storage_l3_routing
 
+      # IMEX domain operational + fully connected (SDN21-01). Observes an
+      # already-running IMEX domain over SSH; does not launch nodes or bring
+      # IMEX up (see imex_domain_test.py docstring). Requires an existing
+      # multi-node GPU cluster - point it at one via imex_node_ids/imex_key_file.
+      - name: imex_domain
+        phase: test
+        command: "python3 ../scripts/network/imex_domain_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--node-ids"
+          - "{{imex_node_ids | default('', true)}}"
+          - "--key-file"
+          - "{{imex_key_file | default('', true)}}"
+        # Headroom over the script's own 90s sweep deadline (plus one in-flight
+        # per-node SSH timeout), so the script always emits its JSON contract
+        # rather than being killed here with no output on a large or
+        # unresponsive domain.
+        timeout: 300
+        output_schema: imex_domain
+
       # Teardown: Clean up shared VPC from create_network
       - name: teardown
         phase: teardown
@@ -397,3 +418,5 @@ tests:
   settings:
     region: "us-west-2"
     storage_l3_routing_cidr: "{{env.AWS_STORAGE_L3_ROUTING_CIDR | default('', true)}}"
+    imex_node_ids: "{{env.AWS_IMEX_NODE_IDS | default('', true)}}"
+    imex_key_file: "{{env.AWS_IMEX_KEY_FILE | default('', true)}}"

--- a/isvctl/configs/providers/aws/scripts/network/imex_domain_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/imex_domain_test.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IMEX domain connectivity test - AWS reference implementation (SDN21-01).
+
+Bringing an IMEX domain up (writing nodes_config.cfg, starting the
+`nvidia-imex` service) is a cluster-lifecycle concern owned elsewhere (see
+NVIDIA Mission Control autonomous-hardware-recovery's `imex_bring_up.sh`
+action) - out of scope per the requirement ("service lifecycle management").
+This script only observes an ALREADY-RUNNING domain: it SSHes into each
+expected member node and asks `nvidia-imex-ctl -N` what that node currently
+sees, then reports each node's raw view. It never aggregates a single
+"fully connected" verdict itself - ImexDomainConnectivityCheck computes
+pairwise connectivity independently from the raw `reachability` map so a
+one-way fault is never masked by an aggregate flag.
+
+Nodes are GPU hosts (multi-node NVLink domain, e.g. P5/P4d instance family)
+that must already be provisioned and IMEX-enabled; this script does not
+launch or provision them (unlike dhcp_ip_test.py's throwaway t3.micro),
+since real GPU capacity is not something a per-test script should launch on
+demand. Point it at an existing cluster via --node-ids (SSH-reachable
+hostnames or IPs) and --key-file, or the AWS_IMEX_* env var equivalents,
+mirroring the "reuse an existing instance" dev workflow documented in
+bare_metal.yaml.
+
+`nvidia-imex-ctl -N -j` (JSON output; confirmed against a live single-node
+UP domain and a live 2-node DOWN domain on 2026-09-04) returns one entry per
+CONFIGURED member (not just the queried node), each with its own
+"connections" map, e.g.:
+    {
+      "nodes": {
+        "0": {
+          "status": "READY",
+          "host": "10.0.0.1",
+          "hostName": "gpu-node-1",
+          "connections": {
+            "0": {"host": "10.0.0.1", "status": "CONNECTED", "changed": true},
+            "1": {"host": "10.0.0.2", "status": "CONNECTED", "changed": true}
+          },
+          "changed": true,
+          "version": "580.95.05"
+        },
+        "1": { "status": "UNAVAILABLE", "host": "10.0.0.2", "connections": {...}, ... }
+      },
+      "timestamp": "9/4/2026 00:37:39.905",
+      "status": "UP"
+    }
+Peer entries (status "UNAVAILABLE", "connections" all "INVALID") appear to be
+reconstructed from nodes_config.cfg rather than a live report from that peer,
+so `_parse_imex_ctl_json` only reads the entry matching the node we actually
+SSHed into - that is what keeps `reachability[node]` an independent
+per-node observation rather than one node's possibly-stale view of everyone
+else. `nvidia-imex-ctl` exits 255 (confirmed live) when it cannot read its
+node config, so a non-zero exit reliably means "this node has no usable
+view" - it is excluded from `members` entirely rather than reported with an
+empty/misleading reachability list. Confirmed live too: the daemon can also
+fail to *start* on a version-mismatched host ("NvGpu Library version ... is
+not matching with current GPU driver version") - `-N` then reports domain
+status "DOWN" with every configured member "UNAVAILABLE", which flows
+through the same non-READY/no-CONNECTED-peers path as any other outage.
+
+The expected member set comes from configuration membership (--node-ids /
+AWS_IMEX_NODE_IDS), i.e. the operator states which nodes were allocated to the
+domain. Those IDs must match the identity form written into nodes_config.cfg.
+
+Usage:
+    python imex_domain_test.py --region us-west-2 \\
+        --node-ids gpu-node-1.cluster.internal,gpu-node-2.cluster.internal \\
+        --key-file /tmp/isv-imex-test-key.pem
+
+Emits the SDN21-01 step output contract (see output_schemas.py "imex_domain"):
+    {
+      "success": true,
+      "platform": "network",
+      "domain": {
+        "domain_id": "...", "state": "up",
+        "expected_members": ["node-01", "node-02"],
+        "fully_connected": true
+      },
+      "nodes_checked": 2,
+      "nodes_validated": 2,
+      "nodes": [
+        {"node_id": "node-01", "service_state": "active",
+         "domain_member": true, "peers_reachable": ["node-02"]}
+      ]
+    }
+``domain.fully_connected`` is the vendor's own aggregate claim, reported for
+context only - ImexDomainConnectivityCheck ignores it and recomputes pairwise
+connectivity from each node's ``peers_reachable``.
+"""
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+from common.ssh_utils import ssh_run
+
+DEFAULT_SSH_USER = "ubuntu"
+IMEX_CTL_COMMAND = "sudo nvidia-imex-ctl -N -j -H"
+# Cap simultaneous ssh processes so a large IMEX domain does not fan out into
+# hundreds of them at once.
+MAX_PARALLEL_QUERIES = 16
+# Overall sweep deadline. Kept well under the wired step timeout so this script
+# always wins the race and prints its JSON contract instead of being killed.
+DEFAULT_DEADLINE_SECONDS = 90
+
+
+def _parse_imex_ctl_json(output: str, queried_host: str) -> tuple[str, str, list[str]]:
+    """Parse `nvidia-imex-ctl -N -j -H` output into (domain_state, own_status, peer_hosts).
+
+    ``own_status`` is the queried node's own entry status ("READY" when its IMEX
+    service is up and participating, "UNAVAILABLE" when it is not), which the
+    caller maps onto the contract's ``service_state`` / ``domain_member``.
+
+    Confirmed live (2026-09-04, 2-node cluster): `nodes` contains an entry for
+    EVERY configured member, not just the queried one - including entries for
+    peers whose own daemon is down (e.g. "status": "UNAVAILABLE", "connections"
+    all "INVALID"), which appear to be reconstructed from nodes_config.cfg
+    rather than a live report from that peer. So we deliberately use only the
+    entry matching `queried_host`'s own connections map as this node's
+    observation, rather than any other entry in the payload - that is what
+    keeps `reachability[node]` an independent, per-node observation instead of
+    the daemon's possibly-stale view of everyone else.
+
+    `queried_host` is whatever identity form --node-ids used (IP or hostname).
+    `nvidia-imex-ctl` always reports the IP in "host" and (with -H) the
+    hostname in "hostName", but each `connections` entry only carries "host"
+    (IP) - so a hostname-configured domain would otherwise (a) never match
+    `queried_host` against "host", finding no "own" entry at all, and (b)
+    even if it did, report peers as IPs that don't match the caller's
+    hostname-based `expected_members`, silently producing zero peers. Both
+    are fixed by matching "own" against either field, then translating each
+    peer's IP back to the same identity form `queried_host` used - built from
+    every node's host/hostName pair, since a peer's own top-level entry
+    carries both even when its `connections` sub-entry only has the IP.
+    """
+    data = json.loads(output)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected a JSON object from nvidia-imex-ctl, got {type(data).__name__}")
+    domain_state = data.get("status", "")
+
+    nodes_raw = data.get("nodes", {})
+    if not isinstance(nodes_raw, dict):
+        raise ValueError(f"`nodes` must be an object, got {type(nodes_raw).__name__}")
+    # Skip individually malformed entries rather than fail the whole node's
+    # query over one bad record - a partial view is still a real observation.
+    nodes = [node for node in nodes_raw.values() if isinstance(node, dict)]
+
+    own_connections: dict[str, Any] = {}
+    own_host = None
+    own_status = ""
+    identity_field = "host"
+    for node in nodes:
+        if node.get("host") == queried_host:
+            own_host = node.get("host")
+            own_connections = node.get("connections") or {}
+            own_status = node.get("status") or ""
+            identity_field = "host"
+            break
+        if node.get("hostName") and node.get("hostName") == queried_host:
+            own_host = node.get("host")
+            own_connections = node.get("connections") or {}
+            own_status = node.get("status") or ""
+            identity_field = "hostName"
+            break
+    if not isinstance(own_connections, dict):
+        own_connections = {}
+
+    # host (IP) -> hostName, so peer connection entries (IP-only) can be
+    # reported in whichever identity form the caller's --node-ids used.
+    host_to_name = {node.get("host"): node.get("hostName") for node in nodes if node.get("host")}
+
+    def _peer_identity(peer_host: str) -> str:
+        if identity_field == "hostName":
+            resolved = host_to_name.get(peer_host)
+            if resolved:
+                return resolved
+        return peer_host
+
+    peers = [
+        _peer_identity(peer["host"])
+        for peer in own_connections.values()
+        if isinstance(peer, dict)
+        and peer.get("status") == "CONNECTED"
+        and peer.get("host")
+        and peer.get("host") != own_host
+    ]
+    return domain_state, own_status, peers
+
+
+def _service_state(own_status: str) -> str:
+    """Map a node's nvidia-imex-ctl entry status onto the contract's service_state."""
+    return {"READY": "active", "UNAVAILABLE": "inactive"}.get(own_status, (own_status or "unknown").lower())
+
+
+def query_node(host: str, user: str, key_file: str, timeout: int) -> dict[str, Any]:
+    """SSH into a single node and query its IMEX domain view."""
+    exit_code, stdout, stderr = ssh_run(host, user, key_file, IMEX_CTL_COMMAND, timeout=timeout)
+    if exit_code != 0:
+        return {"host": host, "ok": False, "error": stderr.strip() or f"exit code {exit_code}"}
+
+    try:
+        domain_state, own_status, peers = _parse_imex_ctl_json(stdout, host)
+    except (json.JSONDecodeError, ValueError) as e:
+        return {"host": host, "ok": False, "error": f"could not parse nvidia-imex-ctl JSON output: {e}"}
+
+    return {
+        "host": host,
+        "ok": True,
+        "domain_state": domain_state,
+        "own_status": own_status,
+        "peers": peers,
+    }
+
+
+def query_members(
+    hosts: list[str],
+    *,
+    user: str,
+    key_file: str,
+    timeout: int,
+    deadline: int,
+) -> dict[str, dict[str, Any]]:
+    """Query every member concurrently, always returning one result per host.
+
+    Concurrency is capped (rather than one thread per member) so a large domain
+    does not fan out into hundreds of simultaneous ssh processes. That cap means
+    wall-clock time is roughly ``ceil(len(hosts) / MAX_PARALLEL_QUERIES) *
+    timeout``, which for a big domain of unresponsive nodes could otherwise run
+    past the orchestrator's step timeout and get this process killed before it
+    prints anything. So the whole sweep is also bounded by ``deadline``: members
+    that have not answered by then are reported as timed-out query errors and
+    the caller still emits the full structured JSON contract.
+    """
+    results: dict[str, dict[str, Any]] = {}
+    pool = ThreadPoolExecutor(max_workers=min(len(hosts), MAX_PARALLEL_QUERIES))
+    try:
+        futures = {pool.submit(query_node, host, user, key_file, timeout): host for host in hosts}
+        try:
+            for future in as_completed(futures, timeout=deadline):
+                results[futures[future]] = future.result()
+        except FuturesTimeoutError:
+            pass
+        for future, host in futures.items():
+            if host not in results:
+                future.cancel()
+                results[host] = {
+                    "host": host,
+                    "ok": False,
+                    "error": f"query did not complete within the {deadline}s deadline",
+                }
+    finally:
+        # Do not block on stragglers - each in-flight ssh_run is already bounded
+        # by its own per-node timeout, and queued work is dropped outright.
+        pool.shutdown(wait=False, cancel_futures=True)
+    return results
+
+
+def main() -> int:
+    """Query each expected IMEX domain member and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="IMEX domain connectivity test (AWS)")
+    parser.add_argument("--region", required=True, help="AWS region (recorded for context only)")
+    parser.add_argument(
+        "--node-ids",
+        default=os.environ.get("AWS_IMEX_NODE_IDS", ""),
+        help="Comma-separated SSH-reachable hostnames/IPs of expected IMEX domain members (min 2)",
+    )
+    parser.add_argument(
+        "--key-file",
+        default=os.environ.get("AWS_IMEX_KEY_FILE", ""),
+        help="SSH private key file for the node(s)",
+    )
+    parser.add_argument("--ssh-user", default=os.environ.get("AWS_IMEX_SSH_USER", DEFAULT_SSH_USER))
+    parser.add_argument("--domain-id", default=os.environ.get("AWS_IMEX_DOMAIN_ID", ""))
+    parser.add_argument("--timeout", type=int, default=30, help="Per-node SSH command timeout (seconds)")
+    parser.add_argument(
+        "--deadline",
+        type=int,
+        default=DEFAULT_DEADLINE_SECONDS,
+        help=(
+            "Overall deadline for querying every member (seconds). Members that have not answered by then are "
+            "reported as timed out so structured JSON is still emitted, rather than the orchestrator killing "
+            "this process at its step timeout with no output."
+        ),
+    )
+    args = parser.parse_args()
+
+    expected_members = [node_id.strip() for node_id in args.node_ids.split(",") if node_id.strip()]
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "imex_domain",
+        "region": args.region,
+        "domain": {
+            "domain_id": args.domain_id or "-".join(sorted(expected_members)),
+            "state": "",
+            "expected_members": expected_members,
+            "fully_connected": False,
+        },
+        "nodes_checked": 0,
+        "nodes_validated": 0,
+        "nodes": [],
+    }
+
+    # SDN21-01 needs a pre-existing multi-node IMEX cluster, which a normal AWS
+    # network run does not provision. When the run simply has not been pointed
+    # at one, skip rather than fail - otherwise wiring this step would break
+    # every network run that isn't specifically testing IMEX. A partially
+    # configured run is still a hard error: it means someone tried to point this
+    # at a cluster and got it wrong, which should not pass silently.
+    if not expected_members and not args.key_file:
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = "IMEX domain not configured for this run (no node IDs or SSH key set)"
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if not expected_members:
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = "IMEX domain not configured for this run (no node IDs set)"
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if len(expected_members) < 2:
+        result["error"] = "--node-ids must list at least two expected IMEX domain members"
+        print(json.dumps(result, indent=2))
+        return 1
+
+    if not args.key_file:
+        result["error"] = "--key-file (or AWS_IMEX_KEY_FILE) is required to SSH into domain members"
+        print(json.dumps(result, indent=2))
+        return 1
+
+    results_by_host = query_members(
+        expected_members,
+        user=args.ssh_user,
+        key_file=args.key_file,
+        timeout=args.timeout,
+        deadline=args.deadline,
+    )
+
+    nodes: list[dict[str, Any]] = []
+    domain_states: set[str] = set()
+    query_errors: list[str] = []
+    validated = 0
+
+    # Iterate in expected_members order (not completion order) for
+    # deterministic output regardless of which SSH call finishes first.
+    for host in expected_members:
+        node_result = results_by_host[host]
+        if not node_result["ok"]:
+            query_errors.append(f"{host}: {node_result['error']}")
+            # A node we could not query reports no membership, so the
+            # validation's set-equality check flags it as missing.
+            nodes.append(
+                {
+                    "node_id": host,
+                    "service_state": "unreachable",
+                    "domain_member": False,
+                    "peers_reachable": [],
+                    "error": node_result["error"],
+                }
+            )
+            continue
+        validated += 1
+        own_status = node_result["own_status"]
+        nodes.append(
+            {
+                "node_id": host,
+                "service_state": _service_state(own_status),
+                # Only a READY node is actually participating in the domain; a
+                # configured-but-down peer is reported, not counted as a member.
+                "domain_member": own_status == "READY",
+                "peers_reachable": node_result["peers"],
+            }
+        )
+        if node_result["domain_state"]:
+            domain_states.add(node_result["domain_state"])
+
+    result["nodes"] = nodes
+    result["nodes_checked"] = len(expected_members)
+    result["nodes_validated"] = validated
+
+    # Members disagreeing on domain state is itself a fault; report it as mixed
+    # rather than picking one node's view and hiding the disagreement.
+    if len(domain_states) == 1:
+        result["domain"]["state"] = next(iter(domain_states)).lower()
+    elif len(domain_states) > 1:
+        result["domain"]["state"] = "mixed(" + ",".join(sorted(s.lower() for s in domain_states)) + ")"
+
+    # The vendor's own aggregate claim, carried for reporting only. The
+    # validation ignores it and recomputes connectivity from peers_reachable.
+    result["domain"]["fully_connected"] = result["domain"]["state"] == "up"
+
+    if query_errors:
+        result["error"] = "; ".join(query_errors)
+
+    result["success"] = validated > 0
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/config/network.yaml
+++ b/isvctl/configs/providers/my-isv/config/network.yaml
@@ -342,6 +342,17 @@ commands:
         timeout: 60
         output_schema: nvlink_domain
 
+      - name: imex_domain
+        phase: test
+        command: "python ../scripts/network/imex_domain_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--node-ids"
+          - "compute-node-1,compute-node-2"
+        timeout: 60
+        output_schema: imex_domain
+
       - name: teardown
         phase: teardown
         command: "python ../scripts/network/teardown.py"

--- a/isvctl/configs/providers/my-isv/scripts/network/imex_domain_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/network/imex_domain_test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IMEX domain connectivity test - TEMPLATE.
+
+This script is called during the "test" phase. It is SELF-CONTAINED:
+  1. Resolve the expected IMEX domain member nodes (which nodes were allocated)
+  2. Query each node's IMEX domain state (e.g. `nvidia-imex-ctl -N` over SSH)
+  3. Report, per node, its service state and the peers IT observes
+  4. Print a JSON object to stdout
+
+All parsing of vendor output belongs here in the provider script; the
+validation sees only the normalized shape below.
+
+The validation (ImexDomainConnectivityCheck) computes pairwise mutual
+connectivity itself from each node's `peers_reachable` - it does NOT trust
+`domain.fully_connected`. Do not pre-aggregate connectivity here; report what
+each node actually observed, including asymmetric/one-way results if present,
+or a real one-way fault will be masked.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "network",
+    "test_name": "imex_domain",
+    "domain": {
+      "domain_id": "imex-0",
+      "state": "up",
+      "expected_members": ["compute-node-1", "compute-node-2"],
+      "fully_connected": true
+    },
+    "nodes_checked": 2,
+    "nodes_validated": 2,
+    "nodes": [
+      {
+        "node_id": "compute-node-1",
+        "service_state": "active",
+        "domain_member": true,
+        "peers_reachable": ["compute-node-2"]
+      }
+    ]
+  }
+
+`service_state` is reported for diagnostics but not asserted on - service
+lifecycle is out of scope. `domain_member` is how a node declares it joined;
+the validation checks that set against `domain.expected_members`.
+
+Usage:
+    python imex_domain_test.py --region <region> --node-ids <id1>,<id2>[,...]
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Query IMEX domain state/connectivity and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="IMEX domain connectivity test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument(
+        "--node-ids",
+        required=True,
+        help="Comma-separated expected IMEX domain member node IDs (min 2)",
+    )
+    args = parser.parse_args()
+    expected_members = [node_id.strip() for node_id in args.node_ids.split(",") if node_id.strip()]
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "imex_domain",
+        "region": args.region,
+        "domain": {
+            "domain_id": "",
+            "state": "",
+            "expected_members": expected_members,
+            "fully_connected": False,
+        },
+        "nodes_checked": 0,
+        "nodes_validated": 0,
+        "nodes": [],
+    }
+
+    # TODO: Replace with your platform's IMEX domain query. Typically this
+    # means SSH-ing into each expected member and running `nvidia-imex-ctl -N`,
+    # then reporting that node's own service state and the peers it observes.
+
+    if DEMO_MODE:
+        result["domain"]["domain_id"] = "imex-0"
+        result["domain"]["state"] = "up"
+        result["domain"]["fully_connected"] = True
+        result["nodes"] = [
+            {
+                "node_id": node_id,
+                "service_state": "active",
+                "domain_member": True,
+                "peers_reachable": [peer for peer in expected_members if peer != node_id],
+            }
+            for node_id in expected_members
+        ]
+        result["nodes_checked"] = len(expected_members)
+        result["nodes_validated"] = len(expected_members)
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's IMEX domain query"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -21,7 +21,12 @@
 # fabric security, tenant-transition sanitization, attestation, break-fix
 # observability (with documented gaps for mutating workflows), and existing
 # instance inventory checks. Full lifecycle and SSH-host validations remain
-# excluded until those steps are wired for NICo.
+# excluded until those steps are wired for NICo. That includes IMEX domain
+# operational/connectivity validation (SDN21-01): NICo's BMaaS API surface
+# is hardware inventory/lifecycle only and does not expose live host/software
+# telemetry such as `nvidia-imex-ctl` state, so no imex_domain step is wired
+# here (see the AWS and my-isv network.yaml configs for real/template
+# implementations of that check).
 #
 # Architecture:
 #   - verify_ingestion.py compares expected-machine manifest vs discovered

--- a/isvctl/configs/suites/network.yaml
+++ b/isvctl/configs/suites/network.yaml
@@ -329,6 +329,11 @@ tests:
           labels: ["min_req", "network"]
           requires: [vm, bare_metal]
           step: nvlink_domain
+        ImexDomainConnectivityCheck:
+          test_id: "SDN21-01"
+          labels: ["min_req", "network"]
+          requires: [vm, bare_metal]
+          step: imex_domain
 
     teardown_checks:
       step: teardown

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -136,6 +136,8 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "backend_switch_fabric_test": "backend_switch_fabric",
     "nvlink_domain": "nvlink_domain",
     "nvlink_domain_test": "nvlink_domain",
+    "imex_domain": "imex_domain",
+    "imex_domain_test": "imex_domain",
     "sg_crud_test": "sg_crud",
     "sg_crud": "sg_crud",
     # Node pool operations
@@ -912,6 +914,75 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
         },
         "if": {"properties": {"nvlink_supported": {"const": True}}},
         "then": {"required": ["nvlink_domain_id"]},
+        "additionalProperties": True,
+    },
+    "imex_domain": {
+        "type": "object",
+        "required": ["success", "platform", "domain", "nodes"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "test_name": {"type": "string", "description": "Always 'imex_domain'"},
+            "domain": {
+                "type": "object",
+                "required": ["domain_id", "state", "expected_members"],
+                "properties": {
+                    "domain_id": {"type": "string", "description": "IMEX domain identifier"},
+                    "state": {
+                        "type": "string",
+                        "description": "Normalized domain state; operational when 'up'",
+                    },
+                    "expected_members": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1},
+                        # No minItems: the schema describes payload shape, while
+                        # the "at least two members" rule is enforced by
+                        # ImexDomainConnectivityCheck. Requiring 2 here would
+                        # also reject the skipped payload emitted when no IMEX
+                        # domain is configured for the run.
+                        "description": "Node IDs expected to have joined the IMEX domain",
+                    },
+                    "fully_connected": {
+                        "type": "boolean",
+                        "description": (
+                            "Provider-reported aggregate connectivity claim. Carried for reporting only - "
+                            "ImexDomainConnectivityCheck deliberately ignores it and recomputes pairwise "
+                            "connectivity from each node's peers_reachable so a one-way fault cannot pass."
+                        ),
+                    },
+                },
+                "additionalProperties": True,
+                "description": "Domain-level state and expected membership",
+            },
+            "nodes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["node_id"],
+                    "properties": {
+                        "node_id": {"type": "string", "minLength": 1, "description": "Node identifier"},
+                        "service_state": {
+                            "type": "string",
+                            "description": "IMEX service state on the node; reported only, not asserted on",
+                        },
+                        "domain_member": {
+                            "type": "boolean",
+                            "description": "Whether this node reports itself as a member of the domain",
+                        },
+                        "peers_reachable": {
+                            "type": "array",
+                            "items": {"type": "string", "minLength": 1},
+                            "description": "Peer node IDs this node observes as reachable",
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+                "description": "Per-node domain reports, one per queried member",
+            },
+            "nodes_checked": {"type": "integer", "description": "How many members were queried"},
+            "nodes_validated": {"type": "integer", "description": "How many members returned a usable report"},
+            "skipped": {"type": "boolean", "description": "True when no IMEX domain was configured for the run"},
+            "skip_reason": {"type": "string", "description": "Why the IMEX domain check was skipped"},
+        },
         "additionalProperties": True,
     },
     "sg_crud": {

--- a/isvctl/tests/providers/aws/test_aws_network_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_network_scripts.py
@@ -22,6 +22,8 @@ import json
 import os
 import subprocess
 import sys
+import threading
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
@@ -2251,3 +2253,305 @@ def test_my_isv_stable_egress_demo_emits_minimal_contract() -> None:
     payload: dict[str, Any] = json.loads(completed.stdout)
     _assert_stable_egress_contract(payload)
     assert payload["tests"]["probe_egress_ip"]["probes"] == 2
+
+
+def _imex_up_payload(node_a_id: str, node_b_id: str, *, hostnames: bool = False) -> str:
+    """Build a real-shaped `nvidia-imex-ctl -N -j -H` UP-domain JSON payload for two nodes.
+
+    Schema confirmed live against `nvidia-imex-ctl -N -j -H` (2026-09-04):
+    every configured member gets an entry (not just the queried node), each
+    with its own `connections` map keyed by "host" (IP only - never a
+    hostname, even when the node's own top-level entry has "hostName" set).
+    """
+    node_a_host, node_a_name = ("10.0.0.1", node_a_id) if hostnames else (node_a_id, "gpu-node-a")
+    node_b_host, node_b_name = ("10.0.0.2", node_b_id) if hostnames else (node_b_id, "gpu-node-b")
+    return json.dumps(
+        {
+            "nodes": {
+                "0": {
+                    "status": "READY",
+                    "host": node_a_host,
+                    "hostName": node_a_name,
+                    "connections": {
+                        "0": {"host": node_a_host, "status": "CONNECTED", "changed": True},
+                        "1": {"host": node_b_host, "status": "CONNECTED", "changed": True},
+                    },
+                },
+                "1": {
+                    "status": "READY",
+                    "host": node_b_host,
+                    "hostName": node_b_name,
+                    "connections": {
+                        "0": {"host": node_a_host, "status": "CONNECTED", "changed": True},
+                        "1": {"host": node_b_host, "status": "CONNECTED", "changed": True},
+                    },
+                },
+            },
+            "timestamp": "9/4/2026 00:00:00.000",
+            "status": "UP",
+        }
+    )
+
+
+def test_imex_parse_matches_queried_ip() -> None:
+    """--node-ids given as IPs: own node found by `host`, peers reported as IPs."""
+    module = _load_network_script("imex_domain_test.py")
+    payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
+
+    domain_state, own_status, peers = module._parse_imex_ctl_json(payload, "10.0.0.1")
+
+    assert domain_state == "UP"
+    assert own_status == "READY"
+    assert peers == ["10.0.0.2"]
+
+
+def test_imex_parse_matches_queried_hostname() -> None:
+    """--node-ids given as hostnames must still resolve the local node and report
+    peers as hostnames, not the underlying IPs nvidia-imex-ctl reports in
+    `connections` - regression test for a CodeRabbit-flagged bug where hostname
+    -configured domains matched nothing and silently reported zero peers."""
+    module = _load_network_script("imex_domain_test.py")
+    payload = _imex_up_payload("gpu-node-a", "gpu-node-b", hostnames=True)
+
+    domain_state, own_status, peers = module._parse_imex_ctl_json(payload, "gpu-node-a")
+
+    assert domain_state == "UP"
+    assert own_status == "READY"
+    assert peers == ["gpu-node-b"]
+
+
+def test_imex_parse_down_domain_reports_no_peers() -> None:
+    """A DOWN domain (real payload shape from a version-mismatched daemon) reports
+    the domain state but no peers, rather than crashing or fabricating connectivity."""
+    module = _load_network_script("imex_domain_test.py")
+    payload = json.dumps(
+        {
+            "nodes": {
+                "1": {
+                    "status": "UNAVAILABLE",
+                    "host": "10.0.0.2",
+                    "connections": {
+                        "0": {"host": "10.0.0.1", "status": "INVALID", "changed": False},
+                        "1": {"host": "10.0.0.2", "status": "INVALID", "changed": False},
+                    },
+                    "hostName": "N/A",
+                },
+                "0": {
+                    "status": "UNAVAILABLE",
+                    "host": "10.0.0.1",
+                    "connections": {
+                        "1": {"host": "10.0.0.2", "status": "INVALID", "changed": False},
+                        "0": {"host": "10.0.0.1", "status": "INVALID", "changed": False},
+                    },
+                    "hostName": "gpu-node-a",
+                },
+            },
+            "timestamp": "9/4/2026 00:00:00.000",
+            "status": "DOWN",
+        }
+    )
+
+    domain_state, own_status, peers = module._parse_imex_ctl_json(payload, "10.0.0.1")
+
+    assert domain_state == "DOWN"
+    # A down daemon reports itself UNAVAILABLE, which maps to service_state
+    # "inactive" and domain_member false in the emitted contract.
+    assert own_status == "UNAVAILABLE"
+    assert module._service_state(own_status) == "inactive"
+    assert peers == []
+
+
+@pytest.mark.parametrize("malformed_payload", ["[]", "null", '{"nodes": []}', '{"nodes": "oops"}'])
+def test_imex_parse_rejects_malformed_payload_shapes(malformed_payload: str) -> None:
+    """A decoded payload that isn't the expected object shape (list, null, or a
+    `nodes` value that isn't an object) must raise ValueError, not AttributeError -
+    CodeRabbit regression: query_node only caught JSONDecodeError, so an
+    AttributeError from `data.get(...)` on a non-dict payload would have escaped
+    ThreadPoolExecutor.map and crashed main() instead of emitting structured JSON."""
+    module = _load_network_script("imex_domain_test.py")
+
+    with pytest.raises(ValueError):
+        module._parse_imex_ctl_json(malformed_payload, "10.0.0.1")
+
+
+def test_imex_query_node_reports_malformed_payload_as_query_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """query_node must convert a zero-exit SSH command returning `[]` into a
+    per-node ok=False error, not raise - so main()'s ThreadPoolExecutor.map
+    still yields structured JSON for every node instead of crashing."""
+    module = _load_network_script("imex_domain_test.py")
+    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, "[]", ""))
+
+    result = module.query_node("10.0.0.1", "ubuntu", "/tmp/key.pem", 30)
+
+    assert result["ok"] is False
+    assert "could not parse" in result["error"]
+
+
+def test_imex_query_members_returns_one_result_per_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every requested host must appear in the result map, keyed by host."""
+    module = _load_network_script("imex_domain_test.py")
+    payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
+    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, payload, ""))
+
+    results = module.query_members(
+        ["10.0.0.1", "10.0.0.2"], user="ubuntu", key_file="/tmp/key.pem", timeout=30, deadline=90
+    )
+
+    assert set(results) == {"10.0.0.1", "10.0.0.2"}
+    assert results["10.0.0.1"]["peers"] == ["10.0.0.2"]
+    assert results["10.0.0.2"]["peers"] == ["10.0.0.1"]
+
+
+def test_imex_query_members_reports_unfinished_hosts_on_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hosts that do not answer within the overall deadline must come back as
+    timed-out query errors, so main() still emits the full JSON contract instead
+    of the orchestrator killing the process at its step timeout with no output."""
+    module = _load_network_script("imex_domain_test.py")
+
+    def _hang(host: str, *_args: Any, **_kwargs: Any) -> tuple[int, str, str]:
+        if host == "10.0.0.2":
+            time.sleep(5)
+        return (0, _imex_up_payload("10.0.0.1", "10.0.0.2"), "")
+
+    monkeypatch.setattr(module, "ssh_run", _hang)
+
+    results = module.query_members(
+        ["10.0.0.1", "10.0.0.2"], user="ubuntu", key_file="/tmp/key.pem", timeout=30, deadline=1
+    )
+
+    assert set(results) == {"10.0.0.1", "10.0.0.2"}
+    assert results["10.0.0.1"]["ok"] is True
+    assert results["10.0.0.2"]["ok"] is False
+    assert "deadline" in results["10.0.0.2"]["error"]
+
+
+def test_imex_query_members_caps_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrency must stay capped so a large domain does not fan out into one
+    ssh process per member."""
+    module = _load_network_script("imex_domain_test.py")
+    hosts = [f"10.0.0.{n}" for n in range(1, 41)]
+    payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
+
+    lock = threading.Lock()
+    live = 0
+    peak = 0
+
+    def _tracked(*_args: Any, **_kwargs: Any) -> tuple[int, str, str]:
+        nonlocal live, peak
+        with lock:
+            live += 1
+            peak = max(peak, live)
+        time.sleep(0.01)
+        with lock:
+            live -= 1
+        return (0, payload, "")
+
+    monkeypatch.setattr(module, "ssh_run", _tracked)
+
+    results = module.query_members(hosts, user="ubuntu", key_file="/tmp/key.pem", timeout=30, deadline=90)
+
+    assert len(results) == len(hosts)
+    assert peak <= module.MAX_PARALLEL_QUERIES
+
+
+def _run_imex_script(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the AWS imex_domain_test.py script with a clean env (no AWS_IMEX_* set)."""
+    script = AWS_NETWORK_SCRIPTS / "imex_domain_test.py"
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        env={"PATH": os.environ.get("PATH", "")},
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["--region", "us-west-2"], id="nothing-configured"),
+        pytest.param(["--region", "us-west-2", "--key-file", "/tmp/key.pem"], id="key-only"),
+    ],
+)
+def test_imex_skips_when_domain_not_configured(args: list[str]) -> None:
+    """SDN21-01 needs a pre-existing multi-node IMEX cluster, which a normal AWS
+    network run does not provision. When the run is not pointed at one, the step
+    must skip cleanly (exit 0 + skipped payload) instead of failing the whole
+    network run - CodeRabbit regression: the step is wired unconditionally, so
+    exiting 1 here broke every AWS network run not specifically testing IMEX."""
+    completed = _run_imex_script(*args)
+
+    assert completed.returncode == 0, completed.stderr
+    payload: dict[str, Any] = json.loads(completed.stdout)
+    assert payload["success"] is True
+    assert payload["skipped"] is True
+    assert "not configured" in payload["skip_reason"]
+
+
+def test_imex_skipped_payload_matches_output_schema() -> None:
+    """The skipped payload must still satisfy the wired imex_domain schema, or the
+    orchestrator flags a schema failure on an intentionally-skipped step."""
+    from isvctl.config.output_schemas import validate_output
+
+    completed = _run_imex_script("--region", "us-west-2")
+    payload: dict[str, Any] = json.loads(completed.stdout)
+
+    is_valid, errors = validate_output(payload, "imex_domain")
+    assert is_valid, errors
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["--node-ids", "node-a", "--key-file", "/tmp/key.pem"], id="single-node"),
+        pytest.param(["--node-ids", "node-a,node-b"], id="no-key-file"),
+    ],
+)
+def test_imex_partial_configuration_still_fails(args: list[str]) -> None:
+    """A partially configured run means someone pointed this at a cluster and got
+    it wrong - that must stay a hard error rather than silently skipping."""
+    completed = _run_imex_script("--region", "us-west-2", *args)
+
+    assert completed.returncode == 1
+    payload: dict[str, Any] = json.loads(completed.stdout)
+    assert payload["success"] is False
+    assert payload.get("skipped") is not True
+    assert payload["error"]
+
+
+def test_imex_emits_sdn21_step_output_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script must emit the SDN21-01 contract shape from the issue: a nested
+    `domain` object plus a `nodes` array of per-node reports, not a flat payload."""
+    module = _load_network_script("imex_domain_test.py")
+    payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
+    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, payload, ""))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["imex_domain_test.py", "--region", "us-west-2", "--node-ids", "10.0.0.1,10.0.0.2", "--key-file", "/tmp/k.pem"],
+    )
+
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = module.main()
+    emitted: dict[str, Any] = json.loads(buf.getvalue())
+
+    assert rc == 0
+    assert emitted["domain"]["domain_id"]
+    assert emitted["domain"]["state"] == "up"
+    assert emitted["domain"]["expected_members"] == ["10.0.0.1", "10.0.0.2"]
+    assert emitted["domain"]["fully_connected"] is True
+    assert emitted["nodes_checked"] == 2
+    assert emitted["nodes_validated"] == 2
+    assert [n["node_id"] for n in emitted["nodes"]] == ["10.0.0.1", "10.0.0.2"]
+    for node in emitted["nodes"]:
+        assert node["service_state"] == "active"
+        assert node["domain_member"] is True
+        assert node["peers_reachable"]
+    # no leftovers from the old hand-rolled shape
+    assert "reachability" not in emitted
+    assert "members" not in emitted

--- a/isvtest/src/isvtest/validations/network.py
+++ b/isvtest/src/isvtest/validations/network.py
@@ -1259,6 +1259,136 @@ class NvlinkDomainCheck(BaseValidation):
         self.set_passed(f"NVLink domain for {node_id}: {nvlink_domain_id}")
 
 
+class ImexDomainConnectivityCheck(BaseValidation):
+    """Validate an IMEX domain is operational and every member pair is mutually connected.
+
+    Membership is taken from the nodes that declare ``domain_member``, and
+    pairwise connectivity is computed here from each node's own
+    ``peers_reachable`` list. The provider-reported ``domain.fully_connected``
+    boolean is deliberately ignored, so a one-way fault (node A observes B, but
+    B does not observe A) cannot pass just because the vendor claims the domain
+    is healthy.
+
+    The IMEX service state of each node is carried for diagnostics but not
+    asserted on - service lifecycle is out of scope for this check.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        domain: object with domain_id, state (operational when "up"),
+                expected_members (min 2), and the ignored fully_connected flag
+        nodes: list of {node_id, service_state, domain_member, peers_reachable}
+        nodes_checked / nodes_validated: counts carried for reporting
+    """
+
+    description: ClassVar[str] = "Check IMEX domain is operational and fully, mutually connected"
+
+    def run(self) -> None:
+        """Check IMEX domain state, membership, and pairwise connectivity."""
+        step_output = self.config.get("step_output", {})
+
+        domain = step_output.get("domain")
+        if not isinstance(domain, dict):
+            self.set_failed("`domain` must be an object with domain_id, state, and expected_members")
+            return
+
+        domain_id = domain.get("domain_id")
+        if not _is_non_empty_string(domain_id):
+            self.set_failed("`domain.domain_id` must be a non-empty string")
+            return
+
+        state = domain.get("state")
+        if not _is_non_empty_string(state) or state.strip().lower() != "up":
+            self.set_failed(f"IMEX domain {domain_id} state is {state!r}, expected an operational state ('up')")
+            return
+
+        expected_error = _validate_string_list(domain.get("expected_members"), "expected_members")
+        if expected_error is not None:
+            self.set_failed(expected_error.replace("`fabric.", "`domain."))
+            return
+        expected_members = domain["expected_members"]
+        if len(set(expected_members)) != len(expected_members):
+            self.set_failed(f"IMEX domain {domain_id} `domain.expected_members` contains duplicate node IDs")
+            return
+        if len(expected_members) < 2:
+            # A single-node connectivity matrix is trivially complete, so this
+            # would otherwise pass vacuously - fail naming the environment.
+            self.set_failed(
+                f"IMEX domain {domain_id} has only {len(expected_members)} expected member(s): this environment "
+                "is too small to validate a multi-node NVLink domain, which requires at least two members"
+            )
+            return
+
+        nodes = step_output.get("nodes")
+        if not isinstance(nodes, list):
+            self.set_failed("`nodes` must be a list of per-node domain reports")
+            return
+        for index, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                self.set_failed(f"`nodes[{index}]` must be an object")
+                return
+            if not _is_non_empty_string(node.get("node_id")):
+                self.set_failed(f"`nodes[{index}].node_id` must be a non-empty string")
+                return
+
+        reported = [node["node_id"] for node in nodes if node.get("domain_member") is True]
+        if len(set(reported)) != len(reported):
+            self.set_failed(f"IMEX domain {domain_id} reports duplicate node IDs among its members")
+            return
+
+        expected_set = set(expected_members)
+        reported_set = set(reported)
+        if expected_set != reported_set:
+            missing = sorted(expected_set - reported_set)
+            unexpected = sorted(reported_set - expected_set)
+            details = []
+            if missing:
+                details.append(f"missing: {missing}")
+            if unexpected:
+                # A node we were not allocated appearing in the domain is a
+                # tenancy finding, not just a bookkeeping mismatch.
+                details.append(f"unexpected (possible tenancy issue): {unexpected}")
+            self.set_failed(f"IMEX domain {domain_id} membership mismatch ({'; '.join(details)})")
+            return
+
+        peers_by_node: dict[str, list[str]] = {}
+        for node in nodes:
+            if node.get("domain_member") is not True:
+                continue
+            peers = node.get("peers_reachable")
+            if not isinstance(peers, list):
+                self.set_failed(f"`peers_reachable` for {node['node_id']} must be a list of peer node IDs")
+                return
+            peers_by_node[node["node_id"]] = peers
+
+        # Compute mutual connectivity per pair rather than trusting
+        # domain.fully_connected, so a one-way fault cannot pass.
+        members = sorted(reported_set)
+        faults: list[str] = []
+        for i, node_a in enumerate(members):
+            for node_b in members[i + 1 :]:
+                a_sees_b = node_b in peers_by_node[node_a]
+                b_sees_a = node_a in peers_by_node[node_b]
+                if a_sees_b and b_sees_a:
+                    continue
+                if a_sees_b or b_sees_a:
+                    one_way = f"{node_a}->{node_b}" if a_sees_b else f"{node_b}->{node_a}"
+                    faults.append(f"{node_a}<->{node_b}: one-way only ({one_way})")
+                else:
+                    faults.append(f"{node_a}<->{node_b}: no connectivity observed in either direction")
+
+        if faults:
+            self.set_failed(f"IMEX domain {domain_id} is not fully connected: {'; '.join(faults)}")
+            return
+
+        pair_count = len(members) * (len(members) - 1) // 2
+        self.set_passed(
+            f"IMEX domain {domain_id} is operational with {len(members)} member(s); "
+            f"all {pair_count} pair(s) mutually connected"
+        )
+
+
 class ByoipCheck(BaseValidation):
     """Validate Bring-Your-Own-IP (BYOIP) with non-conflicting custom CIDRs.
 

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -44,6 +44,7 @@ from isvtest.validations.network import (
     BackendSwitchFabricCheck,
     ByoipCheck,
     FloatingIpCheck,
+    ImexDomainConnectivityCheck,
     LocalizedDnsCheck,
     NvlinkDomainCheck,
     SgPolicyPropagationTimingCheck,
@@ -1733,6 +1734,226 @@ class TestNvlinkDomainCheck:
         result = v.execute()
         assert result["passed"] is False
         assert "nvlink_domain_id_present" in result["error"]
+
+
+def _imex_node(node_id: str, peers: list[str], *, member: bool = True, service_state: str = "active") -> dict[str, Any]:
+    """Build one per-node entry of the SDN21-01 step output contract."""
+    return {
+        "node_id": node_id,
+        "service_state": service_state,
+        "domain_member": member,
+        "peers_reachable": peers,
+    }
+
+
+def _imex_domain_output(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a step_output dict for IMEX domain connectivity tests (2 mutually-connected nodes).
+
+    Shape follows the SDN21-01 step output contract in the issue: a nested
+    ``domain`` object plus a ``nodes`` array of per-node reports.
+    """
+    step_output: dict[str, Any] = {
+        "success": True,
+        "platform": "network",
+        "domain": {
+            "domain_id": "imex-0",
+            "state": "up",
+            "expected_members": ["node-a", "node-b"],
+            # Deliberately true everywhere: the check must never rely on it.
+            "fully_connected": True,
+        },
+        "nodes_checked": 2,
+        "nodes_validated": 2,
+        "nodes": [_imex_node("node-a", ["node-b"]), _imex_node("node-b", ["node-a"])],
+    }
+    if extra:
+        domain_extra = extra.pop("domain", None)
+        if domain_extra is not None:
+            step_output["domain"].update(domain_extra)
+        step_output.update(extra)
+    return {"step_output": step_output}
+
+
+class TestImexDomainConnectivityCheck:
+    """Tests for ImexDomainConnectivityCheck validation (SDN21-01)."""
+
+    def test_all_passed(self) -> None:
+        """Two mutually-connected members with an operational domain passes."""
+        v = ImexDomainConnectivityCheck(config=_imex_domain_output())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "imex-0" in result["output"]
+
+    def test_missing_domain_object(self) -> None:
+        """Reject output without the contract's `domain` object."""
+        config = _imex_domain_output()
+        del config["step_output"]["domain"]
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "`domain`" in result["error"]
+
+    def test_domain_not_operational(self) -> None:
+        """Reject a domain state other than operational."""
+        config = _imex_domain_output({"domain": {"state": "down"}})
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "down" in result["error"]
+
+    def test_state_matched_case_insensitively(self) -> None:
+        """Providers may normalize state casing differently; 'UP' is still operational."""
+        config = _imex_domain_output({"domain": {"state": "UP"}})
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is True
+
+    def test_single_node_auto_fails_naming_environment(self) -> None:
+        """A single expected member fails with a message naming the environment as
+        too small - a 1-node connectivity matrix is trivially complete and would
+        otherwise pass vacuously."""
+        config = _imex_domain_output(
+            {
+                "domain": {"expected_members": ["node-a"]},
+                "nodes": [_imex_node("node-a", [])],
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "too small" in result["error"]
+        assert "at least two" in result["error"]
+
+    def test_missing_member_fails(self) -> None:
+        """An expected member that never reports membership fails."""
+        config = _imex_domain_output({"nodes": [_imex_node("node-a", []), _imex_node("node-b", [], member=False)]})
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "missing" in result["error"]
+
+    def test_unexpected_member_flagged_as_tenancy_finding(self) -> None:
+        """A node we were not allocated appearing in the domain is a tenancy finding."""
+        config = _imex_domain_output(
+            {
+                "nodes": [
+                    _imex_node("node-a", ["node-b", "node-c"]),
+                    _imex_node("node-b", ["node-a", "node-c"]),
+                    _imex_node("node-c", ["node-a", "node-b"]),
+                ]
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "unexpected" in result["error"]
+        assert "tenancy" in result["error"]
+        assert "node-c" in result["error"]
+
+    def test_skipped_payload_skips_instead_of_failing(self) -> None:
+        """An unconfigured run emits skipped=true. BaseValidation.execute() must
+        short-circuit to a pytest skip before run() inspects the payload, so
+        wiring this check into the network suite cannot fail a run that simply
+        has no IMEX cluster to point at."""
+        config = _imex_domain_output(
+            {
+                "skipped": True,
+                "skip_reason": "IMEX domain not configured for this run (no node IDs or SSH key set)",
+                "domain": {"domain_id": "", "state": "", "expected_members": []},
+                "nodes": [],
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        with pytest.raises(pytest.skip.Exception, match="not configured"):
+            v.execute()
+
+    def test_duplicate_expected_members_rejected(self) -> None:
+        """A duplicate expected_members entry must not let a single real member
+        satisfy the multi-node minimum via set-collapsing: len(["node-a",
+        "node-a"]) >= 2 while the set has one element, so a 1-node domain could
+        otherwise pass as a valid 2-node one."""
+        config = _imex_domain_output(
+            {
+                "domain": {"expected_members": ["node-a", "node-a"]},
+                "nodes": [_imex_node("node-a", [])],
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "duplicate" in result["error"]
+
+    def test_duplicate_reported_members_rejected(self) -> None:
+        """Duplicate node IDs among reporting members must not collapse into the expected set."""
+        config = _imex_domain_output({"nodes": [_imex_node("node-a", ["node-b"]), _imex_node("node-a", ["node-b"])]})
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "duplicate" in result["error"]
+
+    def test_one_way_connectivity_fault_detected(self) -> None:
+        """A node reporting a peer that does not report it back must fail, even
+        though domain.fully_connected claims the domain is healthy."""
+        config = _imex_domain_output({"nodes": [_imex_node("node-a", ["node-b"]), _imex_node("node-b", [])]})
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "one-way only" in result["error"]
+
+    def test_fully_connected_flag_is_not_trusted(self) -> None:
+        """fully_connected=true must not rescue a domain with no real connectivity."""
+        config = _imex_domain_output(
+            {
+                "domain": {"fully_connected": True},
+                "nodes": [_imex_node("node-a", []), _imex_node("node-b", [])],
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "no connectivity observed" in result["error"]
+
+    def test_missing_peers_reachable_fails(self) -> None:
+        """A member without a peers_reachable list must fail explicitly."""
+        node_b = _imex_node("node-b", [])
+        del node_b["peers_reachable"]
+        config = _imex_domain_output({"nodes": [_imex_node("node-a", ["node-b"]), node_b]})
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "peers_reachable" in result["error"]
+
+    def test_service_state_is_not_asserted_on(self) -> None:
+        """Service lifecycle is out of scope: a member reporting an unusual
+        service_state still passes as long as membership and connectivity hold."""
+        config = _imex_domain_output(
+            {
+                "nodes": [
+                    _imex_node("node-a", ["node-b"], service_state="degraded"),
+                    _imex_node("node-b", ["node-a"], service_state="active"),
+                ]
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is True
+
+    def test_three_node_domain_all_pairs_checked(self) -> None:
+        """A 3-node fully connected domain verifies all 3 pairs."""
+        config = _imex_domain_output(
+            {
+                "domain": {"expected_members": ["node-a", "node-b", "node-c"]},
+                "nodes": [
+                    _imex_node("node-a", ["node-b", "node-c"]),
+                    _imex_node("node-b", ["node-a", "node-c"]),
+                    _imex_node("node-c", ["node-a", "node-b"]),
+                ],
+            }
+        )
+        v = ImexDomainConnectivityCheck(config=config)
+        result = v.execute()
+        assert result["passed"] is True
+        assert "3 pair" in result["output"]
 
 
 class TestValidationResultCapture:


### PR DESCRIPTION
## Summary

Implements **SDN21-01** (#602): asserts a multi-node IMEX domain is operational and every member pair is *mutually* connected.

The point of the requirement is that the check must **not** trust a provider-reported `fully_connected` flag. It recomputes connectivity per pair from each node's own `peers_reachable`, so a one-way fault fails even when the vendor reports the domain healthy. Membership comes from nodes declaring `domain_member`; unexpected members are flagged as a possible tenancy issue. `service_state` is reported but not asserted on (service lifecycle is out of scope).

Step output follows the contract in the issue (nested `domain` + `nodes[]`), registered as the `imex_domain` schema. All vendor-output parsing happens in the provider script; the validation sees only normalized JSON.

Providers: `my-isv` template/demo stub, `aws` real SSH-based reference querying `nvidia-imex-ctl -N -j -H`. NICo is a documented gap (its API has no live host telemetry) rather than a stub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IMEX domain connectivity validation to network test suites.
  * Checks domain membership, operational state, peer reachability, and bidirectional connectivity.
  * Added AWS SSH-based validation with configurable nodes and key files.
  * Added provider-specific reporting for node status, connectivity, errors, and skipped checks.
  * Added demo-mode support for the my-isv provider.
* **Documentation**
  * Updated test-plan metadata to classify the check under minimum requirements and network validation.
  * Documented that NICo does not perform live IMEX domain validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->