### PR TITLE
docs(requirements): classify test actors and reconcile Kubernetes requirements

### DIFF
--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -105,7 +105,29 @@ ID must change, we keep the previous ID in a list in the `test-plan.yaml` file
 in a field called `legacy_ids`. This list should only be appended to, never
 removed from.
 
-## 4. Labels & selective runs
+## 4. Actor scope
+
+Every test in `test-plan.yaml` must declare exactly one `actor` value describing
+who uses the capability under test:
+
+- `tenant`: a renter/customer operation through a tenant-facing API or from
+  within allocated compute, network, storage, Kubernetes, or Slurm resources.
+- `operator`: a cloud/provider operation against the management plane, fleet,
+  physical infrastructure, BMC, fabric, sanitization, or provider maintenance
+  systems.
+- `both`: a cross-role operation, such as a tenant request that the provider
+  executes and the tenant subsequently verifies.
+- `provider-dependent`: the provider-neutral contract does not determine which
+  party performs the operation. Use this sparingly and clarify the boundary when
+  a real provider implementation is added.
+
+Actor scope describes the user of the capability, not merely the credentials
+held by the validation harness. For example, a runner may need broad AWS account
+permissions while testing a tenant-facing VPC operation. Provider overlays may
+record more specific execution roles, but they must not change the canonical
+actor without reconciling the test plan.
+
+## 5. Labels & selective runs
 
 The end goal is to run **subsets** of tests - an arbitrary tag, or *every test
 belonging to a given requirements document*. We keep the data flexible for this:
@@ -120,7 +142,7 @@ belonging to a given requirements document*. We keep the data flexible for this:
   convenience labels (e.g. a generated `doc:offtake` tag) may be produced later
   from the index, but the index stays the source of truth.
 
-## 5. Onboarding a new requirements document (runbook)
+## 6. Onboarding a new requirements document (runbook)
 
 When a new team's requirements document is blessed, reconcile it here:
 
@@ -137,7 +159,8 @@ When a new team's requirements document is blessed, reconcile it here:
 
 > Kept as a subsection for now; promote to its own `ONBOARDING.md` if it grows.
 
-## 6. Validation & enforcement
+## 7. Validation & enforcement
 
 `reqtrace validate` (run via `make reqcheck`, and in CI through
-`scripts/tests/test_reqtrace.py`) is the machine-checked guard.
+`scripts/tests/test_reqtrace.py`) is the machine-checked guard. It also requires
+every canonical test to declare one of the actor values in section 4.

--- a/docs/requirements/offtake-requirements.md
+++ b/docs/requirements/offtake-requirements.md
@@ -69,7 +69,7 @@
 | K8S05 | Lifecycle Management - control plane | API/CLI/Terraform Provider for CRUD provisioning; <30 min control plane bring-up. | #2, #5, #6 | active |
 | K8S06 | Lifecycle Management - node pool | API/CLI/Terraform for CRUD provisioning ( e.g., create node pool, update node pool, delete node pool, scale a node pool to a target count). Must be able to specify node type (specific CPU or GPU instance type) including CPU-only node pools with high-performance networking for data movement and ingest workloads Ability to specify default node labels and node taints within a node pool when a node joins the cluster. When down-scaling a node pool, ability to down-scale bad/specific nodes. | add | active |
 | K8S07 | API Server Metrics | Share API Server metrics in a Prometheus scrapable format to allow NVIDIA to measure API Server SLO |  | active |
-| K8S08 | Versioning | Provider-managed control plane upgrade processes. | INFO | active |
+| K8S08 | Versioning | The platform operator shall own and execute provider-managed control plane upgrade processes, including routine maintenance and security updates. The operator shall define the supported upgrade policy and transitions, expose upgrade status, and notify affected tenants. This requirement concerns operator-driven maintenance; it does not cover a tenant requesting a control plane version update through the tenant-facing service API. | INFO | active |
 | K8S09 | Zero-Downtime Upgrades | Minor version control plane updates without app downtime or maintenance windows. | INFO | active |
 | K8S10 | Node Upgrades | user-initiated rolling updates respecting pod disruption budgets. | TBD | active |
 | K8S11 | HA Control Plane | Redundant architecture with etcd separation. | INFO | active |

--- a/docs/requirements/offtake-requirements.yaml
+++ b/docs/requirements/offtake-requirements.yaml
@@ -205,7 +205,7 @@ requirements:
     subsection: Kubernetes Operational Excellence
     area: Versioning
     test_details: INFO
-    description: Provider-managed control plane upgrade processes.
+    description: The platform operator shall own and execute provider-managed control plane upgrade processes, including routine maintenance and security updates. The operator shall define the supported upgrade policy and transitions, expose upgrade status, and notify affected tenants. This requirement concerns operator-driven maintenance; it does not cover a tenant requesting a control plane version update through the tenant-facing service API.
   - req_id: K8S09
     section: Kubernetes As a Service (KaaS) Requirements
     subsection: Kubernetes Operational Excellence

--- a/docs/requirements/software-reference-requirements.md
+++ b/docs/requirements/software-reference-requirements.md
@@ -240,7 +240,7 @@ This document lists requirements derived from the *NCP Software Reference Guide*
 
 | Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
 | :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
-| K8S38 | Managed Kubernetes Control Plane | Run through all the steps of the k8s lifecycle management, including user-initated CP update | NSRG: Container-as-a-Service: Kubernetes | `K8S38-01` |  |
+| K8S38 | Managed Kubernetes Control Plane | A tenant shall be able to exercise the complete managed Kubernetes control plane lifecycle through the tenant-facing API/CLI. The tenant initiates create, read, update, and delete operations, including requesting a supported control plane version update; the platform operator executes the managed operation and exposes status until the requested version and terminal state are reached. Application continuity during the update is covered separately by K8S09. | NSRG: Container-as-a-Service: Kubernetes | `K8S38-01` |  |
 | K8S39 | Managed Kubernetes Control Plane | Be able to run k8s workloads | NSRG: Container-as-a-Service: Kubernetes | `K8S39-01` |  |
 | K8S40 | Managed Kubernetes Control Plane | K8s Nim Inference | NSRG: K8s-Native ML/AI Frameworks (Dynamo/NIM) | `K8S40-01` |  |
 | K8S32 | Managed Kubernetes Control Plane | K8s Nim Helm | NSRG: K8s-Native ML/AI Frameworks | `K8S32-01` |  |
@@ -248,7 +248,6 @@ This document lists requirements derived from the *NCP Software Reference Guide*
 | K8S34 | Managed Kubernetes Control Plane | validate adherence to upstream proxy requirements (service to pod load balancing, acces to internal services) | NSRG: Container-as-a-Service: Kubernetes | `K8S34-01` |  |
 | K8S35 | Managed Kubernetes Control Plane | Verify that pod-to-pod L3 traffic flow logs are available and queryable | NSRG: Container-as-a-Service: Kubernetes / Telemetry | `K8S35-01` |  |
 | K8S36 | Managed Kubernetes Control Plane | Verify Cluster Autoscaler integration (upstream) | NSRG: Container-as-a-Service: Kubernetes (autoscaling/Karpenter) | `K8S36-01` |  |
-| K8S37 | Managed Kubernetes Control Plane | Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size | NSRG: Container-as-a-Service: Kubernetes | `K8S37-01` |  |
 | K8S41 | Managed Kubernetes Control Plane | The control plane should automatically add more capacity when load increases (control-plane autoscaling) | NSRG: Container-as-a-Service: Kubernetes (autoscaling) | `K8S41-01` |  |
 
 ### Power Policy Management

--- a/docs/requirements/software-reference-requirements.yaml
+++ b/docs/requirements/software-reference-requirements.yaml
@@ -705,7 +705,7 @@ requirements:
   - req_id: K8S38
     domain: Workload Orchestration
     component: Managed Kubernetes Control Plane
-    description: Run through all the steps of the k8s lifecycle management, including user-initated CP update
+    description: A tenant shall be able to exercise the complete managed Kubernetes control plane lifecycle through the tenant-facing API/CLI. The tenant initiates create, read, update, and delete operations, including requesting a supported control plane version update; the platform operator executes the managed operation and exposes status until the requested version and terminal state are reached. Application continuity during the update is covered separately by K8S09.
     reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes'
     covers_test: K8S38-01
     status: ''
@@ -757,13 +757,6 @@ requirements:
     description: Verify Cluster Autoscaler integration (upstream)
     reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes (autoscaling/Karpenter)'
     covers_test: K8S36-01
-    status: ''
-  - req_id: K8S37
-    domain: Workload Orchestration
-    component: Managed Kubernetes Control Plane
-    description: Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size
-    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes'
-    covers_test: K8S37-01
     status: ''
   - req_id: K8S41
     domain: Workload Orchestration

--- a/docs/requirements/test-requirements-matrix.adoc
+++ b/docs/requirements/test-requirements-matrix.adoc
@@ -2454,7 +2454,7 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | [[K8S05-01]]K8S05-01
 | Workload Orchestration
 | Managed Kubernetes Control Plane
-| Create a K8s Instance using the software platform (CLI, Terraform)
+| Create a K8s Instance using the software platform API/CLI
 | K8S05
 | offtake
 | full
@@ -2463,7 +2463,7 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | [[K8S38-01]]K8S38-01
 | Workload Orchestration
 | Managed Kubernetes Control Plane
-| Run through all the steps of the k8s lifecycle management, including user-initated CP update
+| As a tenant, exercise the complete managed Kubernetes control plane lifecycle through the tenant-facing API/CLI, including requesting a supported control plane version update and observing provider-reported status through completion.
 | K8S38
 | reference
 | full
@@ -2838,14 +2838,14 @@ docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
 | full
 |
 
-| [[K8S37-01]]K8S37-01
+| [[K8S28-01]]K8S28-01
 | Workload Orchestration
 | Managed Kubernetes Control Plane
-| Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size
-| K8S37
-| reference
+| Verify the managed Kubernetes service meets standard Kubernetes performance and control plane SLO targets at up to 5,000 nodes or the provider's declared maximum cluster size, whichever is smaller
+| K8S28
+| offtake
 | full
-|
+| Legacy test IDs: K8S-XX-09, K8S37-01.
 
 | [[K8S26-01]]K8S26-01
 | Workload Orchestration

--- a/docs/requirements/test-requirements-matrix.yaml
+++ b/docs/requirements/test-requirements-matrix.yaml
@@ -2058,13 +2058,13 @@ mappings:
         coverage: full
     annotations: ''
     notes: ''
-  - test_id: K8S37-01
+  - test_id: K8S28-01
     requirements:
-      - req_id: K8S37
-        source: reference
+      - req_id: K8S28
+        source: offtake
         coverage: full
-    annotations: ''
-    notes: ''
+    annotations: 'Former reference requirement K8S37 was consolidated into the canonical offtake K8S28 requirement.'
+    notes: 'Legacy test IDs: K8S-XX-09, K8S37-01.'
   - test_id: K8S26-01
     requirements:
       - req_id: K8S26

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -7,9 +7,9 @@ Run `make plan` to regenerate.
 :toc:
 :max-width: none
 
-[cols="2,2,5,2,2,1,1,1,1,1,3,1,1,1,6,1,4",options="header"]
+[cols="2,2,5,2,2,1,1,1,1,1,1,3,1,1,1,6,1,4",options="header"]
 |===
-| Test Domain | Function | Description | Example | Test ID | Req ID | GH | Labels | Notes | Priority | Issues | Dependencies | Milestone | Release | Test Cases | Status | Justification
+| Test Domain | Function | Description | Example | Test ID | Req ID | GH | Labels | Actor | Notes | Priority | Issues | Dependencies | Milestone | Release | Test Cases | Status | Justification
 
 .20+| Foundational Services
 .10+| Image Registry
@@ -19,6 +19,7 @@ Run `make plan` to regenerate.
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/37[#37]
 | image_registry, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/37[#37] +
@@ -34,6 +35,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/38[#38]
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/39[#39]
 | image_registry
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/39[#39]
@@ -48,6 +50,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/39[#39]
 | BOOT03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/40[#40]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/40[#40]
@@ -62,6 +65,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/40[#40]
 | BOOT03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/104[#104]
 | image_registry, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/104[#104]
@@ -76,6 +80,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/104[#104]
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/41[#41]
 | bare_metal, image_registry, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/41[#41]
@@ -90,6 +95,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/41[#41]
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/43[#43]
 | image_registry, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/43[#43]
@@ -104,6 +110,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/43[#43]
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/44[#44]
 | image_registry, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/44[#44]
@@ -118,6 +125,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/44[#44]
 | IMG01
 |
 |
+| tenant
 |
 | P1
 a|
@@ -132,6 +140,7 @@ a|
 | IMG02
 |
 |
+| tenant
 |
 | P1
 a|
@@ -146,6 +155,7 @@ a|
 | IMG03
 |
 |
+| tenant
 |
 | P1
 a|
@@ -163,6 +173,7 @@ a|
 | AUTH01
 |
 |
+| tenant
 |
 | P1
 a|
@@ -177,6 +188,7 @@ a|
 | AUTH02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
 | vm
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
@@ -191,6 +203,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
 | AUTH03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/248[#248]
 | bare_metal, iam, security, vm
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/248[#248]
@@ -208,6 +221,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/248[#248]
 | IAM01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
 | iam, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
@@ -222,6 +236,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
 | IAM02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/23[#23]
 | iam
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/23[#23]
@@ -236,6 +251,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/23[#23]
 | IAM03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
 | iam
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
@@ -253,6 +269,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
 | IPAM01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
 | network, ssh
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
@@ -267,6 +284,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
 | IPAM02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
 | network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
@@ -284,6 +302,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
 | NETMGMT01
 |
 |
+| operator
 |
 | P0
 a|
@@ -301,6 +320,7 @@ a|
 | RESDB01
 |
 |
+| operator
 |
 | P1
 a|
@@ -319,6 +339,7 @@ a|
 | CP03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/26[#26]
 | control_plane, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/26[#26] +
@@ -334,6 +355,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/27[#27]
 | CP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/261[#261]
 |
+| operator
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/261[#261]
@@ -348,6 +370,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/261[#261]
 | CP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
 | control_plane, iam
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
@@ -362,6 +385,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
 | CP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
 | control_plane, iam, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
@@ -376,6 +400,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
 | CP07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
 | control_plane, iam
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
@@ -390,6 +415,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
 | CP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
 | control_plane, iam
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
@@ -404,6 +430,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
 | CP09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/32[#32]
 | control_plane, iam
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/32[#32] +
@@ -419,6 +446,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/33[#33]
 | CP10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
 | control_plane
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
@@ -433,6 +461,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
 | CP11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/35[#35]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/35[#35]
@@ -450,6 +479,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/35[#35]
 | HWING01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
 | bare_metal, ingestion
+| operator
 |
 | P1 (check w/ ISVs)
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
@@ -464,6 +494,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
 | HWING02
 |
 |
+| operator
 |
 | P1
 a|
@@ -481,6 +512,7 @@ a|
 | SEC22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/315[#315]
 | attestation, bare_metal, security
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/315[#315]
@@ -495,6 +527,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/315[#315]
 | ATTEST01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/243[#243]
 |
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/243[#243]
@@ -509,6 +542,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/243[#243]
 | SEC22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/316[#316]
 |
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/316[#316]
@@ -523,6 +557,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/316[#316]
 | ATTEST02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/319[#319]
 |
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/319[#319] +
@@ -538,6 +573,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/246[#246]
 | CNP09
 |
 | min_req
+| operator
 |
 | P1
 a|
@@ -552,6 +588,7 @@ a|
 | CNP09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/259[#259]
 | attestation, bare_metal, firmware, min_req, security
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/259[#259]
@@ -566,6 +603,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/259[#259]
 | SEC22
 |
 |
+| operator
 | REVIEW
 | P0
 a|
@@ -583,6 +621,7 @@ a|
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/49[#49]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/49[#49]
@@ -597,6 +636,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/49[#49]
 | CNP01, CNP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/51[#51]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/51[#51] +
@@ -612,6 +652,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/52[#52]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/53[#53]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/53[#53]
@@ -626,6 +667,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/53[#53]
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/54[#54]
 | bare_metal, min_req, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/54[#54] +
@@ -641,6 +683,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/134[#134]
 | bare_metal, disk, min_req, sanitization, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/134[#134]
@@ -655,6 +698,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/134[#134]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/105[#105]
 | bare_metal, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/105[#105]
@@ -669,6 +713,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/105[#105]
 | BMAAS01
 |
 |
+| tenant
 | REVIEW
 | P2
 a|
@@ -683,6 +728,7 @@ a|
 | BMAAS02
 |
 |
+| tenant
 | REVIEW
 | P2
 a|
@@ -699,6 +745,7 @@ a|
 | BMAAS03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/48[#48]
 | bare_metal, ssh
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/48[#48] +
@@ -714,6 +761,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/56[#56]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/50[#50]
 | bare_metal, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/50[#50] +
@@ -729,6 +777,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/57[#57]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/135[#135]
 | bare_metal, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/135[#135]
@@ -743,6 +792,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/135[#135]
 | BMAAS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/58[#58]
 |
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/58[#58] +
@@ -758,6 +808,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/69[#69]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/106[#106]
 | bare_metal, min_req
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/106[#106]
@@ -772,6 +823,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/106[#106]
 | BOOT02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/107[#107]
 | bare_metal, min_req, ssh
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/107[#107] +
@@ -787,6 +839,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/108[#108]
 | bare_metal, min_req
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/108[#108]
@@ -801,6 +854,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/108[#108]
 | CNP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
 | bare_metal, min_req
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112] +
@@ -818,6 +872,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/181[#181]
 | BMAAS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
 | bare_metal, dpu
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
@@ -832,6 +887,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
 | BMAAS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
 | bare_metal, gpu, network, ssh
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
@@ -848,6 +904,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
 | BMAAS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
 | bare_metal
+| tenant
 | REVIEW
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
@@ -862,6 +919,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
 | CNP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/109[#109]
 | bare_metal, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/109[#109] +
@@ -877,6 +935,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
 | BMAAS08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
 | bare_metal, gpu, ssh
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
@@ -891,6 +950,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
 | BMAAS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/63[#63]
 | bare_metal, gpu, min_req, ssh, workload
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/63[#63] +
@@ -906,6 +966,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/68[#68]
 | BMAAS10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/64[#64]
 | bare_metal, gpu, min_req, slow, ssh, workload
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/64[#64] +
@@ -921,6 +982,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/82[#82]
 | BMAAS11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
 | bare_metal, gpu, min_req, ssh, workload
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
@@ -935,6 +997,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
 | BMAAS12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
 | bare_metal, gpu, min_req, ssh, workload
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
@@ -949,6 +1012,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
 | CNP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/258[#258]
 | bare_metal, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/258[#258]
@@ -965,6 +1029,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/258[#258]
 | CNP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/197[#197]
 | bare_metal, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/197[#197] +
@@ -981,6 +1046,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/185[#185]
 | CNP08
 |
 | bare_metal, min_req
+| provider-dependent
 |
 | P0
 a|
@@ -998,6 +1064,7 @@ a|
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/42[#42]
 | min_req, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/42[#42]
@@ -1012,6 +1079,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/42[#42]
 | CNP01, CNP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/51[#51]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/51[#51]
@@ -1026,6 +1094,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/51[#51]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/45[#45]
 | min_req, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/45[#45]
@@ -1040,6 +1109,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/45[#45]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/46[#46]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/46[#46]
@@ -1054,6 +1124,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/46[#46]
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
@@ -1070,6 +1141,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
 | VMAAS01
 |
 | ssh, vm
+| tenant
 |
 | P0
 a|
@@ -1084,6 +1156,7 @@ a|
 | CNP01
 |
 | vm
+| tenant
 |
 | P0
 a|
@@ -1098,6 +1171,7 @@ a|
 | VMAAS02
 |
 |
+| tenant
 |
 | P0
 a|
@@ -1112,6 +1186,7 @@ a|
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/110[#110]
 | min_req, vm
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/110[#110]
@@ -1126,6 +1201,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/110[#110]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/111[#111]
 | min_req, vm
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/111[#111]
@@ -1140,6 +1216,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/111[#111]
 | CNP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
 | min_req, vm
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
@@ -1154,6 +1231,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
 | BOOT02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
 | min_req, ssh, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
@@ -1170,6 +1248,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
 | VMAAS03
 |
 |
+| tenant
 |
 | P2
 a|
@@ -1184,6 +1263,7 @@ a|
 | VMAAS04
 |
 |
+| tenant
 |
 | P2
 a|
@@ -1200,6 +1280,7 @@ a|
 | VMAAS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
 | ssh, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
@@ -1214,6 +1295,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
 | VMAAS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
 | gpu, ssh, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
@@ -1228,6 +1310,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
 | VMAAS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
 | gpu, ssh, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
@@ -1242,6 +1325,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
 | VMAAS08
 |
 |
+| tenant
 |
 | P0
 a|
@@ -1256,6 +1340,7 @@ a|
 | VMAAS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
 | gpu, ssh, vm
+| tenant
 | Does this include GPU Passthrough
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
@@ -1270,6 +1355,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
 | VMAAS10
 |
 |
+| tenant
 |
 | P1
 a|
@@ -1286,6 +1372,7 @@ a|
 | VMAAS11
 |
 |
+| tenant
 |
 | P0
 a|
@@ -1300,6 +1387,7 @@ a|
 | VMAAS12
 |
 | gpu, slow, ssh, vm, workload
+| tenant
 |
 | P0
 a|
@@ -1314,6 +1402,7 @@ a|
 | VMAAS13
 |
 |
+| tenant
 |
 | P0
 a|
@@ -1330,6 +1419,7 @@ a|
 | VMAAS14
 |
 |
+| tenant
 |
 | P0
 a|
@@ -1346,6 +1436,7 @@ a|
 | CNP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
 | min_req, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
@@ -1362,6 +1453,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
 | CNP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/198[#198]
 | min_req, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/198[#198]
@@ -1376,6 +1468,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/198[#198]
 | CNP08
 |
 | min_req
+| provider-dependent
 |
 | P0
 a|
@@ -1392,6 +1485,7 @@ a|
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/256[#256]
 | iam, min_req, security, vm
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/256[#256]
@@ -1406,6 +1500,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/256[#256]
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/257[#257]
 | min_req, security, vm
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/257[#257]
@@ -1423,6 +1518,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/257[#257]
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/11[#11]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/11[#11]
@@ -1437,6 +1533,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/11[#11]
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/12[#12]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/12[#12]
@@ -1451,6 +1548,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/12[#12]
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/13[#13]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/13[#13]
@@ -1465,6 +1563,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/13[#13]
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/14[#14]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/14[#14]
@@ -1479,6 +1578,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/14[#14]
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/16[#16]
 |
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/16[#16]
@@ -1493,6 +1593,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/16[#16]
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/17[#17]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/17[#17] +
@@ -1508,6 +1609,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/18[#18]
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/18[#18]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/18[#18]
@@ -1522,6 +1624,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/18[#18]
 | NET03, SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
@@ -1536,6 +1639,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
 | SDN11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
@@ -1550,6 +1654,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
 | SDN05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/117[#117]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/117[#117]
@@ -1564,6 +1669,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/117[#117]
 | SDN06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/118[#118]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/118[#118]
@@ -1578,6 +1684,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/118[#118]
 | SDN07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/119[#119]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/119[#119]
@@ -1592,6 +1699,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/119[#119]
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/199[#199]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/199[#199] +
@@ -1608,6 +1716,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/178[#178]
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/200[#200]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/200[#200]
@@ -1622,6 +1731,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/200[#200]
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/201[#201]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/201[#201]
@@ -1636,6 +1746,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/201[#201]
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/202[#202]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/202[#202]
@@ -1650,6 +1761,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/202[#202]
 | CNP03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/19[#19]
 |
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/19[#19]
@@ -1664,6 +1776,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/19[#19]
 | SDN12
 |
 |
+| tenant
 |
 |
 a|
@@ -1678,6 +1791,7 @@ a|
 | SDN13
 |
 |
+| tenant
 |
 |
 a|
@@ -1692,6 +1806,7 @@ a|
 | SDN14
 |
 |
+| tenant
 |
 |
 a|
@@ -1706,6 +1821,7 @@ a|
 | SDN15
 |
 |
+| tenant
 |
 |
 a|
@@ -1720,6 +1836,7 @@ a|
 | SDN16
 |
 |
+| tenant
 |
 |
 a|
@@ -1734,6 +1851,7 @@ a|
 | SDN17
 |
 |
+| tenant
 |
 |
 a|
@@ -1748,6 +1866,7 @@ a|
 | SDN18
 |
 |
+| tenant
 |
 |
 a|
@@ -1762,6 +1881,7 @@ a|
 | SDN19
 |
 |
+| tenant
 |
 |
 a|
@@ -1776,6 +1896,7 @@ a|
 | SDN20
 |
 |
+| tenant
 |
 |
 a|
@@ -1790,6 +1911,7 @@ a|
 | SDN21
 |
 |
+| tenant
 |
 |
 a|
@@ -1804,6 +1926,7 @@ a|
 | SDN22
 |
 |
+| tenant
 |
 |
 a|
@@ -1818,6 +1941,7 @@ a|
 | SDN23
 |
 |
+| tenant
 |
 |
 a|
@@ -1832,6 +1956,7 @@ a|
 | SDN24
 |
 |
+| tenant
 |
 |
 a|
@@ -1846,6 +1971,7 @@ a|
 | SDN25
 |
 |
+| tenant
 |
 |
 a|
@@ -1860,6 +1986,7 @@ a|
 | SDN26
 |
 |
+| tenant
 |
 |
 a|
@@ -1874,6 +2001,7 @@ a|
 | SDN27
 |
 |
+| tenant
 |
 |
 a|
@@ -1888,6 +2016,7 @@ a|
 | SDN28
 |
 |
+| provider-dependent
 | REVIEW
 |
 a|
@@ -1904,6 +2033,7 @@ a|
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/281[#281]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/281[#281]
@@ -1918,6 +2048,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/281[#281]
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/282[#282]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/282[#282]
@@ -1932,6 +2063,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/282[#282]
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/283[#283]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/283[#283]
@@ -1946,6 +2078,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/283[#283]
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/284[#284]
 | min_req, network, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/284[#284]
@@ -1960,6 +2093,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/284[#284]
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/285[#285]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/285[#285]
@@ -1976,6 +2110,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/285[#285]
 | SDN08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/289[#289]
 | min_req, network
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/289[#289]
@@ -1992,6 +2127,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/289[#289]
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/286[#286]
 | min_req, network, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/286[#286]
@@ -2008,6 +2144,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/286[#286]
 | SDN09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/290[#290]
 | min_req, network
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/290[#290]
@@ -2022,6 +2159,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/290[#290]
 | SDN09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/291[#291]
 | min_req, network
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/291[#291]
@@ -2036,6 +2174,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/291[#291]
 | SDN09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/292[#292]
 | min_req, network, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/292[#292]
@@ -2053,6 +2192,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/292[#292]
 | META01
 |
 |
+| provider-dependent
 |
 | P1
 a|
@@ -2070,6 +2210,7 @@ a|
 | CTRL01
 |
 |
+| tenant
 |
 | P0
 a|
@@ -2084,6 +2225,7 @@ a|
 | CAP02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/203[#203]
 | bare_metal, governance, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/203[#203]
@@ -2098,6 +2240,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/203[#203]
 | CAP03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/204[#204]
 | bare_metal, governance, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/204[#204]
@@ -2114,6 +2257,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/204[#204]
 | CNP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/205[#205]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/205[#205]
@@ -2131,6 +2275,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/205[#205]
 | LB01
 |
 |
+| tenant
 |
 | P2
 a|
@@ -2145,6 +2290,7 @@ a|
 | LB02
 |
 |
+| tenant
 |
 |
 a|
@@ -2159,6 +2305,7 @@ a|
 | LB03
 |
 |
+| tenant
 |
 |
 a|
@@ -2173,6 +2320,7 @@ a|
 | LB04
 |
 |
+| tenant
 |
 |
 a|
@@ -2190,6 +2338,7 @@ a|
 | BFX04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/555[#555]
 | bare_metal, breakfix
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/555[#555]
@@ -2204,6 +2353,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/555[#555]
 | BFX05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/556[#556]
 | bare_metal, breakfix
+| tenant
 |
 |
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/556[#556]
@@ -2218,6 +2368,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/556[#556]
 | BFX06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/557[#557]
 | bare_metal, breakfix
+| tenant
 |
 |
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/557[#557]
@@ -2234,6 +2385,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/557[#557]
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
 | breakfix, kubernetes, min_req
+| both
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
@@ -2248,6 +2400,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/206[#206]
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
 | bare_metal, breakfix, min_req
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
@@ -2262,6 +2415,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/207[#207]
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
 | bare_metal, breakfix, min_req
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
@@ -2276,6 +2430,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/208[#208]
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
 | breakfix, kubernetes, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
@@ -2290,6 +2445,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/209[#209]
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
 | bare_metal, breakfix, min_req
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
@@ -2304,6 +2460,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/210[#210]
 | BFX01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/610[#610]
 | bare_metal, breakfix, min_req
+| both
 | The non-destructive counterpart to BFX01-02 - the tenant keeps the node and its workload while flagging that it needs repair eventually. Return relinquishes the node; report does not.
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/610[#610]
@@ -2320,6 +2477,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/610[#610]
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
 | bare_metal, breakfix, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
@@ -2334,6 +2492,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/211[#211]
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
 | bare_metal, breakfix, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
@@ -2348,6 +2507,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/212[#212]
 | BFX02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
 | bare_metal, breakfix, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
@@ -2364,6 +2524,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/213[#213]
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
 | bare_metal, breakfix, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
@@ -2378,6 +2539,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/320[#320]
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
 | bare_metal, breakfix, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
@@ -2392,6 +2554,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/214[#214]
 | BFX03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]
 | bare_metal, breakfix, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]
@@ -2410,6 +2573,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/215[#215]
 | HSS01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/327[#327]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/327[#327]
@@ -2424,6 +2588,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/327[#327]
 | HSS01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/505[#505]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/505[#505]
@@ -2438,6 +2603,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/505[#505]
 | HSS01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/506[#506]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/506[#506]
@@ -2452,6 +2618,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/506[#506]
 | HSS02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/328[#328]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/328[#328]
@@ -2466,6 +2633,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/328[#328]
 | HSS03, K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/329[#329]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/329[#329]
@@ -2480,6 +2648,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/329[#329]
 | HSS03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/486[#486]
 | storage
+| tenant
 | Implemented in #523 (K8sCsiDriverHealthCheck).
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/486[#486]
@@ -2494,6 +2663,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/486[#486]
 | HSS03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/487[#487]
 | storage
+| tenant
 | Implemented in #523 (K8sCsiDriverHealthCheck).
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/487[#487]
@@ -2508,6 +2678,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/487[#487]
 | HSS03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/488[#488]
 | storage
+| tenant
 | Implemented in #523 (K8sCsiDriverHealthCheck).
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/488[#488]
@@ -2522,6 +2693,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/488[#488]
 | HSS03, K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/489[#489]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/489[#489]
@@ -2536,6 +2708,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/489[#489]
 | HSS03, K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/490[#490]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/490[#490]
@@ -2550,6 +2723,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/490[#490]
 | HSS03, K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/491[#491]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/491[#491]
@@ -2564,6 +2738,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/491[#491]
 | HSS03, K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/492[#492]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/492[#492]
@@ -2578,6 +2753,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/492[#492]
 | HSS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/330[#330]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/330[#330]
@@ -2592,6 +2768,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/330[#330]
 | HSS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/507[#507]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/507[#507]
@@ -2606,6 +2783,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/507[#507]
 | HSS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/508[#508]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/508[#508]
@@ -2620,6 +2798,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/508[#508]
 | HSS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/509[#509]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/509[#509]
@@ -2634,6 +2813,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/509[#509]
 | HSS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/510[#510]
 | storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/510[#510]
@@ -2648,6 +2828,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/510[#510]
 | HSS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/331[#331]
 | min_req, storage
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/331[#331]
@@ -2662,6 +2843,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/331[#331]
 | STOR01
 |
 |
+| tenant
 | REVIEW
 |
 a|
@@ -2678,6 +2860,7 @@ a|
 | DIR02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/326[#326]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/326[#326]
@@ -2692,6 +2875,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/326[#326]
 | DIR02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/494[#494]
 | kubernetes, slow, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/494[#494]
@@ -2706,6 +2890,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/494[#494]
 | DIR01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/324[#324]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/324[#324]
@@ -2720,6 +2905,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/324[#324]
 | DIR01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/325[#325]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/325[#325]
@@ -2736,6 +2922,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/325[#325]
 | DMS01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/263[#263]
 | min_req
+| provider-dependent
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/263[#263]
@@ -2750,6 +2937,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/263[#263]
 | DMS02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/264[#264]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/264[#264]
@@ -2764,6 +2952,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/264[#264]
 | DMS03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/265[#265]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/265[#265]
@@ -2778,6 +2967,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/265[#265]
 | DMS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/266[#266]
 | min_req, network
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/266[#266]
@@ -2794,6 +2984,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/266[#266]
 | STG02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/358[#358]
 | bare_metal, min_req, sanitization, sds_controller
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/358[#358]
@@ -2808,6 +2999,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/358[#358]
 | STG03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/359[#359]
 | bare_metal, min_req, network, sds_controller
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/359[#359]
@@ -2822,6 +3014,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/359[#359]
 | STG04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/360[#360]
 | bare_metal, health, min_req, sds_controller
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/360[#360]
@@ -2836,6 +3029,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/360[#360]
 | STG05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/361[#361]
 | bare_metal, min_req, sds_controller
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/361[#361]
@@ -2852,6 +3046,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/361[#361]
 | SEC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/296[#296]
 | iam, min_req, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/296[#296]
@@ -2866,6 +3061,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/296[#296]
 | SEC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/511[#511]
 | security, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/511[#511]
@@ -2882,6 +3078,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/511[#511]
 | HSS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/332[#332]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/332[#332]
@@ -2899,6 +3096,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/332[#332]
 | HSS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/333[#333]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/333[#333]
@@ -2913,6 +3111,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/333[#333]
 | HSS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/498[#498]
 | kubernetes, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/498[#498] +
@@ -2928,6 +3127,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/499[#499]
 | HSS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/334[#334]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/334[#334]
@@ -2942,6 +3142,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/334[#334]
 | HSS10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/335[#335]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/335[#335]
@@ -2956,6 +3157,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/335[#335]
 | HSS10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/493[#493]
 | storage
+| tenant
 | Platform/context-sensitive (platform: kubernetes). Overlaps HSS10-01 (platform-agnostic whole-filesystem expansion). Candidate for consolidation/deprecation before v1.0; two implementations of one behavior must not both ship to customers.
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/493[#493]
@@ -2970,6 +3172,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/493[#493]
 | HSS12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/336[#336]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/336[#336]
@@ -2984,6 +3187,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/336[#336]
 | HSS13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/337[#337]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/337[#337]
@@ -2998,6 +3202,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/337[#337]
 | HSS14
 | https://github.com/NVIDIA/ai-cloud-validation/issues/338[#338]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/338[#338]
@@ -3012,6 +3217,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/338[#338]
 | HSS14
 | https://github.com/NVIDIA/ai-cloud-validation/issues/495[#495]
 | kubernetes, storage
+| tenant
 | Platform/context-sensitive (platform: kubernetes). Overlaps HSS14-01 (platform-agnostic provider-evidence flock check). Candidate for consolidation/deprecation before v1.0; two implementations of one behavior must not both ship to customers.
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/495[#495]
@@ -3026,6 +3232,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/495[#495]
 | HSS15
 | https://github.com/NVIDIA/ai-cloud-validation/issues/339[#339]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/339[#339]
@@ -3040,6 +3247,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/339[#339]
 | HSS18
 | https://github.com/NVIDIA/ai-cloud-validation/issues/340[#340]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/340[#340]
@@ -3054,6 +3262,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/340[#340]
 | HSS17
 | https://github.com/NVIDIA/ai-cloud-validation/issues/496[#496]
 | kubernetes, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/496[#496]
@@ -3068,6 +3277,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/496[#496]
 | HSS17
 | https://github.com/NVIDIA/ai-cloud-validation/issues/497[#497]
 | kubernetes, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/497[#497]
@@ -3082,6 +3292,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/497[#497]
 | HSS11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/500[#500]
 | kubernetes, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/500[#500] +
@@ -3099,6 +3310,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/503[#503]
 | HSS11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/504[#504]
 | kubernetes, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/504[#504]
@@ -3116,6 +3328,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/504[#504]
 | DATASVC01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/262[#262]
 | control_plane, min_req
+| tenant
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/262[#262]
@@ -3133,6 +3346,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/262[#262]
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/272[#272]
 | min_req
+| tenant
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/272[#272]
@@ -3147,6 +3361,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/272[#272]
 | DATASVC02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/321[#321]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/321[#321]
@@ -3161,6 +3376,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/321[#321]
 | DATASVC03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/322[#322]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/322[#322]
@@ -3175,6 +3391,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/322[#322]
 | DATASVC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/323[#323]
 | min_req, storage
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/323[#323]
@@ -3192,6 +3409,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/323[#323]
 | DATASVC05
 |
 |
+| tenant
 |
 | P2
 a|
@@ -3209,6 +3427,7 @@ a|
 | DATASVC06
 |
 |
+| tenant
 |
 | P2
 a|
@@ -3226,6 +3445,7 @@ a|
 | DATASVC07
 |
 |
+| tenant
 |
 | P2
 a|
@@ -3244,6 +3464,7 @@ a|
 | DATASVC08
 |
 |
+| tenant
 |
 | P2
 a|
@@ -3261,6 +3482,7 @@ a|
 | DATASVC09
 |
 |
+| tenant
 |
 | P2
 a|
@@ -3278,6 +3500,7 @@ a|
 | SLURM01
 |
 |
+| tenant
 |
 | P0
 a|
@@ -3292,6 +3515,7 @@ a|
 | SLURM02
 |
 | slurm
+| tenant
 |
 | P0
 a|
@@ -3306,6 +3530,7 @@ a|
 | SLURM03
 |
 | slurm
+| tenant
 |
 | P0
 a|
@@ -3320,6 +3545,7 @@ a|
 | SLURM04
 |
 | slurm
+| tenant
 |
 | P0
 a|
@@ -3334,6 +3560,7 @@ a|
 | SLURM05
 |
 | slurm
+| tenant
 |
 | P0
 a|
@@ -3348,6 +3575,7 @@ a|
 | SLURM06
 |
 | slurm
+| tenant
 |
 | P0
 a|
@@ -3362,6 +3590,7 @@ a|
 | SLURM07
 |
 | gpu, slow, slurm, workload
+| tenant
 |
 | P0
 a|
@@ -3376,6 +3605,7 @@ a|
 | SLURM08
 |
 | gpu, slow, slurm, workload
+| tenant
 |
 | P0
 a|
@@ -3390,6 +3620,7 @@ a|
 | SLURM09
 |
 | slow, slurm, workload
+| tenant
 |
 | P0
 a|
@@ -3404,6 +3635,7 @@ a|
 | SLURM10
 |
 |
+| tenant
 |
 | P0
 a|
@@ -3421,13 +3653,14 @@ a|
 | K8S05
 |
 | kubernetes, min_req
+| tenant
 |
 | P0
 a|
 | LimitedEnv
 | M0
 |
-| Create a K8s Instance using the software platform (CLI, Terraform)
+| Create a K8s Instance using the software platform API/CLI
 | published
 |
 
@@ -3437,13 +3670,14 @@ a|
 | K8S38
 |
 | min_req
-|
+| both
+| Cross-role: the tenant requests lifecycle operations; the platform operator executes the managed control plane update. Application continuity is tested separately by K8S09-01.
 |
 a|
 |
 | M4
 |
-| Run through all the steps of the k8s lifecycle management, including user-initated CP update
+| As a tenant, exercise the complete managed Kubernetes control plane lifecycle through the tenant-facing API/CLI, including requesting a supported control plane version update and observing provider-reported status through completion.
 | approved
 |
 
@@ -3451,6 +3685,7 @@ a|
 | K8S41
 |
 |
+| both
 |
 | P2
 a|
@@ -3465,6 +3700,7 @@ a|
 | K8S27
 | https://github.com/NVIDIA/ai-cloud-validation/issues/217[#217]
 | min_req
+| tenant
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/217[#217]
@@ -3481,6 +3717,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/217[#217]
 | K8S14
 |
 | min_req
+| both
 |
 |
 a|
@@ -3495,6 +3732,7 @@ a|
 | K8S39
 |
 | min_req
+| tenant
 |
 | P0
 a|
@@ -3509,6 +3747,7 @@ a|
 | K8S40
 |
 | gpu, kubernetes, slow, workload
+| tenant
 |
 | P0
 a|
@@ -3523,6 +3762,7 @@ a|
 | K8S32
 |
 | gpu, kubernetes, slow, workload
+| tenant
 |
 | P0
 a|
@@ -3539,6 +3779,7 @@ a|
 | K8S33
 |
 | gpu, kubernetes, min_req, slow, workload
+| tenant
 |
 | P0
 a|
@@ -3555,6 +3796,7 @@ a|
 | K8S34
 |
 | min_req
+| tenant
 | k8s05
 | P0
 a|
@@ -3571,6 +3813,7 @@ a|
 | K8S24
 |
 | min_req
+| tenant
 | k8s06/22
 | P0
 a|
@@ -3587,6 +3830,7 @@ a|
 | K8S01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/233[#233]
 | kubernetes, l2, min_req, slow
+| tenant
 | k8s01
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/233[#233]
@@ -3603,6 +3847,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/233[#233]
 | K8S17
 |
 | min_req
+| tenant
 |
 |
 a|
@@ -3619,6 +3864,7 @@ a|
 | K8S21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/218[#218]
 | kubernetes, min_req
+| tenant
 | k8s19
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/218[#218]
@@ -3635,6 +3881,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/218[#218]
 | K8S35
 |
 | min_req
+| tenant
 | K8s16
 | P1
 a|
@@ -3651,6 +3898,7 @@ a|
 | K8S22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/219[#219]
 | kubernetes, min_req
+| tenant
 | K8s20
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/219[#219]
@@ -3667,6 +3915,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/219[#219]
 | K8S23
 |
 | min_req
+| tenant
 | K8s21
 |
 a|
@@ -3681,6 +3930,7 @@ a|
 | K8S23
 |
 | min_req
+| tenant
 | K8s21
 |
 a|
@@ -3695,6 +3945,7 @@ a|
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/273[#273]
 | kubernetes, min_req, storage
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/273[#273]
@@ -3709,6 +3960,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/273[#273]
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/274[#274]
 | kubernetes, min_req, storage
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/274[#274]
@@ -3723,6 +3975,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/274[#274]
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/275[#275]
 | kubernetes, min_req, storage
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/275[#275]
@@ -3737,6 +3990,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/275[#275]
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/276[#276]
 | kubernetes, min_req, storage
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/276[#276]
@@ -3753,6 +4007,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/276[#276]
 | K8S25
 |
 | kubernetes, min_req
+| tenant
 | K8S23
 | P0
 a|
@@ -3767,6 +4022,7 @@ a|
 | K8S25
 | https://github.com/NVIDIA/ai-cloud-validation/issues/220[#220]
 | min_req
+| both
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/220[#220]
@@ -3783,6 +4039,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/220[#220]
 | K8S02
 |
 | min_req
+| tenant
 |
 | INFO
 a|
@@ -3797,6 +4054,7 @@ a|
 | K8S02
 |
 | min_req
+| operator
 |
 | INFO
 a|
@@ -3813,6 +4071,7 @@ a|
 | K8S09
 |
 | min_req
+| tenant
 |
 | INFO
 a|
@@ -3827,6 +4086,7 @@ a|
 | K8S10
 |
 | min_req
+| tenant
 |
 | INFO
 a|
@@ -3843,6 +4103,7 @@ a|
 | K8S11
 |
 | min_req
+| operator
 |
 | INFO
 a|
@@ -3859,6 +4120,7 @@ a|
 | K8S12
 |
 | min_req
+| operator
 |
 | INFO
 a|
@@ -3875,6 +4137,7 @@ a|
 | K8S15
 | https://github.com/NVIDIA/ai-cloud-validation/issues/271[#271]
 | kubernetes, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/271[#271]
@@ -3891,6 +4154,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/271[#271]
 | K8S19
 |
 | min_req
+| operator
 |
 | INFO
 a|
@@ -3907,6 +4171,7 @@ a|
 | SEC09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/301[#301]
 | min_req, security
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/301[#301]
@@ -3921,6 +4186,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/301[#301]
 | SEC09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
 | min_req, security
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
@@ -3937,6 +4203,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
 | K8S36
 | https://github.com/NVIDIA/ai-cloud-validation/issues/267[#267]
 | kubernetes, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/267[#267]
@@ -3953,6 +4220,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/267[#267]
 | K8S04
 |
 | min_req
+| operator
 | INFO
 | INFO
 a|
@@ -3969,6 +4237,7 @@ a|
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/269[#269]
 | kubernetes, min_req, slow
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/269[#269] +
@@ -3984,6 +4253,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/221[#221]
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/270[#270]
 | kubernetes, min_req, slow
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/270[#270] +
@@ -3999,6 +4269,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/222[#222]
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/223[#223]
 | kubernetes, min_req, slow
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/223[#223]
@@ -4013,6 +4284,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/223[#223]
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/224[#224]
 | min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/224[#224]
@@ -4029,6 +4301,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/224[#224]
 | K8S07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
 | kubernetes, min_req
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
@@ -4045,6 +4318,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
 | K8S17
 | https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
 | kubernetes, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
@@ -4061,6 +4335,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
 | K8S20
 | https://github.com/NVIDIA/ai-cloud-validation/issues/227[#227]
 | kubernetes, min_req
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/227[#227]
@@ -4073,17 +4348,18 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/227[#227]
 
 | K8s Performance
 |
-| [[K8S37-01]]K8S37-01
-| K8S37
+| [[K8S28-01]]K8S28-01
+| K8S28
 | https://github.com/NVIDIA/ai-cloud-validation/issues/268[#268]
 | min_req
-|
+| tenant
+| Consolidates the duplicate reference requirement and former test K8S37-01 into the canonical offtake K8S28 requirement.
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/268[#268]
 |
 | M5
 |
-| Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size
+| Verify the managed Kubernetes service meets standard Kubernetes performance and control plane SLO targets at up to 5,000 nodes or the provider's declared maximum cluster size, whichever is smaller
 | pending
 |
 
@@ -4093,6 +4369,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/268[#268]
 | K8S26
 | https://github.com/NVIDIA/ai-cloud-validation/issues/277[#277]
 | kubernetes, min_req
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/277[#277]
@@ -4110,6 +4387,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/277[#277]
 | POWER01
 |
 |
+| operator
 |
 | P2
 a|
@@ -4128,6 +4406,7 @@ a|
 | APIGW01
 |
 |
+| tenant
 |
 | P2
 a|
@@ -4145,6 +4424,7 @@ a|
 | AICP01
 |
 |
+| tenant
 |
 | P2
 a|
@@ -4162,6 +4442,7 @@ a|
 | WEBUI01
 |
 |
+| tenant
 |
 | P2
 a|
@@ -4180,6 +4461,7 @@ a|
 | OBS01
 |
 |
+| both
 |
 | P0
 a|
@@ -4194,6 +4476,7 @@ a|
 | OBS02
 |
 |
+| both
 |
 | P0
 a|
@@ -4208,6 +4491,7 @@ a|
 | OBS03
 |
 |
+| both
 |
 | P0
 a|
@@ -4222,6 +4506,7 @@ a|
 | OBS04
 |
 |
+| both
 |
 | P0
 a|
@@ -4238,6 +4523,7 @@ a|
 | OBS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/342[#342]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/342[#342]
@@ -4254,6 +4540,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/342[#342]
 | OBS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/343[#343]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/343[#343]
@@ -4268,6 +4555,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/343[#343]
 | OBS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/344[#344]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/344[#344]
@@ -4282,6 +4570,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/344[#344]
 | OBS08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/345[#345]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/345[#345]
@@ -4296,6 +4585,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/345[#345]
 | OBS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/346[#346]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/346[#346]
@@ -4310,6 +4600,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/346[#346]
 | OBS10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/347[#347]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/347[#347]
@@ -4326,6 +4617,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/347[#347]
 | OBS11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/348[#348]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/348[#348]
@@ -4340,6 +4632,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/348[#348]
 | OBS12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/349[#349]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/349[#349]
@@ -4354,6 +4647,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/349[#349]
 | OBS13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/350[#350]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/350[#350]
@@ -4368,6 +4662,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/350[#350]
 | OBS14
 | https://github.com/NVIDIA/ai-cloud-validation/issues/351[#351]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/351[#351]
@@ -4382,6 +4677,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/351[#351]
 | OBS15
 | https://github.com/NVIDIA/ai-cloud-validation/issues/352[#352]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/352[#352]
@@ -4396,6 +4692,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/352[#352]
 | OBS16
 | https://github.com/NVIDIA/ai-cloud-validation/issues/353[#353]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/353[#353]
@@ -4410,6 +4707,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/353[#353]
 | OBS17
 | https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
 | min_req, observability, security
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
@@ -4424,6 +4722,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
 | OBS18
 | https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
 | bare_metal, min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
@@ -4438,6 +4737,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
 | OBS19
 | https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
 | min_req, network, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
@@ -4455,6 +4755,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
 | TELEM01
 |
 |
+| both
 |
 | P1
 a|
@@ -4469,6 +4770,7 @@ a|
 | TELEM02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/120[#120]
 | min_req
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/120[#120]
@@ -4483,6 +4785,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/120[#120]
 | TELEM03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/121[#121]
 | min_req
+| tenant
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/121[#121]
@@ -4499,6 +4802,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/121[#121]
 | TELEM04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
 | gpu, min_req, observability, security
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
@@ -4515,6 +4819,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
 | TELEM05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
@@ -4529,6 +4834,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
 | TELEM06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
@@ -4545,6 +4851,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
 | TELEM07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
@@ -4559,6 +4866,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
 | TELEM08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
 | min_req, observability
+| both
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
@@ -4577,6 +4885,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
 | SEC12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/306[#306]
 | min_req, network, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/306[#306]
@@ -4591,6 +4900,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/306[#306]
 | SEC12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/307[#307]
 | min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/307[#307]
@@ -4605,6 +4915,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/307[#307]
 | CNP10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/260[#260]
 | min_req, network, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/260[#260]
@@ -4619,6 +4930,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/260[#260]
 | SEC12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/308[#308]
 | min_req, network, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/308[#308]
@@ -4635,6 +4947,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/308[#308]
 | SEC13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/309[#309]
 | min_req, network, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/309[#309]
@@ -4651,6 +4964,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/309[#309]
 | SEC14
 | https://github.com/NVIDIA/ai-cloud-validation/issues/311[#311]
 | min_req, network, security
+| both
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/311[#311]
@@ -4665,6 +4979,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/311[#311]
 | SEC13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/310[#310]
 | min_req, network, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/310[#310]
@@ -4681,6 +4996,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/310[#310]
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/287[#287]
 | bare_metal, infiniband, min_req, network, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/287[#287]
@@ -4695,6 +5011,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/287[#287]
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/288[#288]
 | bare_metal, infiniband, min_req, network, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/288[#288]
@@ -4711,6 +5028,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/288[#288]
 | SEC11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/305[#305]
 | iam, min_req, network, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/305[#305]
@@ -4728,6 +5046,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/305[#305]
 | SEC01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
 | iam, min_req, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
@@ -4744,6 +5063,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
 | SEC06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
 | iam, min_req, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
@@ -4760,6 +5080,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
 | SEC03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/295[#295]
 | iam, min_req, security
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/295[#295]
@@ -4776,6 +5097,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/295[#295]
 | SEC07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/298[#298]
 | iam, min_req, security
+| operator
 | INFO
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/298[#298]
@@ -4793,6 +5115,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/298[#298]
 | SEC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/297[#297]
 | iam, min_req, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/297[#297]
@@ -4810,6 +5133,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/297[#297]
 | SEC08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/299[#299]
 | min_req, security
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/299[#299]
@@ -4824,6 +5148,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/299[#299]
 | SEC08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/300[#300]
 | min_req, security
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/300[#300]
@@ -4841,6 +5166,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/300[#300]
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/312[#312]
 | bare_metal, min_req, sanitization, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/312[#312]
@@ -4855,6 +5181,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/312[#312]
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/313[#313]
 | bare_metal, gpu, min_req, sanitization, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/313[#313]
@@ -4869,6 +5196,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/313[#313]
 | SEC21, SEC22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/314[#314]
 | bare_metal, firmware, min_req, sanitization, security
+| operator
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/314[#314]
@@ -4885,6 +5213,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/314[#314]
 | SEC20
 |
 | min_req
+| operator
 |
 | INFO
 a|
@@ -4901,6 +5230,7 @@ a|
 | SEC09, SEC10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/303[#303]
 | min_req, security
+| operator
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/303[#303]
@@ -4915,6 +5245,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/303[#303]
 | SEC09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/304[#304]
 | min_req, security, slow, workload
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/304[#304]
@@ -4933,6 +5264,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/304[#304]
 | NET01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/278[#278]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/278[#278]
@@ -4950,6 +5282,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/278[#278]
 | NET02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/279[#279]
 | min_req, network
+| tenant
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/279[#279]
@@ -4967,6 +5300,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/279[#279]
 | NET04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/280[#280]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/280[#280]
@@ -4983,6 +5317,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/280[#280]
 | NET05
 |
 | min_req
+| tenant
 |
 | INFO
 a|
@@ -4997,6 +5332,7 @@ a|
 | NET05
 |
 | min_req
+| both
 |
 | INFO
 a|
@@ -5013,6 +5349,7 @@ a|
 | NET06
 |
 | min_req
+| tenant
 |
 | INFO
 a|
@@ -5027,6 +5364,7 @@ a|
 | NET06
 |
 | min_req
+| operator
 |
 | INFO
 a|
@@ -5045,6 +5383,7 @@ a|
 | CAP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
 | bare_metal, governance, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
@@ -5062,6 +5401,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
 | CAP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
 | bare_metal, capacity, min_req, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
@@ -5076,6 +5416,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
 | CAP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
 | bare_metal, capacity, min_req, security
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
@@ -5093,6 +5434,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
 | CAP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/254[#254]
 | bare_metal, health, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/254[#254]
@@ -5107,6 +5449,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/254[#254]
 | CAP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/255[#255]
 | bare_metal, health, min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/255[#255]
@@ -5125,6 +5468,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/255[#255]
 | BM01
 |
 | min_req
+| tenant
 |
 |
 a|
@@ -5139,6 +5483,7 @@ a|
 | BENCH01
 |
 |
+| provider-dependent
 | REVIEW
 | P2
 a|
@@ -5153,6 +5498,7 @@ a|
 | BENCH02
 |
 |
+| provider-dependent
 | REVIEW
 |
 a|
@@ -5167,6 +5513,7 @@ a|
 | BM01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/249[#249]
 | min_req
+| tenant
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/249[#249]

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -36,6 +36,7 @@ domains:
                   - "#38"
                 req_id: BOOT01
                 test_id: BOOT01-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: CRUD an OS install configuration (e.g. iPXE config like Carbide)
@@ -47,6 +48,7 @@ domains:
                   - "#39"
                 req_id: BOOT01
                 test_id: BOOT01-02
+                actor: tenant
                 status: published
                 notes: ""
                 labels:
@@ -62,6 +64,7 @@ domains:
                   - "#40"
                 req_id: BOOT03
                 test_id: BOOT03-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: CRUD (get, list, create, delete) custom OS images for fast boot (raw, qcow2, img, etc) for BM/VM
@@ -74,6 +77,7 @@ domains:
                   - "#104"
                 req_id: BOOT03
                 test_id: BOOT03-02
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Check that an OS image can be installed on a BMaaS system
@@ -89,6 +93,7 @@ domains:
                   - "#41"
                 req_id: BOOT01
                 test_id: BOOT01-03
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Check that an OS install configuration can be installed on a BMaaS system
@@ -103,6 +108,7 @@ domains:
                   - "#43"
                 req_id: BOOT01
                 test_id: BOOT01-04
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Check that a VM image can be installed onto a VMaaS system
@@ -117,6 +123,7 @@ domains:
                   - "#44"
                 req_id: BOOT01
                 test_id: BOOT01-05
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Verify that an OS image (iso file) with full NVIDIA support is readily available
@@ -124,6 +131,7 @@ domains:
                 milestone: M4
                 req_id: IMG01
                 test_id: IMG01-01
+                actor: tenant
                 legacy_ids: [IMG-XX-01]
                 status: approved
                 notes: ""
@@ -132,6 +140,7 @@ domains:
                 milestone: M4
                 req_id: IMG02
                 test_id: IMG02-01
+                actor: tenant
                 legacy_ids: [IMG-XX-02]
                 status: approved
                 notes: ""
@@ -140,6 +149,7 @@ domains:
                 milestone: M4
                 req_id: IMG03
                 test_id: IMG03-01
+                actor: tenant
                 legacy_ids: [IMG-XX-03]
                 status: approved
                 notes: ""
@@ -155,6 +165,7 @@ domains:
                 milestone: M4
                 req_id: AUTH01
                 test_id: AUTH01-01
+                actor: tenant
                 legacy_ids: [AUTH-XX-01]
                 status: approved
                 notes: ""
@@ -162,6 +173,7 @@ domains:
                 milestone: M6
                 req_id: AUTH02
                 test_id: AUTH02-01
+                actor: tenant
                 legacy_ids: [AUTH-XX-02]
                 status: published
                 priority: P1
@@ -174,6 +186,7 @@ domains:
                 milestone: M5
                 req_id: AUTH03
                 test_id: AUTH03-01
+                actor: tenant
                 legacy_ids: [AUTH-XX-03]
                 status: approved
                 priority: P1
@@ -202,6 +215,7 @@ domains:
                   - "#21"
                 req_id: IAM01
                 test_id: IAM01-01
+                actor: tenant
                 legacy_ids: [IAM-XX-01]
                 status: published
                 notes: ""
@@ -216,6 +230,7 @@ domains:
                   - "#23"
                 req_id: IAM02
                 test_id: IAM02-01
+                actor: tenant
                 legacy_ids: [IAM-XX-02]
                 status: published
                 notes: ""
@@ -226,6 +241,7 @@ domains:
                 milestone: M5
                 req_id: IAM03
                 test_id: IAM03-01
+                actor: tenant
                 legacy_ids: [IAM-XX-03]
                 status: approved
                 notes: ""
@@ -247,6 +263,7 @@ domains:
                   - "#131"
                 req_id: IPAM01
                 test_id: IPAM01-01
+                actor: tenant
                 legacy_ids: [CP-XX-01]
                 status: published
                 notes: ""
@@ -262,6 +279,7 @@ domains:
                   - "#132"
                 req_id: IPAM02
                 test_id: IPAM02-01
+                actor: tenant
                 legacy_ids: [CP-XX-02]
                 status: published
                 notes: ""
@@ -279,6 +297,7 @@ domains:
                 milestone: M4
                 req_id: NETMGMT01
                 test_id: NETMGMT01-01
+                actor: operator
                 legacy_ids: [NETMGMT-XX-01]
                 status: pending
                 notes: ""
@@ -293,6 +312,7 @@ domains:
                 milestone: M4
                 req_id: RESDB01
                 test_id: RESDB01-01
+                actor: operator
                 legacy_ids: [RESDB-XX-01]
                 status: pending
                 notes: ""
@@ -315,6 +335,7 @@ domains:
                   - "#27"
                 req_id: CP03
                 test_id: CP03-01
+                actor: tenant
                 legacy_ids: [CP-XX-03]
                 status: published
                 notes: ""
@@ -325,6 +346,7 @@ domains:
                 milestone: M5
                 req_id: CP04
                 test_id: CP04-01
+                actor: operator
                 legacy_ids: [CP-XX-04]
                 status: approved
                 notes: ""
@@ -339,6 +361,7 @@ domains:
                   - "#28"
                 req_id: CP05
                 test_id: CP05-01
+                actor: tenant
                 legacy_ids: [CP-XX-05]
                 status: published
                 notes: ""
@@ -358,6 +381,7 @@ domains:
                   - "#29"
                 req_id: CP06
                 test_id: CP06-01
+                actor: tenant
                 legacy_ids: [CP-XX-06]
                 status: published
                 notes: ""
@@ -370,6 +394,7 @@ domains:
                   - "#30"
                 req_id: CP07
                 test_id: CP07-01
+                actor: tenant
                 legacy_ids: [CP-XX-07]
                 status: published
                 notes: ""
@@ -385,6 +410,7 @@ domains:
                   - "#31"
                 req_id: CP08
                 test_id: CP08-01
+                actor: tenant
                 legacy_ids: [CP-XX-08]
                 status: published
                 notes: ""
@@ -401,6 +427,7 @@ domains:
                   - "#33"
                 req_id: CP09
                 test_id: CP09-01
+                actor: tenant
                 legacy_ids: [CP-XX-09]
                 status: published
                 notes: ""
@@ -416,6 +443,7 @@ domains:
                   - "#34"
                 req_id: CP10
                 test_id: CP10-01
+                actor: tenant
                 legacy_ids: [CP-XX-10]
                 status: published
                 notes: ""
@@ -432,6 +460,7 @@ domains:
                   - "#35"
                 req_id: CP11
                 test_id: CP11-01
+                actor: tenant
                 legacy_ids: [CP-XX-11]
                 status: published
                 notes: ""
@@ -448,6 +477,7 @@ domains:
                   - "#133"
                 req_id: HWING01
                 test_id: HWING01-01
+                actor: operator
                 legacy_ids: [HWING-XX-01]
                 status: published
                 notes: ""
@@ -461,6 +491,7 @@ domains:
                 milestone: M4
                 req_id: HWING02
                 test_id: HWING02-01
+                actor: operator
                 legacy_ids: [HWING-XX-02]
                 status: approved
                 notes: ""
@@ -475,6 +506,7 @@ domains:
                 milestone: M6
                 req_id: SEC22
                 test_id: SEC22-01
+                actor: operator
                 status: published
                 notes: ""
                 github_issues:
@@ -490,6 +522,7 @@ domains:
                 milestone: M5
                 req_id: ATTEST01
                 test_id: ATTEST01-01
+                actor: operator
                 legacy_ids: [ATTEST-XX-01]
                 status: approved
                 notes: ""
@@ -502,6 +535,7 @@ domains:
                 milestone: M6
                 req_id: SEC22
                 test_id: SEC22-02
+                actor: operator
                 status: published
                 notes: ""
                 github_issues:
@@ -513,6 +547,7 @@ domains:
                 milestone: M5
                 req_id: ATTEST02
                 test_id: ATTEST02-01
+                actor: operator
                 legacy_ids: [ATTEST-XX-02]
                 status: published
                 notes: ""
@@ -528,6 +563,7 @@ domains:
                 milestone: M4
                 req_id: CNP09
                 test_id: CNP09-01
+                actor: operator
                 status: approved
                 notes: ""
               - summary: Verify all firmware is cryptographically signed and attested during boot
@@ -544,11 +580,13 @@ domains:
                   - "#259"
                 req_id: CNP09
                 test_id: CNP09-02
+                actor: operator
                 status: published
               - summary: TPM Secure Boot in BIOS
                 notes: REVIEW
                 req_id: SEC22
                 test_id: SEC22-03
+                actor: operator
                 status: pending
                 milestone: M9
                 priority: P0
@@ -568,6 +606,7 @@ domains:
                   - "#49"
                 req_id: CNP01
                 test_id: CNP01-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: "Supports the basic lifecycle of Bare Metal nodes, following the standard CRUD pattern"
@@ -581,6 +620,7 @@ domains:
                   - "#52"
                 req_id: CNP01, CNP04
                 test_id: CNP01-02
+                actor: tenant
                 status: published
               - summary: Delete a Bare Metal node
                 labels:
@@ -593,6 +633,7 @@ domains:
                   - "#53"
                 req_id: CNP01
                 test_id: CNP01-03
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Confirm sanitization on delete - Tenant View
@@ -609,6 +650,7 @@ domains:
                   - "#47"
                 req_id: SEC21
                 test_id: SEC21-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Confirm sanitization on delete - Low Level
@@ -626,6 +668,7 @@ domains:
                   - "#134"
                 req_id: SEC21
                 test_id: SEC21-02
+                actor: operator
                 status: published
                 notes: ""
               - summary: Topology-based placement
@@ -640,12 +683,14 @@ domains:
                   - "#105"
                 req_id: CNP01
                 test_id: CNP01-04
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Node attached storage
                 notes: REVIEW
                 req_id: BMAAS01
                 test_id: BMAAS01-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-01]
                 status: pending
                 priority: P2
@@ -654,6 +699,7 @@ domains:
                 notes: REVIEW
                 req_id: BMAAS02
                 test_id: BMAAS02-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-02]
                 status: pending
                 priority: P2
@@ -671,6 +717,7 @@ domains:
                   - "#56"
                 req_id: BMAAS03
                 test_id: BMAAS03-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-03]
                 status: published
                 notes: ""
@@ -688,6 +735,7 @@ domains:
                   - "#57"
                 req_id: CNP01
                 test_id: CNP01-05
+                actor: tenant
                 status: published
                 notes: ""
               - summary: A running node can be power-cycled in case of issue
@@ -702,6 +750,7 @@ domains:
                   - "#135"
                 req_id: CNP01
                 test_id: CNP01-06
+                actor: tenant
                 status: published
                 notes: ""
               - summary: "DEPRECATED: A node can be reinstalled from its configured stock operating system"
@@ -714,6 +763,7 @@ domains:
                   - "#69"
                 req_id: BMAAS04
                 test_id: BMAAS04-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-04]
                 status: published
                 notes: ""
@@ -730,6 +780,7 @@ domains:
                   - "#106"
                 req_id: CNP01
                 test_id: CNP01-07
+                actor: tenant
                 status: published
               - summary: Support for cloud-init and instance metadata discovery via link-local addresses (e.g. 169.254.169.254) or virtual devices (Bare Metal)
                 labels:
@@ -744,6 +795,7 @@ domains:
                   - "#113"
                 req_id: BOOT02
                 test_id: BOOT02-01
+                actor: tenant
                 status: published
               - summary: A powered off node can be powered back on
                 labels:
@@ -758,6 +810,7 @@ domains:
                   - "#108"
                 req_id: CNP01
                 test_id: CNP01-08
+                actor: tenant
                 status: published
               - summary: Support for user-defined tags/labels and cloud-init metadata on instances. (Bare Metal)
                 labels:
@@ -769,6 +822,7 @@ domains:
                 milestone: M3 .5
                 req_id: CNP05
                 test_id: CNP05-01
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -786,6 +840,7 @@ domains:
                   - "#136"
                 req_id: BMAAS05
                 test_id: BMAAS05-01
+                actor: operator
                 legacy_ids: [BMAAS-XX-05]
                 status: published
                 notes: ""
@@ -801,6 +856,7 @@ domains:
                   - "#60"
                 req_id: BMAAS06
                 test_id: BMAAS06-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-06]
                 status: published
                 notes: ""
@@ -818,6 +874,7 @@ domains:
                 milestone: M5
                 req_id: BMAAS07
                 test_id: BMAAS07-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-07]
                 status: published
                 github_issues:
@@ -837,6 +894,7 @@ domains:
                   - "#114"
                 req_id: CNP06
                 test_id: CNP06-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Verify NVIDIA hardware
@@ -848,6 +906,7 @@ domains:
                   - "#61"
                 req_id: BMAAS08
                 test_id: BMAAS08-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-08]
                 status: published
                 notes: ""
@@ -871,6 +930,7 @@ domains:
                   - "#68"
                 req_id: BMAAS09
                 test_id: BMAAS09-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-09]
                 status: published
                 notes: ""
@@ -892,6 +952,7 @@ domains:
                   - "#82"
                 req_id: BMAAS10
                 test_id: BMAAS10-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-10]
                 status: published
               - summary: NCCL tests
@@ -909,6 +970,7 @@ domains:
                   - "#65"
                 req_id: BMAAS11
                 test_id: BMAAS11-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-11]
                 status: published
                 notes: ""
@@ -928,6 +990,7 @@ domains:
                   - "#66"
                 req_id: BMAAS12
                 test_id: BMAAS12-01
+                actor: tenant
                 legacy_ids: [BMAAS-XX-12]
                 status: published
               - summary: Verify that serial console output is logged and queryable for at least 1 month of history
@@ -941,6 +1004,7 @@ domains:
                   - "#258"
                 req_id: CNP06
                 test_id: CNP06-02
+                actor: tenant
                 status: published
           - description: Stable Identifiers
             tests:
@@ -957,6 +1021,7 @@ domains:
                   - "#185"
                 req_id: CNP08
                 test_id: CNP08-01
+                actor: tenant
                 status: published
               - summary: Verify that a BM node's ID does not change after a maintenance/reprovision event
                 labels:
@@ -968,6 +1033,7 @@ domains:
                 github_issues: []
                 req_id: CNP08
                 test_id: CNP08-02
+                actor: provider-dependent
                 status: pending
       - name: "Compute Service: VMaaS"
         capabilities:
@@ -985,6 +1051,7 @@ domains:
                   - "#42"
                 req_id: CNP01
                 test_id: CNP01-09
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Get info about a specific VM node, including if it is ready for use
@@ -999,6 +1066,7 @@ domains:
                   - "#51"
                 req_id: CNP01, CNP04
                 test_id: CNP01-10
+                actor: tenant
                 status: published
               - summary: Get a list of all VM nodes in a VPC
                 labels:
@@ -1012,6 +1080,7 @@ domains:
                   - "#45"
                 req_id: CNP01
                 test_id: CNP01-11
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Delete a VM node
@@ -1025,6 +1094,7 @@ domains:
                   - "#46"
                 req_id: CNP01
                 test_id: CNP01-12
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Confirm sanitization on delete
@@ -1038,6 +1108,7 @@ domains:
                   - "#47"
                 req_id: SEC21
                 test_id: SEC21-03
+                actor: tenant
                 status: published
                 notes: ""
           - description: Once created, VM nodes can be accessed for usage, and have the high level support controls of reboot, reinstall
@@ -1049,6 +1120,7 @@ domains:
                 milestone: M0
                 req_id: VMAAS01
                 test_id: VMAAS01-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-01]
                 status: approved
                 notes: ""
@@ -1062,6 +1134,7 @@ domains:
                 milestone: M0
                 req_id: CNP01
                 test_id: CNP01-13
+                actor: tenant
                 status: approved
                 notes: ""
                 labels:
@@ -1073,6 +1146,7 @@ domains:
                 milestone: M1
                 req_id: VMAAS02
                 test_id: VMAAS02-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-02]
                 status: pending
                 notes: ""
@@ -1089,6 +1163,7 @@ domains:
                   - "#110"
                 req_id: CNP01
                 test_id: CNP01-14
+                actor: tenant
                 status: published
               - summary: A powered off VM can be started
                 labels:
@@ -1103,6 +1178,7 @@ domains:
                   - "#111"
                 req_id: CNP01
                 test_id: CNP01-15
+                actor: tenant
                 status: published
               - summary: Support for user-defined tags/labels and cloud-init metadata on instances. (VM)
                 labels:
@@ -1117,6 +1193,7 @@ domains:
                   - "#112"
                 req_id: CNP05
                 test_id: CNP05-02
+                actor: tenant
                 status: published
               - summary: Support for cloud-init and instance metadata discovery via link-local addresses (e.g. 169.254.169.254) or virtual devices (VM)
                 labels:
@@ -1129,6 +1206,7 @@ domains:
                   - "#113"
                 req_id: BOOT02
                 test_id: BOOT02-02
+                actor: tenant
                 status: published
                 notes: ""
           - description: Quota should be enforced
@@ -1137,6 +1215,7 @@ domains:
                 priority: P2
                 req_id: VMAAS03
                 test_id: VMAAS03-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-03]
                 status: approved
                 notes: ""
@@ -1145,6 +1224,7 @@ domains:
                 priority: P2
                 req_id: VMAAS04
                 test_id: VMAAS04-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-04]
                 status: approved
                 notes: ""
@@ -1160,6 +1240,7 @@ domains:
                   - "#55"
                 req_id: VMAAS05
                 test_id: VMAAS05-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-05]
                 status: published
                 notes: ""
@@ -1175,6 +1256,7 @@ domains:
                   - "#59"
                 req_id: VMAAS06
                 test_id: VMAAS06-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-06]
                 status: published
                 notes: ""
@@ -1191,6 +1273,7 @@ domains:
                   - "#62"
                 req_id: VMAAS07
                 test_id: VMAAS07-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-07]
                 status: published
                 notes: ""
@@ -1205,6 +1288,7 @@ domains:
                 milestone: M1
                 req_id: VMAAS08
                 test_id: VMAAS08-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-08]
                 status: approved
                 notes: ""
@@ -1218,6 +1302,7 @@ domains:
                   - "#67"
                 req_id: VMAAS09
                 test_id: VMAAS09-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-09]
                 status: published
                 labels:
@@ -1231,6 +1316,7 @@ domains:
                 milestone: M5
                 req_id: VMAAS10
                 test_id: VMAAS10-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-10]
                 status: approved
                 notes: ""
@@ -1243,6 +1329,7 @@ domains:
                 milestone: M0
                 req_id: VMAAS11
                 test_id: VMAAS11-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-11]
                 status: approved
                 notes: ""
@@ -1253,6 +1340,7 @@ domains:
                 milestone: M1
                 req_id: VMAAS12
                 test_id: VMAAS12-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-12]
                 status: approved
                 notes: ""
@@ -1267,6 +1355,7 @@ domains:
                 milestone: M5
                 req_id: VMAAS13
                 test_id: VMAAS13-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-13]
                 status: approved
                 notes: ""
@@ -1280,6 +1369,7 @@ domains:
                 milestone: M5
                 req_id: VMAAS14
                 test_id: VMAAS14-01
+                actor: tenant
                 legacy_ids: [VMAAS-XX-14]
                 status: approved
                 notes: ""
@@ -1295,6 +1385,7 @@ domains:
                   - "#114"
                 req_id: CNP06
                 test_id: CNP06-03
+                actor: tenant
                 status: published
                 notes: ""
           - description: Stable Identifiers
@@ -1310,6 +1401,7 @@ domains:
                   - "#198"
                 req_id: CNP08
                 test_id: CNP08-03
+                actor: tenant
                 status: published
               - summary: Verify that a VM's ID does not change after a live migration or maintenance event
                 labels:
@@ -1320,6 +1412,7 @@ domains:
                 github_issues: []
                 req_id: CNP08
                 test_id: CNP08-04
+                actor: provider-dependent
                 status: pending
           - description: VM Hardening
             tests:
@@ -1336,6 +1429,7 @@ domains:
                   - "#256"
                 req_id: CNP01
                 test_id: CNP01-16
+                actor: tenant
                 status: published
               - summary: Verify USB, clipboard, and unnecessary virtual devices are disabled
                 labels:
@@ -1349,6 +1443,7 @@ domains:
                   - "#257"
                 req_id: CNP01
                 test_id: CNP01-17
+                actor: tenant
                 status: published
       - name: SDN Controller
         capabilities:
@@ -1366,6 +1461,7 @@ domains:
                   - "#11"
                 req_id: SDN01
                 test_id: SDN01-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Retrieve a VPC
@@ -1380,6 +1476,7 @@ domains:
                   - "#12"
                 req_id: SDN01
                 test_id: SDN01-02
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Update a VPC
@@ -1394,6 +1491,7 @@ domains:
                   - "#13"
                 req_id: SDN01
                 test_id: SDN01-03
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Delete a VPC
@@ -1408,6 +1506,7 @@ domains:
                   - "#14"
                 req_id: SDN01
                 test_id: SDN01-04
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Verify that a VPC has an exclusive subnet
@@ -1419,6 +1518,7 @@ domains:
                   - "#16"
                 req_id: SDN04
                 test_id: SDN04-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Verify that nodes in two VPCs cannot communicate over the N/S (TAN) network
@@ -1435,6 +1535,7 @@ domains:
                   - "#18"
                 req_id: SDN04
                 test_id: SDN04-02
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Verify that nodes in two VPCs cannot communicate over the E/W (CIN) network
@@ -1448,6 +1549,7 @@ domains:
                   - "#18"
                 req_id: SDN04
                 test_id: SDN04-03
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Support non-conflicting Bring-Your-Own-IP (including 7.0.0.0/8)
@@ -1460,6 +1562,7 @@ domains:
                   - "#115"
                 req_id: NET03, SDN01
                 test_id: NET03-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Support Stable Private IP allocations, where if a VM crashes and restarts the same IP address remains pinned until the node is deleted
@@ -1472,6 +1575,7 @@ domains:
                   - "#116"
                 req_id: SDN11
                 test_id: SDN11-01
+                actor: tenant
                 legacy_ids: [SDN-XX-01]
                 status: published
                 notes: ""
@@ -1485,6 +1589,7 @@ domains:
                   - "#117"
                 req_id: SDN05
                 test_id: SDN05-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: "Localized DNS: Support for custom, localized DNS settings to enable internal domain resolution to private endpoints (e.g. storage endpoints)"
@@ -1497,6 +1602,7 @@ domains:
                   - "#118"
                 req_id: SDN06
                 test_id: SDN06-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: "Support for VPC peering with full bandwidth and no \"hairpin\" routing."
@@ -1509,6 +1615,7 @@ domains:
                   - "#119"
                 req_id: SDN07
                 test_id: SDN07-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: Create a Security Group
@@ -1519,6 +1626,7 @@ domains:
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-01
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -1534,6 +1642,7 @@ domains:
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-02
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -1547,6 +1656,7 @@ domains:
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-03
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -1560,6 +1670,7 @@ domains:
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-04
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -1574,6 +1685,7 @@ domains:
                   - "#19"
                 req_id: CNP03
                 test_id: CNP03-01
+                actor: tenant
                 status: published
                 notes: ""
               - summary: "NVLink: Create a new partition; verify success response with partition key."
@@ -1582,6 +1694,7 @@ domains:
                 milestone: M4
                 req_id: SDN12
                 test_id: SDN12-01
+                actor: tenant
                 legacy_ids: [SDN-XX-02]
                 status: approved
                 notes: ""
@@ -1592,6 +1705,7 @@ domains:
                 milestone: M4
                 req_id: SDN13
                 test_id: SDN13-01
+                actor: tenant
                 legacy_ids: [SDN-XX-03]
                 status: approved
                 notes: ""
@@ -1602,6 +1716,7 @@ domains:
                 milestone: M4
                 req_id: SDN14
                 test_id: SDN14-01
+                actor: tenant
                 legacy_ids: [SDN-XX-04]
                 status: approved
                 notes: ""
@@ -1612,6 +1727,7 @@ domains:
                 milestone: M4
                 req_id: SDN15
                 test_id: SDN15-01
+                actor: tenant
                 legacy_ids: [SDN-XX-05]
                 status: approved
                 notes: ""
@@ -1622,6 +1738,7 @@ domains:
                 milestone: M4
                 req_id: SDN16
                 test_id: SDN16-01
+                actor: tenant
                 legacy_ids: [SDN-XX-06]
                 status: approved
                 notes: ""
@@ -1632,6 +1749,7 @@ domains:
                 milestone: M4
                 req_id: SDN17
                 test_id: SDN17-01
+                actor: tenant
                 legacy_ids: [SDN-XX-07]
                 status: approved
                 notes: ""
@@ -1642,6 +1760,7 @@ domains:
                 milestone: M4
                 req_id: SDN18
                 test_id: SDN18-01
+                actor: tenant
                 legacy_ids: [SDN-XX-08]
                 status: approved
                 notes: ""
@@ -1652,6 +1771,7 @@ domains:
                 milestone: M4
                 req_id: SDN19
                 test_id: SDN19-01
+                actor: tenant
                 legacy_ids: [SDN-XX-09]
                 status: approved
                 notes: ""
@@ -1662,6 +1782,7 @@ domains:
                 milestone: M4
                 req_id: SDN20
                 test_id: SDN20-01
+                actor: tenant
                 legacy_ids: [SDN-XX-10]
                 status: approved
                 notes: ""
@@ -1672,6 +1793,7 @@ domains:
                 milestone: M4
                 req_id: SDN21
                 test_id: SDN21-01
+                actor: tenant
                 legacy_ids: [SDN-XX-11]
                 status: approved
                 notes: ""
@@ -1682,6 +1804,7 @@ domains:
                 milestone: M4
                 req_id: SDN22
                 test_id: SDN22-01
+                actor: tenant
                 legacy_ids: [SDN-XX-12]
                 status: approved
                 notes: ""
@@ -1692,6 +1815,7 @@ domains:
                 milestone: M4
                 req_id: SDN23
                 test_id: SDN23-01
+                actor: tenant
                 legacy_ids: [SDN-XX-13]
                 status: approved
                 notes: ""
@@ -1702,6 +1826,7 @@ domains:
                 milestone: M4
                 req_id: SDN24
                 test_id: SDN24-01
+                actor: tenant
                 legacy_ids: [SDN-XX-14]
                 status: approved
                 notes: ""
@@ -1712,6 +1837,7 @@ domains:
                 milestone: M4
                 req_id: SDN25
                 test_id: SDN25-01
+                actor: tenant
                 legacy_ids: [SDN-XX-15]
                 status: approved
                 notes: ""
@@ -1722,6 +1848,7 @@ domains:
                 milestone: M4
                 req_id: SDN26
                 test_id: SDN26-01
+                actor: tenant
                 legacy_ids: [SDN-XX-16]
                 status: approved
                 notes: ""
@@ -1732,6 +1859,7 @@ domains:
                 milestone: M4
                 req_id: SDN27
                 test_id: SDN27-01
+                actor: tenant
                 legacy_ids: [SDN-XX-17]
                 status: approved
                 notes: ""
@@ -1740,6 +1868,7 @@ domains:
                 notes: REVIEW
                 req_id: SDN28
                 test_id: SDN28-01
+                actor: provider-dependent
                 legacy_ids: [SDN-XX-18]
                 status: pending
                 priority: ""
@@ -1758,6 +1887,7 @@ domains:
                   - "#281"
                 req_id: SDN02
                 test_id: SDN02-05
+                actor: tenant
                 status: published
               - summary: Verify security group rules can be scoped at node level
                 labels:
@@ -1771,6 +1901,7 @@ domains:
                   - "#282"
                 req_id: SDN02
                 test_id: SDN02-06
+                actor: tenant
                 status: published
               - summary: Verify security group rules can be scoped at subnet/tenant level
                 labels:
@@ -1784,6 +1915,7 @@ domains:
                   - "#283"
                 req_id: SDN02
                 test_id: SDN02-07
+                actor: tenant
                 status: published
               - summary: Measure and verify policy propagation timing is within acceptable bounds
                 labels:
@@ -1797,6 +1929,7 @@ domains:
                   - "#284"
                 req_id: SDN02
                 test_id: SDN02-08
+                actor: tenant
                 status: published
               - summary: Verify security group rules can be scoped at K8s API service level
                 labels:
@@ -1810,6 +1943,7 @@ domains:
                   - "#285"
                 req_id: SDN02
                 test_id: SDN02-09
+                actor: tenant
                 status: published
           - description: All-to-All Storage Routing
             tests:
@@ -1824,6 +1958,7 @@ domains:
                   - "#289"
                 req_id: SDN08
                 test_id: SDN08-01
+                actor: tenant
                 status: published
           - description: Port Security
             tests:
@@ -1839,6 +1974,7 @@ domains:
                   - "#286"
                 req_id: SDN02
                 test_id: SDN02-10
+                actor: tenant
                 status: published
           - description: Network Infrastructure Observability
             tests:
@@ -1853,6 +1989,7 @@ domains:
                   - "#290"
                 req_id: SDN09
                 test_id: SDN09-01
+                actor: tenant
                 status: published
               - summary: Verify logging captures latency/performance fluctuations
                 labels:
@@ -1865,6 +2002,7 @@ domains:
                   - "#291"
                 req_id: SDN09
                 test_id: SDN09-02
+                actor: tenant
                 status: published
               - summary: Verify a detailed audit trail exists for all configuration changes to network filtering rules
                 labels:
@@ -1878,6 +2016,7 @@ domains:
                   - "#292"
                 req_id: SDN09
                 test_id: SDN09-03
+                actor: tenant
                 status: published
       - name: Metadata Service
         capabilities:
@@ -1891,6 +2030,7 @@ domains:
                 milestone: M4
                 req_id: META01
                 test_id: META01-01
+                actor: provider-dependent
                 legacy_ids: [META-XX-01]
                 status: approved
                 notes: ""
@@ -1904,6 +2044,7 @@ domains:
                 milestone: M4
                 req_id: CTRL01
                 test_id: CTRL01-01
+                actor: tenant
                 legacy_ids: [CTRL-XX-01]
                 status: approved
                 notes: ""
@@ -1914,6 +2055,7 @@ domains:
                   - min_req
                 req_id: CAP02
                 test_id: CAP02-01
+                actor: tenant
                 status: approved
                 notes: ""
                 priority: P1
@@ -1927,6 +2069,7 @@ domains:
                   - min_req
                 req_id: CAP03
                 test_id: CAP03-01
+                actor: tenant
                 status: approved
                 notes: ""
                 priority: P1
@@ -1945,6 +2088,7 @@ domains:
                   - "#205"
                 req_id: CNP08
                 test_id: CNP08-05
+                actor: tenant
                 status: pending
       - name: Load Balancing
         capabilities:
@@ -1957,6 +2101,7 @@ domains:
                   - LimitedEnv
                 req_id: LB01
                 test_id: LB01-01
+                actor: tenant
                 legacy_ids: [LB-XX-01]
                 status: approved
                 notes: ""
@@ -1966,6 +2111,7 @@ domains:
                   - LimitedEnv
                 req_id: LB02
                 test_id: LB02-01
+                actor: tenant
                 legacy_ids: [LB-XX-02]
                 status: approved
                 notes: ""
@@ -1974,6 +2120,7 @@ domains:
               - summary: Verify that nodes can be marked as down or up (for rolling deployments/etc)
                 req_id: LB03
                 test_id: LB03-01
+                actor: tenant
                 legacy_ids: [LB-XX-03]
                 status: approved
                 notes: ""
@@ -1984,6 +2131,7 @@ domains:
                   - LimitedEnv
                 req_id: LB04
                 test_id: LB04-01
+                actor: tenant
                 legacy_ids: [LB-XX-04]
                 status: approved
                 notes: ""
@@ -2003,6 +2151,7 @@ domains:
                   - LimitedEnv
                 req_id: BFX04
                 test_id: BFX04-01
+                actor: tenant
                 legacy_ids: [BFX-XX-01]
                 status: approved
                 notes: ""
@@ -2017,6 +2166,7 @@ domains:
                   - LimitedEnv
                 req_id: BFX05
                 test_id: BFX05-01
+                actor: tenant
                 legacy_ids: [BFX-XX-02]
                 status: approved
                 notes: ""
@@ -2032,6 +2182,7 @@ domains:
                   - LimitedEnv
                 req_id: BFX06
                 test_id: BFX06-01
+                actor: tenant
                 legacy_ids: [BFX-XX-03]
                 status: approved
                 notes: ""
@@ -2053,6 +2204,7 @@ domains:
                   - "#206"
                 req_id: BFX01
                 test_id: BFX01-01
+                actor: both
                 status: pending
               - summary: Return an individual node to the provider for maintenance via the API
                 labels:
@@ -2066,6 +2218,7 @@ domains:
                   - "#207"
                 req_id: BFX01
                 test_id: BFX01-02
+                actor: both
                 status: pending
               - summary: Return a rack to the provider for maintenance via the API
                 labels:
@@ -2079,6 +2232,7 @@ domains:
                   - "#208"
                 req_id: BFX01
                 test_id: BFX01-03
+                actor: both
                 status: pending
               - summary: Cordon a node (mark unschedulable); verify no new workloads are placed; verify existing workloads continue
                 labels:
@@ -2092,6 +2246,7 @@ domains:
                   - "#209"
                 req_id: BFX01
                 test_id: BFX01-04
+                actor: tenant
                 status: pending
               - summary: Request a host replacement when health thresholds are breached; verify the node is removed from the pool
                 labels:
@@ -2105,6 +2260,7 @@ domains:
                   - "#210"
                 req_id: BFX01
                 test_id: BFX01-05
+                actor: both
                 status: pending
               - summary: Report an individual node to the provider for maintenance via the API
                 labels:
@@ -2118,6 +2274,7 @@ domains:
                   - "#610"
                 req_id: BFX01
                 test_id: BFX01-06
+                actor: both
                 status: pending
           - description: Breakfix Events Query
             tests:
@@ -2133,6 +2290,7 @@ domains:
                   - "#211"
                 req_id: BFX02
                 test_id: BFX02-01
+                actor: tenant
                 status: pending
               - summary: Query retirement notices for a node/rack
                 labels:
@@ -2146,6 +2304,7 @@ domains:
                   - "#212"
                 req_id: BFX02
                 test_id: BFX02-02
+                actor: tenant
                 status: pending
               - summary: Query historical repair status for a node
                 labels:
@@ -2159,6 +2318,7 @@ domains:
                   - "#213"
                 req_id: BFX02
                 test_id: BFX02-03
+                actor: tenant
                 status: pending
           - description: Breakfix Diagnostics
             tests:
@@ -2174,6 +2334,7 @@ domains:
                   - "#320"
                 req_id: BFX03
                 test_id: BFX03-01
+                actor: tenant
                 status: pending
               - summary: Inspect firmware versions of NV switch trays
                 labels:
@@ -2187,6 +2348,7 @@ domains:
                   - "#214"
                 req_id: BFX03
                 test_id: BFX03-02
+                actor: tenant
                 status: pending
               - summary: Query a node's log history through a telemetry endpoint
                 labels:
@@ -2200,6 +2362,7 @@ domains:
                   - "#215"
                 req_id: BFX03
                 test_id: BFX03-03
+                actor: tenant
                 status: pending
   - name: Data Services
     components:
@@ -2219,6 +2382,7 @@ domains:
                   - "#327"
                 req_id: HSS01
                 test_id: HSS01-01
+                actor: tenant
                 status: published
               - summary: Verify authentication to the storage management API with the configured credential (basic auth or bearer token)
                 labels:
@@ -2230,6 +2394,7 @@ domains:
                   - "#505"
                 req_id: HSS01
                 test_id: HSS01-02
+                actor: tenant
                 status: pending
               - summary: Verify the volume provisioning API provisions a volume of the requested size within NVIDIA's tenant
                 labels:
@@ -2241,6 +2406,7 @@ domains:
                   - "#506"
                 req_id: HSS01
                 test_id: HSS01-03
+                actor: tenant
                 status: pending
               - summary: Verify QoS — provisioned throughput meets requested minimum bandwidth and IOPS
                 labels:
@@ -2253,6 +2419,7 @@ domains:
                   - "#328"
                 req_id: HSS02
                 test_id: HSS02-01
+                actor: tenant
                 status: published
               - summary: Verify K8s CSI integration for storage
                 labels:
@@ -2264,6 +2431,7 @@ domains:
                   - "#329"
                 req_id: HSS03, K8S23
                 test_id: HSS03-01
+                actor: tenant
                 status: published
               - summary: Verify the CSI controller Deployment and node DaemonSet pods are running and healthy
                 labels:
@@ -2275,6 +2443,7 @@ domains:
                   - "#486"
                 req_id: HSS03
                 test_id: HSS03-02
+                actor: tenant
                 status: published
               - summary: Verify the CSIDriver object is registered for the NCP provisioner
                 labels:
@@ -2286,6 +2455,7 @@ domains:
                   - "#487"
                 req_id: HSS03
                 test_id: HSS03-03
+                actor: tenant
                 status: published
               - summary: Verify at least one StorageClass references the NCP CSI provisioner
                 labels:
@@ -2297,6 +2467,7 @@ domains:
                   - "#488"
                 req_id: HSS03
                 test_id: HSS03-04
+                actor: tenant
                 status: published
               - summary: Verify a PVC against the NCP StorageClass reaches Bound and creates a PV
                 labels:
@@ -2308,6 +2479,7 @@ domains:
                   - "#489"
                 req_id: HSS03, K8S23
                 test_id: HSS03-05
+                actor: tenant
                 status: published
               - summary: Verify the provisioned PV capacity is >= the PVC request
                 labels:
@@ -2319,6 +2491,7 @@ domains:
                   - "#490"
                 req_id: HSS03, K8S23
                 test_id: HSS03-06
+                actor: tenant
                 status: published
               - summary: Verify a pod can mount the PVC and read back data it wrote
                 labels:
@@ -2330,6 +2503,7 @@ domains:
                   - "#491"
                 req_id: HSS03, K8S23
                 test_id: HSS03-07
+                actor: tenant
                 status: published
               - summary: Verify multiple concurrent PVCs bind to distinct PVs
                 labels:
@@ -2341,6 +2515,7 @@ domains:
                   - "#492"
                 req_id: HSS03, K8S23
                 test_id: HSS03-08
+                actor: tenant
                 status: published
               - summary: Verify quota limits can be set on user workloads/volumes
                 labels:
@@ -2352,6 +2527,7 @@ domains:
                   - "#330"
                 req_id: HSS04
                 test_id: HSS04-01
+                actor: tenant
                 status: published
               - summary: Verify a functional API reports tenant-level storage utilization and quota
                 labels:
@@ -2363,6 +2539,7 @@ domains:
                   - "#507"
                 req_id: HSS04
                 test_id: HSS04-02
+                actor: tenant
                 status: pending
               - summary: Verify a functional API lists the quotas configured within the NVIDIA tenancy
                 labels:
@@ -2374,6 +2551,7 @@ domains:
                   - "#508"
                 req_id: HSS04
                 test_id: HSS04-03
+                actor: tenant
                 status: pending
               - summary: Verify a functional API returns utilization against a given quota by ID
                 labels:
@@ -2385,6 +2563,7 @@ domains:
                   - "#509"
                 req_id: HSS04
                 test_id: HSS04-04
+                actor: tenant
                 status: pending
               - summary: Verify reported quota consumption reflects data written to the filesystem
                 labels:
@@ -2396,6 +2575,7 @@ domains:
                   - "#510"
                 req_id: HSS04
                 test_id: HSS04-05
+                actor: tenant
                 status: pending
               - summary: Verify non-disruptive upgrades (NVIDIA can defer maintenance up to 2 weeks)
                 labels:
@@ -2408,11 +2588,13 @@ domains:
                   - "#331"
                 req_id: HSS05
                 test_id: HSS05-01
+                actor: both
                 status: published
               - summary: "Storage: Config/default/access to network provided storage"
                 notes: REVIEW
                 req_id: STOR01
                 test_id: STOR01-01
+                actor: tenant
                 legacy_ids: [STOR-XX-01]
                 status: pending
                 priority: ""
@@ -2430,6 +2612,7 @@ domains:
                   - "#326"
                 req_id: DIR02
                 test_id: DIR02-01
+                actor: tenant
                 status: pending
               - summary: Verify POSIX filesystem compliance via the applicable pjdfstest suites
                 labels:
@@ -2443,6 +2626,7 @@ domains:
                   - "#494"
                 req_id: DIR02
                 test_id: DIR02-02
+                actor: tenant
                 status: published
               - summary: Verify configurable filesystem-wide quota limits
                 labels:
@@ -2455,6 +2639,7 @@ domains:
                   - "#324"
                 req_id: DIR01
                 test_id: DIR01-01
+                actor: tenant
                 status: pending
               - summary: Verify usage accounting for uid/gids
                 labels:
@@ -2467,6 +2652,7 @@ domains:
                   - "#325"
                 req_id: DIR01
                 test_id: DIR01-02
+                actor: tenant
                 status: pending
           - description: Data Movement
             tests:
@@ -2480,6 +2666,7 @@ domains:
                   - "#263"
                 req_id: DMS01
                 test_id: DMS01-01
+                actor: provider-dependent
                 status: published
               - summary: Verify dedicated CPU nodes are available for data mover with high-performance networking
                 labels:
@@ -2491,6 +2678,7 @@ domains:
                   - "#264"
                 req_id: DMS02
                 test_id: DMS02-01
+                actor: tenant
                 status: published
               - summary: Verify the same filesystem mounted on GPU nodes is accessible from data mover nodes
                 labels:
@@ -2502,6 +2690,7 @@ domains:
                   - "#265"
                 req_id: DMS03
                 test_id: DMS03-01
+                actor: tenant
                 status: published
               - summary: Verify stable egress IP for allowlisting access to NVIDIA services
                 labels:
@@ -2514,6 +2703,7 @@ domains:
                   - "#266"
                 req_id: DMS05
                 test_id: DMS05-01
+                actor: tenant
                 status: published
           - description: DGXC-Managed Storage Deployment
             tests:
@@ -2530,6 +2720,7 @@ domains:
                   - "#358"
                 req_id: STG02
                 test_id: STG02-01
+                actor: tenant
                 status: pending
               - summary: Verify stable IP assignment for storage nodes across lifecycle operations
                 labels:
@@ -2544,6 +2735,7 @@ domains:
                   - "#359"
                 req_id: STG03
                 test_id: STG03-01
+                actor: tenant
                 status: pending
               - summary: Verify out-of-band failure detection (device, network, memory, drive)
                 labels:
@@ -2558,6 +2750,7 @@ domains:
                   - "#360"
                 req_id: STG04
                 test_id: STG04-01
+                actor: tenant
                 status: pending
               - summary: Verify topology observability — visibility into failure domains for physical diversity
                 labels:
@@ -2571,6 +2764,7 @@ domains:
                   - "#361"
                 req_id: STG05
                 test_id: STG05-01
+                actor: tenant
                 status: pending
           - description: Storage Security
             tests:
@@ -2586,6 +2780,7 @@ domains:
                   - "#296"
                 req_id: SEC04
                 test_id: SEC04-01
+                actor: tenant
                 status: published
               - summary: Verify multi-tenant isolation — quota listings contain only paths within the tenant's namespace
                 labels:
@@ -2598,6 +2793,7 @@ domains:
                   - "#511"
                 req_id: SEC04
                 test_id: SEC04-03
+                actor: tenant
                 status: pending
           - description: RDMA Memory Protection
             tests:
@@ -2612,6 +2808,7 @@ domains:
                   - "#332"
                 req_id: HSS06
                 test_id: HSS06-01
+                actor: tenant
                 status: published
       - name: Parallel File System Services
         capabilities:
@@ -2628,6 +2825,7 @@ domains:
                   - "#333"
                 req_id: HSS07
                 test_id: HSS07-01
+                actor: tenant
                 status: published
               - summary: Verify large-directory listing of 1,000,000 files and 500,000 subdirectories without error or truncation
                 labels:
@@ -2641,6 +2839,7 @@ domains:
                   - "#499"
                 req_id: HSS07
                 test_id: HSS07-02
+                actor: tenant
                 status: published
               - summary: "Verify multiple filesystems can exist within total capacity (minimum FS size <= 50 TiB)"
                 labels:
@@ -2653,6 +2852,7 @@ domains:
                   - "#334"
                 req_id: HSS09
                 test_id: HSS09-01
+                actor: tenant
                 status: published
               - summary: Verify live filesystem expansion (capacity, inodes, IO, metadata)
                 labels:
@@ -2665,6 +2865,7 @@ domains:
                   - "#335"
                 req_id: HSS10
                 test_id: HSS10-01
+                actor: tenant
                 status: published
               - summary: Verify PVC expansion grows PV capacity and pod-visible size (if supported)
                 labels:
@@ -2676,6 +2877,7 @@ domains:
                   - "#493"
                 req_id: HSS10
                 test_id: HSS10-02
+                actor: tenant
                 status: published
               - summary: Verify uid/gid/project-id soft and hard quotas with enforcement
                 labels:
@@ -2688,6 +2890,7 @@ domains:
                   - "#336"
                 req_id: HSS12
                 test_id: HSS12-01
+                actor: tenant
                 status: published
               - summary: Verify root-squash can be enabled and disabled at any time
                 labels:
@@ -2700,6 +2903,7 @@ domains:
                   - "#337"
                 req_id: HSS13
                 test_id: HSS13-01
+                actor: tenant
                 status: published
               - summary: Verify the filesystem can be mounted with flock
                 labels:
@@ -2712,6 +2916,7 @@ domains:
                   - "#338"
                 req_id: HSS14
                 test_id: HSS14-01
+                actor: tenant
                 status: published
               - summary: Verify flock() locking behavior is correct across pods on the same PVC
                 labels:
@@ -2724,6 +2929,7 @@ domains:
                   - "#495"
                 req_id: HSS14
                 test_id: HSS14-02
+                actor: tenant
                 status: published
               - summary: Verify changelog/audit data is accessible (tracking by uid/gid, file/dir operations)
                 labels:
@@ -2736,6 +2942,7 @@ domains:
                   - "#339"
                 req_id: HSS15
                 test_id: HSS15-01
+                actor: tenant
                 status: published
               - summary: Verify client multipathing to all storage servers
                 labels:
@@ -2748,6 +2955,7 @@ domains:
                   - "#340"
                 req_id: HSS18
                 test_id: HSS18-01
+                actor: tenant
                 status: published
               - summary: Verify a file written on one node is visible with correct content on another node within 1 second
                 labels:
@@ -2760,6 +2968,7 @@ domains:
                   - "#496"
                 req_id: HSS17
                 test_id: HSS17-01
+                actor: tenant
                 status: published
               - summary: Verify file size and mtime changes on one node are reflected on another within the attribute-cache window
                 labels:
@@ -2772,6 +2981,7 @@ domains:
                   - "#497"
                 req_id: HSS17
                 test_id: HSS17-02
+                actor: tenant
                 status: published
               - summary: Verify NFS mounts use the expected version (e.g. vers=4.1), nconnect value, transport protocol (proto=rdma or proto=tcp), and readahead tuning
                 labels:
@@ -2787,6 +2997,7 @@ domains:
                   - "#503"
                 req_id: HSS11
                 test_id: HSS11-01
+                actor: tenant
                 status: published
               - summary: Verify required vendor/DKMS kernel modules are installed on all GPU and CPU nodes
                 labels:
@@ -2799,6 +3010,7 @@ domains:
                   - "#504"
                 req_id: HSS11
                 test_id: HSS11-04
+                actor: tenant
                 status: published
       - name: Object Storage Service
         capabilities:
@@ -2816,6 +3028,7 @@ domains:
                   - "#262"
                 req_id: DATASVC01
                 test_id: DATASVC01-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-01]
                 status: published
       - name: Block Storage Services
@@ -2833,6 +3046,7 @@ domains:
                   - "#272"
                 req_id: K8S23
                 test_id: K8S23-01
+                actor: tenant
                 status: published
               - summary: Verify volume snapshots
                 labels:
@@ -2845,6 +3059,7 @@ domains:
                   - "#321"
                 req_id: DATASVC02
                 test_id: DATASVC02-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-02]
                 status: published
               - summary: Verify volume resizing
@@ -2858,6 +3073,7 @@ domains:
                   - "#322"
                 req_id: DATASVC03
                 test_id: DATASVC03-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-03]
                 status: published
               - summary: Verify persistent block volumes survive instance restarts
@@ -2871,6 +3087,7 @@ domains:
                   - "#323"
                 req_id: DATASVC04
                 test_id: DATASVC04-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-04]
                 status: published
       - name: Cache Services
@@ -2884,6 +3101,7 @@ domains:
                   - LimitedEnv
                 req_id: DATASVC05
                 test_id: DATASVC05-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-05]
                 status: pending
                 notes: ""
@@ -2899,6 +3117,7 @@ domains:
                   - LimitedEnv
                 req_id: DATASVC06
                 test_id: DATASVC06-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-06]
                 status: pending
                 notes: ""
@@ -2914,6 +3133,7 @@ domains:
                   - LimitedEnv
                 req_id: DATASVC07
                 test_id: DATASVC07-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-07]
                 status: pending
                 notes: ""
@@ -2930,6 +3150,7 @@ domains:
                 milestone: M4
                 req_id: DATASVC08
                 test_id: DATASVC08-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-08]
                 status: pending
                 notes: ""
@@ -2942,6 +3163,7 @@ domains:
                 priority: P2
                 req_id: DATASVC09
                 test_id: DATASVC09-01
+                actor: tenant
                 legacy_ids: [DATASVC-XX-09]
                 status: pending
                 notes: ""
@@ -2959,6 +3181,7 @@ domains:
                 milestone: M0
                 req_id: SLURM01
                 test_id: SLURM01-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-01]
                 status: published
               - summary: SlurmInfoAvailable
@@ -2969,6 +3192,7 @@ domains:
                 milestone: M0
                 req_id: SLURM02
                 test_id: SLURM02-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-02]
                 status: published
                 labels:
@@ -2981,6 +3205,7 @@ domains:
                 milestone: M0
                 req_id: SLURM03
                 test_id: SLURM03-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-03]
                 status: published
                 labels:
@@ -2993,6 +3218,7 @@ domains:
                 milestone: M0
                 req_id: SLURM04
                 test_id: SLURM04-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-04]
                 status: published
                 labels:
@@ -3005,6 +3231,7 @@ domains:
                 milestone: M0
                 req_id: SLURM05
                 test_id: SLURM05-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-05]
                 status: published
                 labels:
@@ -3017,6 +3244,7 @@ domains:
                 milestone: M0
                 req_id: SLURM06
                 test_id: SLURM06-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-06]
                 status: published
                 labels:
@@ -3029,6 +3257,7 @@ domains:
                 milestone: M0
                 req_id: SLURM07
                 test_id: SLURM07-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-07]
                 status: published
                 labels:
@@ -3044,6 +3273,7 @@ domains:
                 milestone: M0
                 req_id: SLURM08
                 test_id: SLURM08-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-08]
                 status: published
                 labels:
@@ -3059,6 +3289,7 @@ domains:
                 milestone: M0
                 req_id: SLURM09
                 test_id: SLURM09-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-09]
                 status: published
                 labels:
@@ -3073,6 +3304,7 @@ domains:
                 milestone: M0
                 req_id: SLURM10
                 test_id: SLURM10-01
+                actor: tenant
                 legacy_ids: [SLURM-XX-10]
                 status: published
       - name: Managed Kubernetes Control Plane
@@ -3080,7 +3312,7 @@ domains:
           - description: Tenant-isolated Kubernetes control planes for managing k8s workloads. does placement, networking, lifecyle mgmt.
             example: AWS EKS, GCP GKE
             tests:
-              - summary: Create a K8s Instance using the software platform (CLI, Terraform)
+              - summary: Create a K8s Instance using the software platform API/CLI
                 labels:
                   - kubernetes
                   - min_req
@@ -3091,22 +3323,25 @@ domains:
                 milestone: M0
                 req_id: K8S05
                 test_id: K8S05-01
+                actor: tenant
                 status: published
           - description: Full lifecycle management
             tests:
-              - summary: Run through all the steps of the k8s lifecycle management, including user-initated CP update
+              - summary: As a tenant, exercise the complete managed Kubernetes control plane lifecycle through the tenant-facing API/CLI, including requesting a supported control plane version update and observing provider-reported status through completion.
                 labels:
                   - min_req
                 milestone: M4
                 req_id: K8S38
                 test_id: K8S38-01
+                actor: both
                 legacy_ids: [K8S-XX-01]
                 status: approved
-                notes: ""
+                notes: "Cross-role: the tenant requests lifecycle operations; the platform operator executes the managed control plane update. Application continuity is tested separately by K8S09-01."
                 priority: ""
               - summary: The control plane should automatically add more capacity when load increases
                 req_id: K8S41
                 test_id: K8S41-01
+                actor: both
                 legacy_ids: [SEC23-01]
                 status: pending
                 notes: ""
@@ -3117,6 +3352,7 @@ domains:
                   - min_req
                 req_id: K8S27
                 test_id: K8S27-01
+                actor: tenant
                 status: pending
                 notes: ""
                 priority: P2
@@ -3131,6 +3367,7 @@ domains:
                 milestone: M4
                 req_id: K8S14
                 test_id: K8S14-01
+                actor: both
                 status: approved
                 notes: ""
                 priority: ""
@@ -3144,6 +3381,7 @@ domains:
                 milestone: M0
                 req_id: K8S39
                 test_id: K8S39-01
+                actor: tenant
                 legacy_ids: [K8S-XX-02]
                 status: published
               - summary: K8s Nim Inference
@@ -3154,6 +3392,7 @@ domains:
                 milestone: M0
                 req_id: K8S40
                 test_id: K8S40-01
+                actor: tenant
                 legacy_ids: [K8S-XX-03]
                 status: published
                 labels:
@@ -3169,6 +3408,7 @@ domains:
                 milestone: M0
                 req_id: K8S32
                 test_id: K8S32-01
+                actor: tenant
                 legacy_ids: [K8S-XX-04]
                 status: published
                 labels:
@@ -3188,6 +3428,7 @@ domains:
                 priority: P0
                 req_id: K8S33
                 test_id: K8S33-01
+                actor: tenant
                 legacy_ids: [K8S-XX-05]
                 status: approved
                 notes: ""
@@ -3200,6 +3441,7 @@ domains:
                 notes: k8s05
                 req_id: K8S34
                 test_id: K8S34-01
+                actor: tenant
                 legacy_ids: [K8S-XX-06]
                 status: approved
                 priority: P0
@@ -3212,6 +3454,7 @@ domains:
                 notes: k8s06/22
                 req_id: K8S24
                 test_id: K8S24-01
+                actor: tenant
                 status: approved
                 priority: P0
                 milestone: ""
@@ -3226,6 +3469,7 @@ domains:
                 notes: k8s01
                 req_id: K8S01
                 test_id: K8S01-01
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -3238,6 +3482,7 @@ domains:
                   - min_req
                 req_id: K8S17
                 test_id: K8S17-01
+                actor: tenant
                 status: approved
                 notes: ""
                 priority: ""
@@ -3251,6 +3496,7 @@ domains:
                 notes: k8s19
                 req_id: K8S21
                 test_id: K8S21-01
+                actor: tenant
                 status: published
                 priority: P1
                 github_issues:
@@ -3264,6 +3510,7 @@ domains:
                 notes: K8s16
                 req_id: K8S35
                 test_id: K8S35-01
+                actor: tenant
                 legacy_ids: [K8S-XX-07]
                 status: approved
                 priority: P1
@@ -3277,6 +3524,7 @@ domains:
                 notes: K8s20
                 req_id: K8S22
                 test_id: K8S22-01
+                actor: tenant
                 status: published
                 priority: P0
                 github_issues:
@@ -3290,6 +3538,7 @@ domains:
                 notes: K8s21
                 req_id: K8S23
                 test_id: K8S23-02
+                actor: tenant
                 status: approved
                 priority: ""
                 milestone: ""
@@ -3299,6 +3548,7 @@ domains:
                 notes: K8s21
                 req_id: K8S23
                 test_id: K8S23-03
+                actor: tenant
                 status: approved
                 priority: ""
                 milestone: ""
@@ -3314,6 +3564,7 @@ domains:
                   - "#273"
                 req_id: K8S23
                 test_id: K8S23-04
+                actor: tenant
                 status: published
               - summary: Verify CSI supports both static and dynamic provisioning via PVs and PVCs
                 labels:
@@ -3327,6 +3578,7 @@ domains:
                   - "#274"
                 req_id: K8S23
                 test_id: K8S23-05
+                actor: tenant
                 status: published
               - summary: Verify CSI credentials are tenant cluster scoped (no cross-cluster access)
                 labels:
@@ -3340,6 +3592,7 @@ domains:
                   - "#275"
                 req_id: K8S23
                 test_id: K8S23-06
+                actor: tenant
                 status: published
               - summary: Verify APIs to query storage usage against overall cluster quota with per-PVC/Volume breakdown
                 labels:
@@ -3353,6 +3606,7 @@ domains:
                   - "#276"
                 req_id: K8S23
                 test_id: K8S23-07
+                actor: tenant
                 status: published
           - description: NVIDIA Operator support
             tests:
@@ -3363,6 +3617,7 @@ domains:
                 notes: K8S23
                 req_id: K8S25
                 test_id: K8S25-01
+                actor: tenant
                 status: approved
                 priority: P0
                 milestone: ""
@@ -3372,6 +3627,7 @@ domains:
                 notes: ""
                 req_id: K8S25
                 test_id: K8S25-02
+                actor: both
                 status: pending
                 priority: P0
                 milestone: M5
@@ -3388,6 +3644,7 @@ domains:
                 github_issues: []
                 req_id: K8S02
                 test_id: K8S02-01
+                actor: tenant
                 status: pending
               - summary: Verify automated control plane security patching with no/minimal downtime
                 labels:
@@ -3398,6 +3655,7 @@ domains:
                 github_issues: []
                 req_id: K8S02
                 test_id: K8S02-02
+                actor: operator
                 status: pending
           - description: Zero-Downtime Upgrades
             tests:
@@ -3410,6 +3668,7 @@ domains:
                 github_issues: []
                 req_id: K8S09
                 test_id: K8S09-01
+                actor: tenant
                 status: pending
               - summary: Perform a rolling node upgrade and verify disruption budgets are respected
                 labels:
@@ -3420,6 +3679,7 @@ domains:
                 github_issues: []
                 req_id: K8S10
                 test_id: K8S10-01
+                actor: tenant
                 status: pending
           - description: HA Control Plane
             tests:
@@ -3432,6 +3692,7 @@ domains:
                 github_issues: []
                 req_id: K8S11
                 test_id: K8S11-01
+                actor: operator
                 status: pending
           - description: "Backup & Disaster Recovery"
             tests:
@@ -3444,6 +3705,7 @@ domains:
                 github_issues: []
                 req_id: K8S12
                 test_id: K8S12-01
+                actor: operator
                 status: pending
           - description: K8s Access Controls
             tests:
@@ -3458,6 +3720,7 @@ domains:
                   - "#271"
                 req_id: K8S15
                 test_id: K8S15-01
+                actor: tenant
                 status: published
           - description: K8s Encryption
             tests:
@@ -3470,6 +3733,7 @@ domains:
                 github_issues: []
                 req_id: K8S19
                 test_id: K8S19-01
+                actor: operator
                 status: pending
           - description: Certificate Management
             tests:
@@ -3484,6 +3748,7 @@ domains:
                   - "#301"
                 req_id: SEC09
                 test_id: SEC09-01
+                actor: operator
                 status: published
               - summary: Verify support for both provider-managed and customer-managed keys
                 labels:
@@ -3496,6 +3761,7 @@ domains:
                   - "#302"
                 req_id: SEC09
                 test_id: SEC09-02
+                actor: both
                 status: published
           - description: Autoscaling
             tests:
@@ -3510,6 +3776,7 @@ domains:
                   - "#267"
                 req_id: K8S36
                 test_id: K8S36-01
+                actor: tenant
                 legacy_ids: [K8S-XX-08]
                 status: published
           - description: Kubernetes Security Response
@@ -3523,6 +3790,7 @@ domains:
                 github_issues: []
                 req_id: K8S04
                 test_id: K8S04-01
+                actor: operator
                 status: pending
           - description: Node Pool Lifecycle Management
             tests:
@@ -3539,6 +3807,7 @@ domains:
                   - "#221"
                 req_id: K8S06
                 test_id: K8S06-01
+                actor: tenant
                 status: published
               - summary: Update a K8s node pool (e.g., scale to a target count)
                 labels:
@@ -3553,6 +3822,7 @@ domains:
                   - "#222"
                 req_id: K8S06
                 test_id: K8S06-02
+                actor: tenant
                 status: published
               - summary: Delete a K8s node pool
                 labels:
@@ -3566,6 +3836,7 @@ domains:
                   - "#223"
                 req_id: K8S06
                 test_id: K8S06-03
+                actor: tenant
                 status: published
               - summary: Verify default node labels and taints can be specified when a node joins the cluster via node pool
                 labels:
@@ -3577,6 +3848,7 @@ domains:
                   - "#224"
                 req_id: K8S06
                 test_id: K8S06-04
+                actor: tenant
                 status: published
           - description: API Server Metrics
             tests:
@@ -3591,6 +3863,7 @@ domains:
                   - "#225"
                 req_id: K8S07
                 test_id: K8S07-01
+                actor: both
                 status: published
           - description: Public OIDC Endpoint
             tests:
@@ -3605,6 +3878,7 @@ domains:
                   - "#226"
                 req_id: K8S17
                 test_id: K8S17-02
+                actor: tenant
                 legacy_ids: [K8S18-01]
                 status: published
           - description: K8s Control Plane Logging
@@ -3620,26 +3894,29 @@ domains:
                   - "#227"
                 req_id: K8S20
                 test_id: K8S20-01
+                actor: both
                 status: published
           - description: K8s Performance
             tests:
-              - summary: Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size
+              - summary: Verify the managed Kubernetes service meets standard Kubernetes performance and control plane SLO targets at up to 5,000 nodes or the provider's declared maximum cluster size, whichever is smaller
                 labels:
                   - min_req
                 priority: P0
                 milestone: M5
-                notes: ""
+                notes: "Consolidates the duplicate reference requirement and former test K8S37-01 into the canonical offtake K8S28 requirement."
                 github_issues:
                   - "#268"
-                req_id: K8S37
-                test_id: K8S37-01
-                legacy_ids: [K8S-XX-09]
+                req_id: K8S28
+                test_id: K8S28-01
+                actor: tenant
+                legacy_ids: [K8S-XX-09, K8S37-01]
                 status: pending
           - description: Multi-Cluster Support
             tests:
               - summary: Support multiple clusters in the same tenancy and in the same VPC
                 req_id: K8S26
                 test_id: K8S26-01
+                actor: tenant
                 labels:
                   - kubernetes
                   - min_req
@@ -3660,6 +3937,7 @@ domains:
                   - MiniCloud
                 req_id: POWER01
                 test_id: POWER01-01
+                actor: operator
                 legacy_ids: [POWER-XX-01]
                 status: approved
                 notes: ""
@@ -3675,6 +3953,7 @@ domains:
                 priority: P2
                 req_id: APIGW01
                 test_id: APIGW01-01
+                actor: tenant
                 legacy_ids: [APIGW-XX-01]
                 status: approved
                 notes: ""
@@ -3687,6 +3966,7 @@ domains:
                 priority: P2
                 req_id: AICP01
                 test_id: AICP01-01
+                actor: tenant
                 legacy_ids: [AICP-XX-01]
                 status: approved
                 notes: ""
@@ -3702,6 +3982,7 @@ domains:
                 milestone: M5
                 req_id: WEBUI01
                 test_id: WEBUI01-01
+                actor: tenant
                 legacy_ids: [WEBUI-XX-01]
                 status: approved
                 notes: ""
@@ -3719,6 +4000,7 @@ domains:
                 milestone: M0
                 req_id: OBS01
                 test_id: OBS01-01
+                actor: both
                 legacy_ids: [OBS-XX-01]
                 status: published
               - summary: Logging information about the control plane is available
@@ -3729,6 +4011,7 @@ domains:
                 milestone: M0
                 req_id: OBS02
                 test_id: OBS02-01
+                actor: both
                 legacy_ids: [OBS-XX-02]
                 status: published
               - summary: Logging information from instances
@@ -3739,6 +4022,7 @@ domains:
                 milestone: M0
                 req_id: OBS03
                 test_id: OBS03-01
+                actor: both
                 legacy_ids: [OBS-XX-03]
                 status: published
               - summary: Alerts can be issued by the system in case of problems
@@ -3749,6 +4033,7 @@ domains:
                 milestone: M0
                 req_id: OBS04
                 test_id: OBS04-01
+                actor: both
                 legacy_ids: [OBS-XX-04]
                 status: published
           - description: Telemetry Delivery
@@ -3764,6 +4049,7 @@ domains:
                   - "#342"
                 req_id: OBS05
                 test_id: OBS05-01
+                actor: both
                 legacy_ids: [OBS-XX-05]
                 status: published
           - description: Network Telemetry
@@ -3780,6 +4066,7 @@ domains:
                   - "#343"
                 req_id: OBS06
                 test_id: OBS06-01
+                actor: both
                 legacy_ids: [OBS-XX-06]
                 status: published
               - summary: Verify telemetry is available for East-West (back-end / GPU interconnect) network
@@ -3794,6 +4081,7 @@ domains:
                   - "#344"
                 req_id: OBS07
                 test_id: OBS07-01
+                actor: both
                 legacy_ids: [OBS-XX-07]
                 status: published
               - summary: Verify telemetry is available for Management network
@@ -3808,6 +4096,7 @@ domains:
                   - "#345"
                 req_id: OBS08
                 test_id: OBS08-01
+                actor: both
                 legacy_ids: [OBS-XX-08]
                 status: published
               - summary: Verify telemetry is available for NVSwitch Fabric (GB200+)
@@ -3822,6 +4111,7 @@ domains:
                   - "#346"
                 req_id: OBS09
                 test_id: OBS09-01
+                actor: both
                 legacy_ids: [OBS-XX-09]
                 status: published
               - summary: Verify telemetry is available for Host network (NIC-level)
@@ -3836,6 +4126,7 @@ domains:
                   - "#347"
                 req_id: OBS10
                 test_id: OBS10-01
+                actor: both
                 legacy_ids: [OBS-XX-10]
                 status: published
           - description: Required Logs
@@ -3851,6 +4142,7 @@ domains:
                   - "#348"
                 req_id: OBS11
                 test_id: OBS11-01
+                actor: both
                 legacy_ids: [OBS-XX-11]
                 status: published
               - summary: Verify Subnet Manager logs are available (where applicable)
@@ -3864,6 +4156,7 @@ domains:
                   - "#349"
                 req_id: OBS12
                 test_id: OBS12-01
+                actor: both
                 legacy_ids: [OBS-XX-12]
                 status: published
               - summary: Verify UFM Event logs are available
@@ -3877,6 +4170,7 @@ domains:
                   - "#350"
                 req_id: OBS13
                 test_id: OBS13-01
+                actor: both
                 legacy_ids: [OBS-XX-13]
                 status: published
               - summary: Verify general switch logs are available
@@ -3891,6 +4185,7 @@ domains:
                   - "#351"
                 req_id: OBS14
                 test_id: OBS14-01
+                actor: both
                 legacy_ids: [OBS-XX-14]
                 status: published
               - summary: Verify switch syslogs are available
@@ -3905,6 +4200,7 @@ domains:
                   - "#352"
                 req_id: OBS15
                 test_id: OBS15-01
+                actor: both
                 legacy_ids: [OBS-XX-15]
                 status: published
               - summary: Verify switch kernel logs are available
@@ -3919,6 +4215,7 @@ domains:
                   - "#353"
                 req_id: OBS16
                 test_id: OBS16-01
+                actor: both
                 legacy_ids: [OBS-XX-16]
                 status: published
               - summary: Verify BMC SEL logs are available
@@ -3933,6 +4230,7 @@ domains:
                   - "#354"
                 req_id: OBS17
                 test_id: OBS17-01
+                actor: both
                 legacy_ids: [OBS-XX-17]
                 status: published
               - summary: Verify host syslogs are available
@@ -3947,6 +4245,7 @@ domains:
                   - "#355"
                 req_id: OBS18
                 test_id: OBS18-01
+                actor: both
                 legacy_ids: [OBS-XX-18]
                 status: published
               - summary: Verify VPC Flow logs (all ingress/egress traffic) are available
@@ -3961,6 +4260,7 @@ domains:
                   - "#356"
                 req_id: OBS19
                 test_id: OBS19-01
+                actor: both
                 legacy_ids: [OBS-XX-19]
                 status: published
       - name: Telemetry / Data Lakes
@@ -3973,6 +4273,7 @@ domains:
                   - LimitedEnv
                 req_id: TELEM01
                 test_id: TELEM01-01
+                actor: both
                 legacy_ids: [TELEM-XX-01]
                 status: approved
                 notes: ""
@@ -3989,6 +4290,7 @@ domains:
                   - "#120"
                 req_id: TELEM02
                 test_id: TELEM02-01
+                actor: tenant
                 legacy_ids: [TELEM-XX-02]
                 status: published
               - summary: Read only access to a VM serial console
@@ -4003,6 +4305,7 @@ domains:
                   - "#121"
                 req_id: TELEM03
                 test_id: TELEM03-01
+                actor: tenant
                 legacy_ids: [TELEM-XX-03]
                 status: published
           - description: BMC/Redfish Telemetry
@@ -4020,6 +4323,7 @@ domains:
                   - "#362"
                 req_id: TELEM04
                 test_id: TELEM04-01
+                actor: both
                 legacy_ids: [TELEM-XX-04]
                 status: published
           - description: Storage Telemetry
@@ -4035,6 +4339,7 @@ domains:
                   - "#363"
                 req_id: TELEM05
                 test_id: TELEM05-01
+                actor: both
                 legacy_ids: [TELEM-XX-05]
                 status: approved
               - summary: Verify storage performance metrics are available (bandwidth, IOPS, latency)
@@ -4048,6 +4353,7 @@ domains:
                   - "#364"
                 req_id: TELEM06
                 test_id: TELEM06-01
+                actor: both
                 legacy_ids: [TELEM-XX-06]
                 status: approved
           - description: NVLink Switch Telemetry
@@ -4063,6 +4369,7 @@ domains:
                   - "#365"
                 req_id: TELEM07
                 test_id: TELEM07-01
+                actor: both
                 legacy_ids: [TELEM-XX-07]
                 status: approved
               - summary: Verify NVLink metrics are available from the switch perspective (port-level counters, error rates)
@@ -4076,6 +4383,7 @@ domains:
                   - "#366"
                 req_id: TELEM08
                 test_id: TELEM08-01
+                actor: both
                 legacy_ids: [TELEM-XX-08]
                 status: approved
   - name: "Security & Identity"
@@ -4096,6 +4404,7 @@ domains:
                   - "#306"
                 req_id: SEC12
                 test_id: SEC12-01
+                actor: operator
                 status: published
               - summary: Verify BMC interfaces are not reachable from tenant networks
                 labels:
@@ -4109,6 +4418,7 @@ domains:
                   - "#307"
                 req_id: SEC12
                 test_id: SEC12-02
+                actor: tenant
                 status: published
               - summary: Verify IPMI is disabled; Redfish over TLS is used with AAA
                 labels:
@@ -4122,6 +4432,7 @@ domains:
                   - "#260"
                 req_id: CNP10
                 test_id: CNP10-01
+                actor: operator
                 status: published
               - summary: Verify BMC is only accessible via a hardened bastion (jumphost) server; direct public/corporate network access is blocked
                 labels:
@@ -4135,6 +4446,7 @@ domains:
                   - "#308"
                 req_id: SEC12
                 test_id: SEC12-03
+                actor: operator
                 status: published
           - description: Network Traffic Encryption
             tests:
@@ -4150,6 +4462,7 @@ domains:
                   - "#309"
                 req_id: SEC13
                 test_id: SEC13-01
+                actor: tenant
                 status: pending
           - description: Edge Security
             tests:
@@ -4165,6 +4478,7 @@ domains:
                   - "#311"
                 req_id: SEC14
                 test_id: SEC14-01
+                actor: both
                 status: published
               - summary: Verify insecure protocols (HTTP, SSLv3, TLSv1) are disabled
                 labels:
@@ -4178,6 +4492,7 @@ domains:
                   - "#310"
                 req_id: SEC13
                 test_id: SEC13-02
+                actor: tenant
                 status: published
           - description: InfiniBand Security
             tests:
@@ -4195,6 +4510,7 @@ domains:
                   - "#287"
                 req_id: SDN04
                 test_id: SDN04-04
+                actor: operator
                 status: published
               - summary: "Verify IB keys are configured: P_Key, Management Key, Aggregation Management Key, VendorSpecific Key, CongestionControl Key, Node2Node Key, Manager2Node Key"
                 labels:
@@ -4210,12 +4526,14 @@ domains:
                   - "#288"
                 req_id: SDN04
                 test_id: SDN04-05
+                actor: operator
                 status: published
           - description: Tenancy Isolation
             tests:
               - summary: Verify hard physical or logical isolation between tenants for network, data, compute, and storage resources
                 req_id: SEC11
                 test_id: SEC11-01
+                actor: tenant
                 labels:
                   - iam
                   - min_req
@@ -4243,6 +4561,7 @@ domains:
                   - "#293"
                 req_id: SEC01
                 test_id: SEC01-01
+                actor: tenant
                 status: published
           - description: In-Cluster Authentication
             tests:
@@ -4258,6 +4577,7 @@ domains:
                   - "#294"
                 req_id: SEC06
                 test_id: SEC06-01
+                actor: tenant
                 legacy_ids: [SEC02-01]
                 status: published
           - description: External Service Authentication
@@ -4274,6 +4594,7 @@ domains:
                   - "#295"
                 req_id: SEC03
                 test_id: SEC03-01
+                actor: tenant
                 status: published
           - description: Admin Interface Security
             tests:
@@ -4289,6 +4610,7 @@ domains:
                   - "#298"
                 req_id: SEC07
                 test_id: SEC07-01
+                actor: operator
                 status: published
       - name: Authorization
         capabilities:
@@ -4306,6 +4628,7 @@ domains:
                   - "#297"
                 req_id: SEC04
                 test_id: SEC04-02
+                actor: tenant
                 status: published
       - name: "Audit & Logging"
         capabilities:
@@ -4322,6 +4645,7 @@ domains:
                   - "#299"
                 req_id: SEC08
                 test_id: SEC08-01
+                actor: operator
                 status: published
               - summary: Verify audit logs are retained for at least 30 days
                 labels:
@@ -4334,6 +4658,7 @@ domains:
                   - "#300"
                 req_id: SEC08
                 test_id: SEC08-02
+                actor: operator
                 status: published
       - name: "Hardware Security & Compliance"
         capabilities:
@@ -4352,6 +4677,7 @@ domains:
                   - "#312"
                 req_id: SEC21
                 test_id: SEC21-04
+                actor: operator
                 status: published
               - summary: Verify SRAM/GPU memory is sanitized between tenants
                 labels:
@@ -4367,6 +4693,7 @@ domains:
                   - "#313"
                 req_id: SEC21
                 test_id: SEC21-05
+                actor: operator
                 status: published
               - summary: Verify TPM and BIOS are reset during tenant transitions or hardware replacement
                 labels:
@@ -4382,6 +4709,7 @@ domains:
                   - "#314"
                 req_id: SEC21, SEC22
                 test_id: SEC21-06
+                actor: operator
                 status: published
           - description: At-Rest Encryption
             tests:
@@ -4394,6 +4722,7 @@ domains:
                 github_issues: []
                 req_id: SEC20
                 test_id: SEC20-01
+                actor: operator
                 status: pending
           - description: Key Management
             tests:
@@ -4408,6 +4737,7 @@ domains:
                   - "#303"
                 req_id: SEC09, SEC10
                 test_id: SEC09-03
+                actor: operator
                 status: published
               - summary: Verify support for Customer Managed Keys (BYOK)
                 labels:
@@ -4422,6 +4752,7 @@ domains:
                   - "#304"
                 req_id: SEC09
                 test_id: SEC09-04
+                actor: tenant
                 status: published
   - name: Network Transport
     components:
@@ -4440,6 +4771,7 @@ domains:
                   - "#278"
                 req_id: NET01
                 test_id: NET01-01
+                actor: tenant
                 status: published
       - name: NVLink Domain API
         capabilities:
@@ -4456,6 +4788,7 @@ domains:
                   - "#279"
                 req_id: NET02
                 test_id: NET02-02
+                actor: tenant
                 status: published
       - name: Transport Connectivity
         capabilities:
@@ -4471,6 +4804,7 @@ domains:
                   - "#280"
                 req_id: NET04
                 test_id: NET04-01
+                actor: tenant
                 status: pending
           - description: DGXC Storage Interconnect
             tests:
@@ -4483,6 +4817,7 @@ domains:
                 github_issues: []
                 req_id: NET05
                 test_id: NET05-01
+                actor: tenant
                 status: pending
               - summary: Verify end-to-end MACsec encryption (fail-closed)
                 labels:
@@ -4493,6 +4828,7 @@ domains:
                 github_issues: []
                 req_id: NET05
                 test_id: NET05-02
+                actor: both
                 status: pending
           - description: Cluster Internet Access
             tests:
@@ -4505,6 +4841,7 @@ domains:
                 github_issues: []
                 req_id: NET06
                 test_id: NET06-01
+                actor: tenant
                 status: pending
               - summary: Verify redundant upstream paths for internet connectivity
                 labels:
@@ -4515,6 +4852,7 @@ domains:
                 github_issues: []
                 req_id: NET06
                 test_id: NET06-02
+                actor: operator
                 status: pending
   - name: "Capacity & Fleet Management"
     components:
@@ -4534,6 +4872,7 @@ domains:
                   - "#251"
                 req_id: CAP01
                 test_id: CAP01-01
+                actor: tenant
                 status: published
       - name: Capacity Reservations
         capabilities:
@@ -4552,6 +4891,7 @@ domains:
                   - "#252"
                 req_id: CAP04
                 test_id: CAP04-01
+                actor: tenant
                 status: published
               - summary: Verify atomic allocation of a topology block as a single unit
                 labels:
@@ -4566,6 +4906,7 @@ domains:
                   - "#253"
                 req_id: CAP04
                 test_id: CAP04-02
+                actor: tenant
                 status: published
       - name: Unified Health APIs
         capabilities:
@@ -4583,6 +4924,7 @@ domains:
                   - "#254"
                 req_id: CAP05
                 test_id: CAP05-01
+                actor: tenant
                 status: published
               - summary: Verify primitive-level health aggregation (cluster, nodegroup, or reservation level)
                 labels:
@@ -4596,6 +4938,7 @@ domains:
                   - "#255"
                 req_id: CAP05
                 test_id: CAP05-02
+                actor: tenant
                 status: published
   - name: Benchmarking
     components:
@@ -4608,6 +4951,7 @@ domains:
                   - min_req
                 req_id: BM01
                 test_id: BM01-01
+                actor: tenant
                 status: pending
                 notes: ""
                 priority: ""
@@ -4616,6 +4960,7 @@ domains:
                 notes: REVIEW
                 req_id: BENCH01
                 test_id: BENCH01-01
+                actor: provider-dependent
                 legacy_ids: [BENCH-XX-01]
                 status: pending
                 priority: P2
@@ -4624,6 +4969,7 @@ domains:
                 notes: REVIEW
                 req_id: BENCH02
                 test_id: BENCH02-01
+                actor: provider-dependent
                 legacy_ids: [BENCH-XX-02]
                 status: pending
                 priority: ""
@@ -4638,4 +4984,5 @@ domains:
                   - "#249"
                 req_id: BM01
                 test_id: BM01-02
+                actor: tenant
                 status: published

--- a/scripts/reqtrace.py
+++ b/scripts/reqtrace.py
@@ -49,6 +49,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TEST_PLAN = REPO_ROOT / "docs" / "test-plan.yaml"
 REQ_DIR = REPO_ROOT / "docs" / "requirements"
 MATRIX_DOC = REQ_DIR / "test-requirements-matrix.yaml"
+VALID_ACTORS = {"tenant", "operator", "both", "provider-dependent"}
 
 
 def _load(path: Path) -> Any:
@@ -68,6 +69,21 @@ def load_plan_test_ids(path: Path) -> set[str]:
                     if tid:
                         ids.add(tid)
     return ids
+
+
+def plan_actor_errors(path: Path) -> list[str]:
+    """Require one canonical actor classification on every test-plan entry."""
+    errors: list[str] = []
+    data = _load(path)
+    for domain in data.get("domains", []):
+        for comp in domain.get("components", []):
+            for cap in comp.get("capabilities", []):
+                for test in cap.get("tests", []):
+                    tid = test.get("test_id", "<no test_id>")
+                    actor = test.get("actor")
+                    if not isinstance(actor, str) or actor not in VALID_ACTORS:
+                        errors.append(f"test {tid!r}: actor must be one of {sorted(VALID_ACTORS)}, got {actor!r}")
+    return errors
 
 
 def discover_source_files() -> list[tuple[str, Path]]:
@@ -186,6 +202,7 @@ def validate() -> int:
     warnings: list[str] = []
 
     plan_ids = load_plan_test_ids(TEST_PLAN)
+    errors.extend(plan_actor_errors(TEST_PLAN))
     source_files = discover_source_files()
     if not source_files:
         errors.append("no source requirement listings found in docs/requirements/")

--- a/scripts/test_plan_yaml_to_adoc.py
+++ b/scripts/test_plan_yaml_to_adoc.py
@@ -39,6 +39,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Constraint shared by `labels` and `dependencies` entries: identifier-like only.
 LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 ISSUE_REF_RE = re.compile(r"#(\d+)")
+VALID_ACTORS = {"tenant", "operator", "both", "provider-dependent"}
 
 
 # ---------------------------------------------------------------------------
@@ -119,7 +120,7 @@ def _validate_string_list(field_name: str, values: Any, test_id: str, errors: li
 
 
 def validate_test_plan(data: dict[str, Any]) -> None:
-    """Walk every test and verify `labels` and `dependencies` are well-formed.
+    """Walk every test and verify actor and list metadata are well-formed.
 
     Raises ``SystemExit`` with a list of all problems found, so a single run
     surfaces every issue instead of failing on the first.
@@ -130,6 +131,9 @@ def validate_test_plan(data: dict[str, Any]) -> None:
             for cap in comp.get("capabilities", []):
                 for t in cap.get("tests", []):
                     tid = t.get("test_id", "<no test_id>")
+                    actor = t.get("actor")
+                    if not isinstance(actor, str) or actor not in VALID_ACTORS:
+                        errors.append(f"{tid}: actor must be one of {sorted(VALID_ACTORS)}, got {actor!r}")
                     _validate_string_list("labels", t.get("labels"), tid, errors)
                     _validate_string_list("dependencies", t.get("dependencies"), tid, errors)
                     for entry in t.get("github_issues") or []:
@@ -156,9 +160,9 @@ def generate_adoc(data: dict[str, Any], outfile: str) -> None:
         ":toc:",
         ":max-width: none",
         "",
-        '[cols="2,2,5,2,2,1,1,1,1,1,3,1,1,1,6,1,4",options="header"]',
+        '[cols="2,2,5,2,2,1,1,1,1,1,1,3,1,1,1,6,1,4",options="header"]',
         "|===",
-        "| Test Domain | Function | Description | Example | Test ID | Req ID | GH | Labels | Notes | Priority | Issues | Dependencies | Milestone | Release | Test Cases | Status | Justification",
+        "| Test Domain | Function | Description | Example | Test ID | Req ID | GH | Labels | Actor | Notes | Priority | Issues | Dependencies | Milestone | Release | Test Cases | Status | Justification",
         "",
     ]
 
@@ -202,6 +206,7 @@ def generate_adoc(data: dict[str, Any], outfile: str) -> None:
                             first_gh_link = f"https://github.com/{GH_REPO}/issues/{num}[#{num}]"
                     parts.append(cell(first_gh_link))
                     parts.append(cell(fmt_list(test.get("labels", []))))
+                    parts.append(cell(esc_adoc(test.get("actor", ""))))
                     parts.append(cell(esc_adoc(test.get("notes", ""))))
                     parts.append(cell(esc_adoc(test.get("priority", ""))))
                     parts.append(acell(fmt_gh_issues_adoc(test.get("github_issues", []))))

--- a/scripts/tests/test_reqtrace.py
+++ b/scripts/tests/test_reqtrace.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import yaml
+
 _SCRIPT = Path(__file__).resolve().parent.parent / "reqtrace.py"
 _spec = importlib.util.spec_from_file_location("reqtrace", _SCRIPT)
 assert _spec and _spec.loader
@@ -55,6 +57,37 @@ def test_sources_and_ids_resolve() -> None:
 def test_coverage_runs() -> None:
     """`coverage` should execute cleanly."""
     assert reqtrace.coverage() == 0
+
+
+def test_actor_metadata_is_required(tmp_path: Path) -> None:
+    """Missing and unknown actor values are rejected."""
+    path = tmp_path / "test-plan.yaml"
+    plan = {
+        "domains": [
+            {
+                "components": [
+                    {
+                        "capabilities": [
+                            {
+                                "tests": [
+                                    {"test_id": "GOOD-01", "actor": "tenant"},
+                                    {"test_id": "MISSING-01"},
+                                    {"test_id": "BAD-01", "actor": "customer"},
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    errors = reqtrace.plan_actor_errors(path)
+
+    assert len(errors) == 2
+    assert any("MISSING-01" in error for error in errors)
+    assert any("BAD-01" in error for error in errors)
 
 
 def test_duplicate_source_name_is_rejected() -> None:

--- a/scripts/tests/test_test_plan_yaml_to_adoc.py
+++ b/scripts/tests/test_test_plan_yaml_to_adoc.py
@@ -31,11 +31,15 @@ adoc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(adoc)
 
 
-def _plan(github_issues: list[str]) -> dict[str, Any]:
+def _plan(github_issues: list[str], actor: str | None = "tenant") -> dict[str, Any]:
     """Build a minimal test-plan dict containing one test's ``github_issues`` wiring."""
     return {
         "domains": [
-            {"components": [{"capabilities": [{"tests": [{"test_id": "X-1", "github_issues": github_issues}]}]}]}
+            {
+                "components": [
+                    {"capabilities": [{"tests": [{"test_id": "X-1", "actor": actor, "github_issues": github_issues}]}]}
+                ]
+            }
         ]
     }
 
@@ -64,3 +68,10 @@ def test_validate_rejects_non_bare_issue_reference() -> None:
 def test_validate_accepts_bare_issue_reference() -> None:
     """A bare '#N' reference is valid."""
     adoc.validate_test_plan(_plan(["#40"]))
+
+
+@pytest.mark.parametrize("actor", [None, "customer", ["tenant"]])
+def test_validate_rejects_missing_or_invalid_actor(actor: Any) -> None:
+    """Every canonical test must have exactly one supported actor value."""
+    with pytest.raises(SystemExit, match="actor must be one of"):
+        adoc.validate_test_plan(_plan(["#40"], actor))


### PR DESCRIPTION
Classify every canonical test as tenant, operator, both, or provider-dependent. Enforce the actor field in requirement validation, render it in the generated test plan, and document how actor scope differs from harness credential privilege.

Consolidate the duplicate K8S37 performance requirement into K8S28 while preserving legacy IDs. Clarify K8S08 as operator-managed maintenance and K8S38 as a tenant-requested, provider-executed lifecycle operation.

Regenerate the committed requirement documents and add regression coverage for actor metadata.

This falls under issue #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added actor ownership classifications to test requirements and plans, covering tenant, operator, joint, and provider-dependent responsibilities.
  - Clarified Kubernetes lifecycle, control-plane upgrade, status visibility, and notification requirements.
  - Consolidated Kubernetes performance coverage under the current requirement and removed the obsolete duplicate requirement.

- **Validation**
  - Test plans now require a valid actor classification for every canonical test.
  - Generated test-plan tables display actor ownership and reject missing or unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->