### PR TITLE
feat(network): assert IMEX ships in the delivered node image (SDN17-01)

### DIFF
--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -1850,7 +1850,7 @@ a|
 | [[SDN17-01]]SDN17-01
 | SDN17
 |
-|
+| min_req, network
 | tenant
 |
 |

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -1744,6 +1744,9 @@ domains:
                 notes: ""
                 priority: ""
               - summary: "IMEX: Assert nvidia-imex and nvidia-imex-ctl packages are installed and nvidia-imex.service unit is registered with systemd."
+                labels:
+                  - min_req
+                  - network
                 dependencies:
                   - LimitedEnv
                 milestone: M4

--- a/isvctl/configs/providers/aws/config/network.yaml
+++ b/isvctl/configs/providers/aws/config/network.yaml
@@ -399,6 +399,22 @@ commands:
         timeout: 300
         output_schema: imex_domain
 
+      # IMEX ships in the delivered node image (SDN17-01). Host-model check:
+      # daemon + control tooling present and registered with the node's service
+      # manager. Reuses the same node list/key as the domain check above.
+      - name: imex_service
+        phase: test
+        command: "python3 ../scripts/network/imex_service_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--node-ids"
+          - "{{imex_node_ids | default('', true)}}"
+          - "--key-file"
+          - "{{imex_key_file | default('', true)}}"
+        timeout: 300
+        output_schema: imex_service
+
       # Teardown: Clean up shared VPC from create_network
       - name: teardown
         phase: teardown

--- a/isvctl/configs/providers/aws/scripts/common/imex.py
+++ b/isvctl/configs/providers/aws/scripts/common/imex.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared plumbing for the IMEX host checks (SDN17-01, SDN21-01).
+
+Both IMEX checks sweep the same set of SSH-reachable nodes with the same
+bounded-concurrency policy and the same rule for when an under-configured run
+should skip rather than fail. Only what each one *asks* a node differs, so that
+is all the callers implement; everything around it lives here so the two cannot
+drift apart.
+
+CLI flags are deliberately NOT declared here. ``test_stub_contracts`` statically
+walks each stub for ``add_argument`` calls to prove the wired YAML only passes
+flags the script accepts, and that guard is worth more than the handful of lines
+sharing them would save - so each script declares its own flags, using the
+defaults below so the values cannot drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any
+
+from common.ssh_utils import ssh_run
+
+DEFAULT_SSH_USER = "ubuntu"
+DEFAULT_TIMEOUT_SECONDS = 30
+# Cap simultaneous ssh processes so a large IMEX domain or allocation does not
+# fan out into hundreds of them at once.
+MAX_PARALLEL_QUERIES = 16
+# Overall sweep deadline. Kept well under the wired step timeout so the caller
+# always wins the race and prints its JSON contract instead of being killed.
+DEFAULT_DEADLINE_SECONDS = 90
+
+
+def parse_node_ids(raw: str) -> list[str]:
+    """Split a comma-separated ``--node-ids`` value into clean node IDs."""
+    return [node_id.strip() for node_id in raw.split(",") if node_id.strip()]
+
+
+def config_gate(node_ids: list[str], key_file: str, *, subject: str) -> dict[str, str] | None:
+    """Decide whether an under-configured run should skip or fail.
+
+    The IMEX checks need a pre-existing cluster that a normal network run does
+    not provision, so a run that was simply never pointed at one must skip
+    rather than fail every unrelated check in the suite. A *partially*
+    configured run is different: it means someone aimed the check at a cluster
+    and got it wrong, which should not pass silently.
+
+    Returns ``None`` when the run is fully configured, otherwise a dict with
+    either ``skip_reason`` or ``error``.
+    """
+    if not node_ids:
+        detail = "no node IDs or SSH key set" if not key_file else "no node IDs set"
+        return {"skip_reason": f"{subject} not configured for this run ({detail})"}
+    if not key_file:
+        return {"error": "--key-file (or AWS_IMEX_KEY_FILE) is required to SSH into the node(s)"}
+    return None
+
+
+def run_remote(host: str, user: str, key_file: str, command: str, timeout: int) -> dict[str, Any]:
+    """Run one command on a node, classifying failure into the sweep's result shape.
+
+    Returns ``{"host", "ok": True, "stdout"}`` on success, or
+    ``{"host", "ok": False, "error"}`` on a non-zero exit. Callers layer their
+    own parsing on top; failing here is reported rather than raised so one bad
+    node never takes down the whole sweep.
+    """
+    exit_code, stdout, stderr = ssh_run(host, user, key_file, command, timeout=timeout)
+    if exit_code != 0:
+        return {"host": host, "ok": False, "error": stderr.strip() or f"exit code {exit_code}"}
+    return {"host": host, "ok": True, "stdout": stdout}
+
+
+def sweep_nodes(
+    hosts: list[str],
+    query: Callable[[str], dict[str, Any]],
+    *,
+    deadline: int,
+    action: str = "query",
+) -> dict[str, dict[str, Any]]:
+    """Run ``query`` against every host concurrently, one result per host.
+
+    Concurrency is capped (rather than one thread per node) so a large fleet
+    does not fan out into hundreds of simultaneous ssh processes. That cap means
+    wall-clock time is roughly ``ceil(len(hosts) / MAX_PARALLEL_QUERIES) *
+    per-node timeout``, which against an unresponsive fleet could otherwise run
+    past the orchestrator's step timeout and get the caller killed before it
+    prints anything. So the whole sweep is also bounded by ``deadline``: hosts
+    that have not answered by then come back as timed-out errors and the caller
+    still emits its full structured JSON contract.
+
+    Args:
+        hosts: Node IDs to sweep, also passed to ``query`` as the SSH target.
+        query: Per-host callable returning a result dict; it owns whatever the
+            check actually asks the node, and is expected to report its own
+            failures as ``{"ok": False, "error": ...}`` rather than raising.
+        deadline: Overall wall-clock budget for the whole sweep, in seconds.
+        action: Noun used in the timeout message ("query", "probe", ...).
+    """
+    results: dict[str, dict[str, Any]] = {}
+    if not hosts:
+        return results
+
+    pool = ThreadPoolExecutor(max_workers=min(len(hosts), MAX_PARALLEL_QUERIES))
+    try:
+        futures = {pool.submit(query, host): host for host in hosts}
+        try:
+            for future in as_completed(futures, timeout=deadline):
+                results[futures[future]] = future.result()
+        except FuturesTimeoutError:
+            pass
+        for future, host in futures.items():
+            if host not in results:
+                future.cancel()
+                results[host] = {
+                    "host": host,
+                    "ok": False,
+                    "error": f"{action} did not complete within the {deadline}s deadline",
+                }
+    finally:
+        # Do not block on stragglers - each in-flight ssh_run is already bounded
+        # by its own per-node timeout, and queued work is dropped outright.
+        pool.shutdown(wait=False, cancel_futures=True)
+    return results

--- a/isvctl/configs/providers/aws/scripts/network/imex_domain_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/imex_domain_test.py
@@ -106,22 +106,21 @@ import argparse
 import json
 import os
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
 
-from common.ssh_utils import ssh_run
+from common.imex import (
+    DEFAULT_DEADLINE_SECONDS,
+    DEFAULT_SSH_USER,
+    DEFAULT_TIMEOUT_SECONDS,
+    config_gate,
+    parse_node_ids,
+    run_remote,
+    sweep_nodes,
+)
 
-DEFAULT_SSH_USER = "ubuntu"
 IMEX_CTL_COMMAND = "sudo nvidia-imex-ctl -N -j -H"
-# Cap simultaneous ssh processes so a large IMEX domain does not fan out into
-# hundreds of them at once.
-MAX_PARALLEL_QUERIES = 16
-# Overall sweep deadline. Kept well under the wired step timeout so this script
-# always wins the race and prints its JSON contract instead of being killed.
-DEFAULT_DEADLINE_SECONDS = 90
 
 
 def _parse_imex_ctl_json(output: str, queried_host: str) -> tuple[str, str, list[str]]:
@@ -214,9 +213,10 @@ def _service_state(own_status: str) -> str:
 
 def query_node(host: str, user: str, key_file: str, timeout: int) -> dict[str, Any]:
     """SSH into a single node and query its IMEX domain view."""
-    exit_code, stdout, stderr = ssh_run(host, user, key_file, IMEX_CTL_COMMAND, timeout=timeout)
-    if exit_code != 0:
-        return {"host": host, "ok": False, "error": stderr.strip() or f"exit code {exit_code}"}
+    result = run_remote(host, user, key_file, IMEX_CTL_COMMAND, timeout)
+    if not result["ok"]:
+        return result
+    stdout = result["stdout"]
 
     try:
         domain_state, own_status, peers = _parse_imex_ctl_json(stdout, host)
@@ -230,49 +230,6 @@ def query_node(host: str, user: str, key_file: str, timeout: int) -> dict[str, A
         "own_status": own_status,
         "peers": peers,
     }
-
-
-def query_members(
-    hosts: list[str],
-    *,
-    user: str,
-    key_file: str,
-    timeout: int,
-    deadline: int,
-) -> dict[str, dict[str, Any]]:
-    """Query every member concurrently, always returning one result per host.
-
-    Concurrency is capped (rather than one thread per member) so a large domain
-    does not fan out into hundreds of simultaneous ssh processes. That cap means
-    wall-clock time is roughly ``ceil(len(hosts) / MAX_PARALLEL_QUERIES) *
-    timeout``, which for a big domain of unresponsive nodes could otherwise run
-    past the orchestrator's step timeout and get this process killed before it
-    prints anything. So the whole sweep is also bounded by ``deadline``: members
-    that have not answered by then are reported as timed-out query errors and
-    the caller still emits the full structured JSON contract.
-    """
-    results: dict[str, dict[str, Any]] = {}
-    pool = ThreadPoolExecutor(max_workers=min(len(hosts), MAX_PARALLEL_QUERIES))
-    try:
-        futures = {pool.submit(query_node, host, user, key_file, timeout): host for host in hosts}
-        try:
-            for future in as_completed(futures, timeout=deadline):
-                results[futures[future]] = future.result()
-        except FuturesTimeoutError:
-            pass
-        for future, host in futures.items():
-            if host not in results:
-                future.cancel()
-                results[host] = {
-                    "host": host,
-                    "ok": False,
-                    "error": f"query did not complete within the {deadline}s deadline",
-                }
-    finally:
-        # Do not block on stragglers - each in-flight ssh_run is already bounded
-        # by its own per-node timeout, and queued work is dropped outright.
-        pool.shutdown(wait=False, cancel_futures=True)
-    return results
 
 
 def main() -> int:
@@ -290,21 +247,23 @@ def main() -> int:
         help="SSH private key file for the node(s)",
     )
     parser.add_argument("--ssh-user", default=os.environ.get("AWS_IMEX_SSH_USER", DEFAULT_SSH_USER))
-    parser.add_argument("--domain-id", default=os.environ.get("AWS_IMEX_DOMAIN_ID", ""))
-    parser.add_argument("--timeout", type=int, default=30, help="Per-node SSH command timeout (seconds)")
+    parser.add_argument(
+        "--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Per-node SSH command timeout (seconds)"
+    )
     parser.add_argument(
         "--deadline",
         type=int,
         default=DEFAULT_DEADLINE_SECONDS,
         help=(
-            "Overall deadline for querying every member (seconds). Members that have not answered by then are "
+            "Overall deadline for sweeping every node (seconds). Nodes that have not answered by then are "
             "reported as timed out so structured JSON is still emitted, rather than the orchestrator killing "
             "this process at its step timeout with no output."
         ),
     )
+    parser.add_argument("--domain-id", default=os.environ.get("AWS_IMEX_DOMAIN_ID", ""))
     args = parser.parse_args()
 
-    expected_members = [node_id.strip() for node_id in args.node_ids.split(",") if node_id.strip()]
+    expected_members = parse_node_ids(args.node_ids)
 
     result: dict[str, Any] = {
         "success": False,
@@ -322,41 +281,28 @@ def main() -> int:
         "nodes": [],
     }
 
-    # SDN21-01 needs a pre-existing multi-node IMEX cluster, which a normal AWS
-    # network run does not provision. When the run simply has not been pointed
-    # at one, skip rather than fail - otherwise wiring this step would break
-    # every network run that isn't specifically testing IMEX. A partially
-    # configured run is still a hard error: it means someone tried to point this
-    # at a cluster and got it wrong, which should not pass silently.
-    if not expected_members and not args.key_file:
-        result["success"] = True
-        result["skipped"] = True
-        result["skip_reason"] = "IMEX domain not configured for this run (no node IDs or SSH key set)"
+    # An unconfigured run skips; a partially configured one is a hard error.
+    gate = config_gate(expected_members, args.key_file, subject="IMEX domain")
+    if gate is not None:
+        result.update(gate)
+        if "skip_reason" in gate:
+            result["success"] = True
+            result["skipped"] = True
+            print(json.dumps(result, indent=2))
+            return 0
         print(json.dumps(result, indent=2))
-        return 0
+        return 1
 
-    if not expected_members:
-        result["success"] = True
-        result["skipped"] = True
-        result["skip_reason"] = "IMEX domain not configured for this run (no node IDs set)"
-        print(json.dumps(result, indent=2))
-        return 0
-
+    # Specific to the domain check: a single-node domain is trivially complete,
+    # so it is a misconfiguration rather than something to assert against.
     if len(expected_members) < 2:
         result["error"] = "--node-ids must list at least two expected IMEX domain members"
         print(json.dumps(result, indent=2))
         return 1
 
-    if not args.key_file:
-        result["error"] = "--key-file (or AWS_IMEX_KEY_FILE) is required to SSH into domain members"
-        print(json.dumps(result, indent=2))
-        return 1
-
-    results_by_host = query_members(
+    results_by_host = sweep_nodes(
         expected_members,
-        user=args.ssh_user,
-        key_file=args.key_file,
-        timeout=args.timeout,
+        lambda host: query_node(host, args.ssh_user, args.key_file, args.timeout),
         deadline=args.deadline,
     )
 

--- a/isvctl/configs/providers/aws/scripts/network/imex_service_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/imex_service_test.py
@@ -49,20 +49,23 @@ import argparse
 import json
 import os
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
 
-from common.ssh_utils import ssh_run
+from common.imex import (
+    DEFAULT_DEADLINE_SECONDS,
+    DEFAULT_SSH_USER,
+    DEFAULT_TIMEOUT_SECONDS,
+    config_gate,
+    parse_node_ids,
+    run_remote,
+    sweep_nodes,
+)
 
-DEFAULT_SSH_USER = "ubuntu"
 DEFAULT_SERVICE = "nvidia-imex.service"
 DEFAULT_DAEMON_BIN = "nvidia-imex"
 DEFAULT_CTL_BIN = "nvidia-imex-ctl"
-MAX_PARALLEL_QUERIES = 16
-DEFAULT_DEADLINE_SECONDS = 90
 
 _LOAD_STATES = {"loaded": "loaded", "masked": "masked", "not-found": "not_found"}
 _BOOT_STATES = {"enabled", "disabled", "static", "masked"}
@@ -116,48 +119,10 @@ def _parse_probe(output: str) -> dict[str, Any]:
 
 def query_node(host: str, user: str, key_file: str, timeout: int, probe: str) -> dict[str, Any]:
     """SSH into one node and probe for the IMEX service and its tooling."""
-    exit_code, stdout, stderr = ssh_run(host, user, key_file, probe, timeout=timeout)
-    if exit_code != 0:
-        return {"host": host, "ok": False, "error": stderr.strip() or f"exit code {exit_code}"}
-    return {"host": host, "ok": True, **_parse_probe(stdout)}
-
-
-def query_nodes(
-    hosts: list[str],
-    *,
-    user: str,
-    key_file: str,
-    timeout: int,
-    deadline: int,
-    probe: str,
-) -> dict[str, dict[str, Any]]:
-    """Probe every node concurrently, always returning one result per host.
-
-    Concurrency is capped so a large allocation does not fan out into one ssh
-    process per node, and the whole sweep is bounded by ``deadline`` so an
-    unresponsive fleet still yields structured JSON instead of being killed at
-    the orchestrator's step timeout.
-    """
-    results: dict[str, dict[str, Any]] = {}
-    pool = ThreadPoolExecutor(max_workers=min(len(hosts), MAX_PARALLEL_QUERIES))
-    try:
-        futures = {pool.submit(query_node, host, user, key_file, timeout, probe): host for host in hosts}
-        try:
-            for future in as_completed(futures, timeout=deadline):
-                results[futures[future]] = future.result()
-        except FuturesTimeoutError:
-            pass
-        for future, host in futures.items():
-            if host not in results:
-                future.cancel()
-                results[host] = {
-                    "host": host,
-                    "ok": False,
-                    "error": f"probe did not complete within the {deadline}s deadline",
-                }
-    finally:
-        pool.shutdown(wait=False, cancel_futures=True)
-    return results
+    result = run_remote(host, user, key_file, probe, timeout)
+    if not result["ok"]:
+        return result
+    return {"host": host, "ok": True, **_parse_probe(result["stdout"])}
 
 
 def main() -> int:
@@ -169,8 +134,25 @@ def main() -> int:
         default=os.environ.get("AWS_IMEX_NODE_IDS", ""),
         help="Comma-separated SSH-reachable node IDs covered by the allocation",
     )
-    parser.add_argument("--key-file", default=os.environ.get("AWS_IMEX_KEY_FILE", ""))
+    parser.add_argument(
+        "--key-file",
+        default=os.environ.get("AWS_IMEX_KEY_FILE", ""),
+        help="SSH private key file for the node(s)",
+    )
     parser.add_argument("--ssh-user", default=os.environ.get("AWS_IMEX_SSH_USER", DEFAULT_SSH_USER))
+    parser.add_argument(
+        "--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Per-node SSH command timeout (seconds)"
+    )
+    parser.add_argument(
+        "--deadline",
+        type=int,
+        default=DEFAULT_DEADLINE_SECONDS,
+        help=(
+            "Overall deadline for sweeping every node (seconds). Nodes that have not answered by then are "
+            "reported as timed out so structured JSON is still emitted, rather than the orchestrator killing "
+            "this process at its step timeout with no output."
+        ),
+    )
     parser.add_argument("--service", default=os.environ.get("AWS_IMEX_SERVICE", DEFAULT_SERVICE))
     parser.add_argument("--daemon-bin", default=DEFAULT_DAEMON_BIN, help="IMEX daemon binary probed by role")
     parser.add_argument("--control-bin", default=DEFAULT_CTL_BIN, help="IMEX control tool probed by role")
@@ -183,11 +165,9 @@ def main() -> int:
             "node's own NVLink self-report, so a node cannot opt itself out of scope."
         ),
     )
-    parser.add_argument("--timeout", type=int, default=30, help="Per-node SSH command timeout (seconds)")
-    parser.add_argument("--deadline", type=int, default=DEFAULT_DEADLINE_SECONDS, help="Overall sweep deadline")
     args = parser.parse_args()
 
-    node_ids = [node_id.strip() for node_id in args.node_ids.split(",") if node_id.strip()]
+    node_ids = parse_node_ids(args.node_ids)
 
     result: dict[str, Any] = {
         "success": False,
@@ -199,37 +179,24 @@ def main() -> int:
         "nodes": [],
     }
 
-    # A normal AWS network run does not provision an NVLink allocation, so an
-    # unconfigured run skips rather than failing every unrelated network run.
-    # A partially configured one stays a hard error - that means someone aimed
-    # this at a cluster and got it wrong, which should not pass silently.
-    if not node_ids and not args.key_file:
-        result["success"] = True
-        result["skipped"] = True
-        result["skip_reason"] = "IMEX nodes not configured for this run (no node IDs or SSH key set)"
-        print(json.dumps(result, indent=2))
-        return 0
-
-    if not node_ids:
-        result["success"] = True
-        result["skipped"] = True
-        result["skip_reason"] = "IMEX nodes not configured for this run (no node IDs set)"
-        print(json.dumps(result, indent=2))
-        return 0
-
-    if not args.key_file:
-        result["error"] = "--key-file (or AWS_IMEX_KEY_FILE) is required to SSH into the nodes"
+    # An unconfigured run skips; a partially configured one is a hard error.
+    gate = config_gate(node_ids, args.key_file, subject="IMEX nodes")
+    if gate is not None:
+        result.update(gate)
+        if "skip_reason" in gate:
+            result["success"] = True
+            result["skipped"] = True
+            print(json.dumps(result, indent=2))
+            return 0
         print(json.dumps(result, indent=2))
         return 1
 
     probe = _probe_command(args.service, args.daemon_bin, args.control_bin)
-    results_by_host = query_nodes(
+    results_by_host = sweep_nodes(
         node_ids,
-        user=args.ssh_user,
-        key_file=args.key_file,
-        timeout=args.timeout,
+        lambda host: query_node(host, args.ssh_user, args.key_file, args.timeout, probe),
         deadline=args.deadline,
-        probe=probe,
+        action="probe",
     )
 
     nodes: list[dict[str, Any]] = []

--- a/isvctl/configs/providers/aws/scripts/network/imex_service_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/imex_service_test.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IMEX service/tooling presence test - AWS reference implementation (SDN17-01).
+
+Asserts the host model: that IMEX ships in the delivered node image and is
+registered with the node's service manager, without the tenant installing it.
+Whether the service is enabled at boot, currently running, or has joined a
+domain are all out of scope (SDN21-01 covers the domain itself).
+
+Probing is by ROLE, not by package name. The daemon ships branch-versioned
+(e.g. `nvidia-imex=<driver-branch>-1ubuntu1`) and the control tool is a binary
+inside that same package, so a hardcoded package name goes stale on every
+driver branch. Confirmed on a live host: the package installs
+`/usr/bin/nvidia-imex` and `/usr/bin/nvidia-imex-ctl`, so presence is probed
+via `command -v` and the control tool is additionally invoked to prove it
+actually runs rather than merely existing.
+
+Registration is read from systemd rather than the filesystem, because a unit
+file on disk that the manager has not loaded does not count, and because a
+boolean would collapse "absent" and "masked" into one answer. `systemctl show
+-p LoadState` distinguishes them:
+
+    LoadState=loaded     -> "loaded"    (the only passing state)
+    LoadState=masked     -> "masked"    (deployment-model mismatch)
+    LoadState=not-found  -> "not_found"
+    (anything else)      -> "error"
+
+`UnitFileState` supplies boot disposition, normalized and reported as evidence
+only - never asserted on.
+
+Scope is set by the allocation, not the node: `--nvlink-allocation` marks the
+queried nodes as belonging to a multi-node NVLink allocation. That flag is
+deliberately NOT derived from the node's own NVLink self-report, so a node
+cannot opt itself out of being asserted against.
+
+Usage:
+    python imex_service_test.py --region us-west-2 \\
+        --node-ids gpu-node-1,gpu-node-2 --key-file /tmp/key.pem
+"""
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+from common.ssh_utils import ssh_run
+
+DEFAULT_SSH_USER = "ubuntu"
+DEFAULT_SERVICE = "nvidia-imex.service"
+DEFAULT_DAEMON_BIN = "nvidia-imex"
+DEFAULT_CTL_BIN = "nvidia-imex-ctl"
+MAX_PARALLEL_QUERIES = 16
+DEFAULT_DEADLINE_SECONDS = 90
+
+_LOAD_STATES = {"loaded": "loaded", "masked": "masked", "not-found": "not_found"}
+_BOOT_STATES = {"enabled", "disabled", "static", "masked"}
+
+
+def _probe_command(service: str, daemon_bin: str, ctl_bin: str) -> str:
+    """Build the single remote probe. Delimited so partial output stays parseable."""
+    return (
+        f"echo DAEMON=$(command -v {daemon_bin} >/dev/null 2>&1 && echo yes || echo no); "
+        # Presence alone is not enough for the control tool - the requirement is
+        # that it is *invocable*, so actually run it.
+        f"echo CTL=$(command -v {ctl_bin} >/dev/null 2>&1 && "
+        f"({ctl_bin} --version >/dev/null 2>&1 && echo yes || echo present_not_invocable) || echo no); "
+        f"echo LOAD=$(systemctl show {service} -p LoadState --value 2>/dev/null); "
+        f"echo BOOT=$(systemctl show {service} -p UnitFileState --value 2>/dev/null)"
+    )
+
+
+def _parse_probe(output: str) -> dict[str, Any]:
+    """Parse the delimited probe output into the normalized per-node fields."""
+    fields: dict[str, str] = {}
+    for line in output.splitlines():
+        key, sep, value = line.strip().partition("=")
+        if sep:
+            fields[key] = value.strip()
+
+    load_state = fields.get("LOAD", "")
+    if load_state in _LOAD_STATES:
+        registration = _LOAD_STATES[load_state]
+    elif not load_state:
+        # No answer from the manager at all is an error, not "absent" - the
+        # latter is a claim about the image we have not actually established.
+        registration = "error"
+    else:
+        registration = "error"
+
+    boot = fields.get("BOOT", "")
+    boot_disposition = boot if boot in _BOOT_STATES else ("none" if not boot else "unknown")
+    # systemd reports a masked unit's file state as "masked"; the contract has
+    # no such boot value, and masking is already reported via registration.
+    if boot_disposition == "masked":
+        boot_disposition = "none"
+
+    return {
+        "service_present": fields.get("DAEMON") == "yes",
+        "control_tooling_present": fields.get("CTL") == "yes",
+        "service_registration": registration,
+        "boot_disposition": boot_disposition,
+    }
+
+
+def query_node(host: str, user: str, key_file: str, timeout: int, probe: str) -> dict[str, Any]:
+    """SSH into one node and probe for the IMEX service and its tooling."""
+    exit_code, stdout, stderr = ssh_run(host, user, key_file, probe, timeout=timeout)
+    if exit_code != 0:
+        return {"host": host, "ok": False, "error": stderr.strip() or f"exit code {exit_code}"}
+    return {"host": host, "ok": True, **_parse_probe(stdout)}
+
+
+def query_nodes(
+    hosts: list[str],
+    *,
+    user: str,
+    key_file: str,
+    timeout: int,
+    deadline: int,
+    probe: str,
+) -> dict[str, dict[str, Any]]:
+    """Probe every node concurrently, always returning one result per host.
+
+    Concurrency is capped so a large allocation does not fan out into one ssh
+    process per node, and the whole sweep is bounded by ``deadline`` so an
+    unresponsive fleet still yields structured JSON instead of being killed at
+    the orchestrator's step timeout.
+    """
+    results: dict[str, dict[str, Any]] = {}
+    pool = ThreadPoolExecutor(max_workers=min(len(hosts), MAX_PARALLEL_QUERIES))
+    try:
+        futures = {pool.submit(query_node, host, user, key_file, timeout, probe): host for host in hosts}
+        try:
+            for future in as_completed(futures, timeout=deadline):
+                results[futures[future]] = future.result()
+        except FuturesTimeoutError:
+            pass
+        for future, host in futures.items():
+            if host not in results:
+                future.cancel()
+                results[host] = {
+                    "host": host,
+                    "ok": False,
+                    "error": f"probe did not complete within the {deadline}s deadline",
+                }
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+    return results
+
+
+def main() -> int:
+    """Probe each node for IMEX service/tooling and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="IMEX service presence test (AWS)")
+    parser.add_argument("--region", required=True, help="AWS region (recorded for context only)")
+    parser.add_argument(
+        "--node-ids",
+        default=os.environ.get("AWS_IMEX_NODE_IDS", ""),
+        help="Comma-separated SSH-reachable node IDs covered by the allocation",
+    )
+    parser.add_argument("--key-file", default=os.environ.get("AWS_IMEX_KEY_FILE", ""))
+    parser.add_argument("--ssh-user", default=os.environ.get("AWS_IMEX_SSH_USER", DEFAULT_SSH_USER))
+    parser.add_argument("--service", default=os.environ.get("AWS_IMEX_SERVICE", DEFAULT_SERVICE))
+    parser.add_argument("--daemon-bin", default=DEFAULT_DAEMON_BIN, help="IMEX daemon binary probed by role")
+    parser.add_argument("--control-bin", default=DEFAULT_CTL_BIN, help="IMEX control tool probed by role")
+    parser.add_argument(
+        "--nvlink-allocation",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Whether these nodes belong to a multi-node NVLink allocation. Set from the allocation, never from a "
+            "node's own NVLink self-report, so a node cannot opt itself out of scope."
+        ),
+    )
+    parser.add_argument("--timeout", type=int, default=30, help="Per-node SSH command timeout (seconds)")
+    parser.add_argument("--deadline", type=int, default=DEFAULT_DEADLINE_SECONDS, help="Overall sweep deadline")
+    args = parser.parse_args()
+
+    node_ids = [node_id.strip() for node_id in args.node_ids.split(",") if node_id.strip()]
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "imex_service",
+        "region": args.region,
+        "nodes_checked": 0,
+        "nodes_validated": 0,
+        "nodes": [],
+    }
+
+    # A normal AWS network run does not provision an NVLink allocation, so an
+    # unconfigured run skips rather than failing every unrelated network run.
+    # A partially configured one stays a hard error - that means someone aimed
+    # this at a cluster and got it wrong, which should not pass silently.
+    if not node_ids and not args.key_file:
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = "IMEX nodes not configured for this run (no node IDs or SSH key set)"
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if not node_ids:
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = "IMEX nodes not configured for this run (no node IDs set)"
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if not args.key_file:
+        result["error"] = "--key-file (or AWS_IMEX_KEY_FILE) is required to SSH into the nodes"
+        print(json.dumps(result, indent=2))
+        return 1
+
+    probe = _probe_command(args.service, args.daemon_bin, args.control_bin)
+    results_by_host = query_nodes(
+        node_ids,
+        user=args.ssh_user,
+        key_file=args.key_file,
+        timeout=args.timeout,
+        deadline=args.deadline,
+        probe=probe,
+    )
+
+    nodes: list[dict[str, Any]] = []
+    errors: list[str] = []
+    validated = 0
+    for host in node_ids:
+        node_result = results_by_host[host]
+        if not node_result["ok"]:
+            errors.append(f"{host}: {node_result['error']}")
+            # An unreachable node is still in scope and still counts as a
+            # failure - it must not quietly drop out of the asserted set.
+            nodes.append(
+                {
+                    "node_id": host,
+                    "in_nvlink_allocation": args.nvlink_allocation,
+                    "service_present": False,
+                    "control_tooling_present": False,
+                    "service_registration": "error",
+                    "boot_disposition": "unknown",
+                    "error": node_result["error"],
+                }
+            )
+            continue
+        validated += 1
+        nodes.append(
+            {
+                "node_id": host,
+                "in_nvlink_allocation": args.nvlink_allocation,
+                "service_present": node_result["service_present"],
+                "control_tooling_present": node_result["control_tooling_present"],
+                "service_registration": node_result["service_registration"],
+                "boot_disposition": node_result["boot_disposition"],
+            }
+        )
+
+    result["nodes"] = nodes
+    result["nodes_checked"] = len(node_ids)
+    result["nodes_validated"] = validated
+    if errors:
+        result["error"] = "; ".join(errors)
+    result["success"] = validated > 0
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/config/network.yaml
+++ b/isvctl/configs/providers/my-isv/config/network.yaml
@@ -353,6 +353,17 @@ commands:
         timeout: 60
         output_schema: imex_domain
 
+      - name: imex_service
+        phase: test
+        command: "python ../scripts/network/imex_service_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--node-ids"
+          - "compute-node-1,compute-node-2"
+        timeout: 60
+        output_schema: imex_service
+
       - name: teardown
         phase: teardown
         command: "python ../scripts/network/teardown.py"

--- a/isvctl/configs/providers/my-isv/scripts/network/imex_service_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/network/imex_service_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IMEX service/tooling presence test (host model) - TEMPLATE.
+
+This script is called during the "test" phase. It is SELF-CONTAINED:
+  1. Resolve which nodes the allocation covers
+  2. On each node, probe for the IMEX daemon and its control tooling
+  3. Ask the node's service manager whether the service is registered
+  4. Print a JSON object to stdout
+
+All parsing of vendor output belongs here in the provider script; the
+validation sees only the normalized shape below.
+
+Two things worth getting right, both of which the validation cannot fix for you:
+
+  * `in_nvlink_allocation` must come from the ALLOCATION, not from the node's
+    own view of its NVLink support. A node must not be able to self-report its
+    way out of scope - inside a multi-node NVLink allocation that is a FAIL,
+    not a skip.
+  * Probe for the artifacts by ROLE, not by a fixed package name. The daemon
+    ships branch-versioned and the control tool is a binary inside that
+    package, so a hardcoded package name goes stale every driver branch.
+    Query the service manager rather than looking for a unit file on disk,
+    so an absent service can be told apart from a masked one.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "network",
+    "test_name": "imex_service",
+    "nodes_checked": 2,
+    "nodes_validated": 2,
+    "nodes": [
+      {
+        "node_id": "compute-node-1",
+        "in_nvlink_allocation": true,
+        "service_present": true,
+        "control_tooling_present": true,
+        "service_registration": "loaded",
+        "boot_disposition": "disabled"
+      }
+    ]
+  }
+
+`service_registration` is a normalized enum: loaded, masked, not_found, error.
+Only "loaded" passes; "masked" is a deployment-model mismatch, not a missing
+package.
+
+`boot_disposition` is a normalized enum: enabled, disabled, static, none,
+unknown. It is reported as evidence and never asserted on - whether IMEX starts
+at boot, and whether it is currently running, are both out of scope.
+
+Usage:
+    python imex_service_test.py --region <region> --node-ids <id1>,<id2>[,...]
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Probe IMEX service/tooling presence and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="IMEX service presence test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument(
+        "--node-ids",
+        required=True,
+        help="Comma-separated node IDs covered by the allocation",
+    )
+    args = parser.parse_args()
+    node_ids = [node_id.strip() for node_id in args.node_ids.split(",") if node_id.strip()]
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "imex_service",
+        "region": args.region,
+        "nodes_checked": 0,
+        "nodes_validated": 0,
+        "nodes": [],
+    }
+
+    # TODO: Replace with your platform's probe. Typically this means, per node,
+    # checking that the IMEX daemon and control-tool binaries exist and that the
+    # service manager reports a loaded definition for the service.
+
+    if DEMO_MODE:
+        result["nodes"] = [
+            {
+                "node_id": node_id,
+                "in_nvlink_allocation": True,
+                "service_present": True,
+                "control_tooling_present": True,
+                "service_registration": "loaded",
+                "boot_disposition": "disabled",
+            }
+            for node_id in node_ids
+        ]
+        result["nodes_checked"] = len(node_ids)
+        result["nodes_validated"] = len(node_ids)
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's IMEX service probe"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -22,11 +22,12 @@
 # observability (with documented gaps for mutating workflows), and existing
 # instance inventory checks. Full lifecycle and SSH-host validations remain
 # excluded until those steps are wired for NICo. That includes IMEX domain
-# operational/connectivity validation (SDN21-01): NICo's BMaaS API surface
-# is hardware inventory/lifecycle only and does not expose live host/software
-# telemetry such as `nvidia-imex-ctl` state, so no imex_domain step is wired
-# here (see the AWS and my-isv network.yaml configs for real/template
-# implementations of that check).
+# operational/connectivity validation (SDN21-01) and IMEX service/tooling
+# presence (SDN17-01): NICo's BMaaS API surface is hardware inventory/lifecycle
+# only and does not expose live host/software telemetry such as
+# `nvidia-imex-ctl` state or the node's service-manager registration, so no
+# imex_domain or imex_service step is wired here (see the AWS and my-isv
+# network.yaml configs for real/template implementations of those checks).
 #
 # Architecture:
 #   - verify_ingestion.py compares expected-machine manifest vs discovered

--- a/isvctl/configs/suites/network.yaml
+++ b/isvctl/configs/suites/network.yaml
@@ -334,6 +334,11 @@ tests:
           labels: ["min_req", "network"]
           requires: [vm, bare_metal]
           step: imex_domain
+        ImexServicePresenceCheck:
+          test_id: "SDN17-01"
+          labels: ["min_req", "network"]
+          requires: [vm, bare_metal]
+          step: imex_service
 
     teardown_checks:
       step: teardown

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -138,6 +138,8 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "nvlink_domain_test": "nvlink_domain",
     "imex_domain": "imex_domain",
     "imex_domain_test": "imex_domain",
+    "imex_service": "imex_service",
+    "imex_service_test": "imex_service",
     "sg_crud_test": "sg_crud",
     "sg_crud": "sg_crud",
     # Node pool operations
@@ -982,6 +984,59 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
             "nodes_validated": {"type": "integer", "description": "How many members returned a usable report"},
             "skipped": {"type": "boolean", "description": "True when no IMEX domain was configured for the run"},
             "skip_reason": {"type": "string", "description": "Why the IMEX domain check was skipped"},
+        },
+        "additionalProperties": True,
+    },
+    "imex_service": {
+        "type": "object",
+        "required": ["success", "platform", "nodes"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "test_name": {"type": "string", "description": "Always 'imex_service'"},
+            "nodes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["node_id"],
+                    "properties": {
+                        "node_id": {"type": "string", "minLength": 1, "description": "Node identifier"},
+                        "in_nvlink_allocation": {
+                            "type": "boolean",
+                            "description": (
+                                "Whether the node belongs to a multi-node NVLink allocation. Set from the "
+                                "allocation, not the node's self-report, so a node cannot opt itself out of scope."
+                            ),
+                        },
+                        "service_present": {
+                            "type": "boolean",
+                            "description": "Whether the IMEX daemon ships in the delivered node image",
+                        },
+                        "control_tooling_present": {
+                            "type": "boolean",
+                            "description": "Whether the IMEX control tooling is present and invocable",
+                        },
+                        "service_registration": {
+                            "type": "string",
+                            "enum": ["loaded", "masked", "not_found", "error"],
+                            "description": (
+                                "Normalized service-manager registration state, queried from the manager rather "
+                                "than the filesystem. Only 'loaded' passes; 'masked' is a deployment-model mismatch."
+                            ),
+                        },
+                        "boot_disposition": {
+                            "type": "string",
+                            "enum": ["enabled", "disabled", "static", "none", "unknown"],
+                            "description": "Normalized boot disposition, reported as evidence and never asserted on",
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+                "description": "Per-node IMEX service/tooling reports",
+            },
+            "nodes_checked": {"type": "integer", "description": "How many nodes were examined"},
+            "nodes_validated": {"type": "integer", "description": "How many nodes returned a usable report"},
+            "skipped": {"type": "boolean", "description": "True when no nodes were configured for the run"},
+            "skip_reason": {"type": "string", "description": "Why the IMEX service check was skipped"},
         },
         "additionalProperties": True,
     },

--- a/isvctl/tests/providers/aws/test_aws_network_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_network_scripts.py
@@ -2379,7 +2379,7 @@ def test_imex_query_node_reports_malformed_payload_as_query_error(monkeypatch: p
     per-node ok=False error, not raise - so main()'s ThreadPoolExecutor.map
     still yields structured JSON for every node instead of crashing."""
     module = _load_network_script("imex_domain_test.py")
-    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, "[]", ""))
+    monkeypatch.setattr(module, "run_remote", lambda h, *a, **k: {"host": h, "ok": True, "stdout": "[]"})
 
     result = module.query_node("10.0.0.1", "ubuntu", "/tmp/key.pem", 30)
 
@@ -2387,56 +2387,66 @@ def test_imex_query_node_reports_malformed_payload_as_query_error(monkeypatch: p
     assert "could not parse" in result["error"]
 
 
-def test_imex_query_members_returns_one_result_per_host(monkeypatch: pytest.MonkeyPatch) -> None:
+def _load_common_module(module_name: str) -> ModuleType:
+    """Load a provider-local helper from aws/scripts/common as a module.
+
+    The helper imports its siblings as ``common.*``, exactly as the scripts do,
+    so the scripts directory has to be importable first - otherwise this only
+    works by accident after some other test has loaded a script.
+    """
+    scripts_root = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts"
+    if str(scripts_root) not in sys.path:
+        sys.path.insert(0, str(scripts_root))
+    script_path = scripts_root / "common" / module_name
+    spec = importlib.util.spec_from_file_location(f"test_common_{script_path.stem}", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# The node sweep, the CLI options and the under-configured gate are shared by
+# both IMEX checks (SDN17-01 and SDN21-01), so they are tested once here rather
+# than duplicated per script.
+
+
+def test_imex_sweep_returns_one_result_per_host() -> None:
     """Every requested host must appear in the result map, keyed by host."""
-    module = _load_network_script("imex_domain_test.py")
-    payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
-    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, payload, ""))
+    imex = _load_common_module("imex.py")
 
-    results = module.query_members(
-        ["10.0.0.1", "10.0.0.2"], user="ubuntu", key_file="/tmp/key.pem", timeout=30, deadline=90
-    )
+    results = imex.sweep_nodes(["h1", "h2"], lambda host: {"host": host, "ok": True}, deadline=90)
 
-    assert set(results) == {"10.0.0.1", "10.0.0.2"}
-    assert results["10.0.0.1"]["peers"] == ["10.0.0.2"]
-    assert results["10.0.0.2"]["peers"] == ["10.0.0.1"]
+    assert set(results) == {"h1", "h2"}
+    assert all(r["ok"] for r in results.values())
 
 
-def test_imex_query_members_reports_unfinished_hosts_on_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_imex_sweep_reports_unfinished_hosts_on_deadline() -> None:
     """Hosts that do not answer within the overall deadline must come back as
-    timed-out query errors, so main() still emits the full JSON contract instead
+    timed-out errors, so the caller still emits its full JSON contract instead
     of the orchestrator killing the process at its step timeout with no output."""
-    module = _load_network_script("imex_domain_test.py")
+    imex = _load_common_module("imex.py")
 
-    def _hang(host: str, *_args: Any, **_kwargs: Any) -> tuple[int, str, str]:
-        if host == "10.0.0.2":
+    def _query(host: str) -> dict[str, Any]:
+        if host == "slow":
             time.sleep(5)
-        return (0, _imex_up_payload("10.0.0.1", "10.0.0.2"), "")
+        return {"host": host, "ok": True}
 
-    monkeypatch.setattr(module, "ssh_run", _hang)
+    results = imex.sweep_nodes(["fast", "slow"], _query, deadline=1, action="probe")
 
-    results = module.query_members(
-        ["10.0.0.1", "10.0.0.2"], user="ubuntu", key_file="/tmp/key.pem", timeout=30, deadline=1
-    )
-
-    assert set(results) == {"10.0.0.1", "10.0.0.2"}
-    assert results["10.0.0.1"]["ok"] is True
-    assert results["10.0.0.2"]["ok"] is False
-    assert "deadline" in results["10.0.0.2"]["error"]
+    assert results["fast"]["ok"] is True
+    assert results["slow"]["ok"] is False
+    assert "probe did not complete within the 1s deadline" in results["slow"]["error"]
 
 
-def test_imex_query_members_caps_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Concurrency must stay capped so a large domain does not fan out into one
-    ssh process per member."""
-    module = _load_network_script("imex_domain_test.py")
-    hosts = [f"10.0.0.{n}" for n in range(1, 41)]
-    payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
-
+def test_imex_sweep_caps_concurrency() -> None:
+    """Concurrency stays capped so a large fleet does not fan out into one ssh
+    process per node."""
+    imex = _load_common_module("imex.py")
     lock = threading.Lock()
     live = 0
     peak = 0
 
-    def _tracked(*_args: Any, **_kwargs: Any) -> tuple[int, str, str]:
+    def _query(host: str) -> dict[str, Any]:
         nonlocal live, peak
         with lock:
             live += 1
@@ -2444,14 +2454,53 @@ def test_imex_query_members_caps_concurrency(monkeypatch: pytest.MonkeyPatch) ->
         time.sleep(0.01)
         with lock:
             live -= 1
-        return (0, payload, "")
+        return {"host": host, "ok": True}
 
-    monkeypatch.setattr(module, "ssh_run", _tracked)
-
-    results = module.query_members(hosts, user="ubuntu", key_file="/tmp/key.pem", timeout=30, deadline=90)
+    hosts = [f"h{n}" for n in range(40)]
+    results = imex.sweep_nodes(hosts, _query, deadline=90)
 
     assert len(results) == len(hosts)
-    assert peak <= module.MAX_PARALLEL_QUERIES
+    assert peak <= imex.MAX_PARALLEL_QUERIES
+
+
+def test_imex_sweep_handles_empty_host_list() -> None:
+    """An empty sweep must not raise (ThreadPoolExecutor rejects max_workers=0)."""
+    imex = _load_common_module("imex.py")
+
+    assert imex.sweep_nodes([], lambda host: {"host": host, "ok": True}, deadline=90) == {}
+
+
+@pytest.mark.parametrize(
+    ("node_ids", "key_file", "expected"),
+    [
+        pytest.param([], "", "skip", id="nothing-configured"),
+        pytest.param([], "/tmp/k.pem", "skip", id="key-only"),
+        pytest.param(["n1"], "", "error", id="nodes-without-key"),
+        pytest.param(["n1"], "/tmp/k.pem", None, id="fully-configured"),
+    ],
+)
+def test_imex_config_gate(node_ids: list[str], key_file: str, expected: str | None) -> None:
+    """An unconfigured run skips so it cannot break unrelated network runs, but a
+    partially configured one stays a hard error - that means someone aimed the
+    check at a cluster and got it wrong, which should not pass silently."""
+    imex = _load_common_module("imex.py")
+
+    gate = imex.config_gate(node_ids, key_file, subject="IMEX domain")
+
+    if expected is None:
+        assert gate is None
+    elif expected == "skip":
+        assert "skip_reason" in gate
+        assert "not configured" in gate["skip_reason"]
+    else:
+        assert "error" in gate
+
+
+def test_imex_parse_node_ids_trims_and_drops_blanks() -> None:
+    """Node ID parsing is shared, so both checks accept the same spellings."""
+    imex = _load_common_module("imex.py")
+
+    assert imex.parse_node_ids(" n1 , ,n2,") == ["n1", "n2"]
 
 
 def _run_imex_script(*args: str) -> subprocess.CompletedProcess[str]:
@@ -2525,7 +2574,7 @@ def test_imex_emits_sdn21_step_output_contract(monkeypatch: pytest.MonkeyPatch) 
     `domain` object plus a `nodes` array of per-node reports, not a flat payload."""
     module = _load_network_script("imex_domain_test.py")
     payload = _imex_up_payload("10.0.0.1", "10.0.0.2")
-    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, payload, ""))
+    monkeypatch.setattr(module, "run_remote", lambda h, *a, **k: {"host": h, "ok": True, "stdout": payload})
     monkeypatch.setattr(
         sys,
         "argv",
@@ -2641,7 +2690,9 @@ def test_imex_service_unreachable_node_stays_in_scope(monkeypatch: pytest.Monkey
     """A node that cannot be reached must not silently drop out of the asserted
     set - it stays in scope and is reported as an error registration."""
     module = _load_network_script("imex_service_test.py")
-    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (255, "", "connection refused"))
+    monkeypatch.setattr(
+        module, "run_remote", lambda h, *a, **k: {"host": h, "ok": False, "error": "connection refused"}
+    )
     monkeypatch.setattr(
         sys,
         "argv",
@@ -2667,7 +2718,9 @@ def test_imex_service_unreachable_node_stays_in_scope(monkeypatch: pytest.Monkey
 def test_imex_service_emits_sdn17_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     """The script emits the SDN17-01 contract shape from the issue."""
     module = _load_network_script("imex_service_test.py")
-    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, _imex_probe_output(), ""))
+    monkeypatch.setattr(
+        module, "run_remote", lambda h, *a, **k: {"host": h, "ok": True, "stdout": _imex_probe_output()}
+    )
     monkeypatch.setattr(
         sys,
         "argv",

--- a/isvctl/tests/providers/aws/test_aws_network_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_network_scripts.py
@@ -2555,3 +2555,157 @@ def test_imex_emits_sdn21_step_output_contract(monkeypatch: pytest.MonkeyPatch) 
     # no leftovers from the old hand-rolled shape
     assert "reachability" not in emitted
     assert "members" not in emitted
+
+
+def _imex_probe_output(daemon: str = "yes", ctl: str = "yes", load: str = "loaded", boot: str = "disabled") -> str:
+    """Build probe stdout in the shape the remote command emits."""
+    return f"DAEMON={daemon}\nCTL={ctl}\nLOAD={load}\nBOOT={boot}\n"
+
+
+def test_imex_service_parses_real_systemd_shape() -> None:
+    """Parse the probe output shape a healthy host emits. LoadState/UnitFileState
+    values are the real ones observed on a live host with nvidia-imex installed."""
+    module = _load_network_script("imex_service_test.py")
+
+    parsed = module._parse_probe(_imex_probe_output())
+
+    assert parsed["service_present"] is True
+    assert parsed["control_tooling_present"] is True
+    assert parsed["service_registration"] == "loaded"
+    assert parsed["boot_disposition"] == "disabled"
+
+
+@pytest.mark.parametrize(
+    ("load_state", "expected"),
+    [
+        pytest.param("loaded", "loaded", id="loaded"),
+        pytest.param("masked", "masked", id="masked"),
+        pytest.param("not-found", "not_found", id="systemd-hyphen-normalized"),
+        pytest.param("", "error", id="no-answer-from-manager"),
+        pytest.param("bogus", "error", id="unrecognized"),
+    ],
+)
+def test_imex_service_normalizes_load_state(load_state: str, expected: str) -> None:
+    """systemd LoadState maps onto the contract's normalized enum. Querying the
+    manager (rather than the filesystem) is what lets absent be told apart from
+    masked - a boolean would collapse the two."""
+    module = _load_network_script("imex_service_test.py")
+
+    assert module._parse_probe(_imex_probe_output(load=load_state))["service_registration"] == expected
+
+
+@pytest.mark.parametrize(
+    ("unit_file_state", "expected"),
+    [
+        pytest.param("enabled", "enabled", id="enabled"),
+        pytest.param("disabled", "disabled", id="disabled"),
+        pytest.param("static", "static", id="static"),
+        pytest.param("", "none", id="empty"),
+        pytest.param("indirect", "unknown", id="unrecognized"),
+        pytest.param("masked", "none", id="masked-has-no-boot-value"),
+    ],
+)
+def test_imex_service_normalizes_boot_disposition(unit_file_state: str, expected: str) -> None:
+    """Boot disposition is evidence only, but still normalized to the contract enum."""
+    module = _load_network_script("imex_service_test.py")
+
+    assert module._parse_probe(_imex_probe_output(boot=unit_file_state))["boot_disposition"] == expected
+
+
+def test_imex_service_control_tooling_present_but_not_invocable() -> None:
+    """The requirement is that the control tool is *invocable*, so a binary that
+    exists but fails to run is not counted as present."""
+    module = _load_network_script("imex_service_test.py")
+
+    parsed = module._parse_probe(_imex_probe_output(ctl="present_not_invocable"))
+
+    assert parsed["control_tooling_present"] is False
+
+
+def test_imex_service_probe_targets_roles_not_package_names() -> None:
+    """The daemon ships branch-versioned and the control tool is a binary inside
+    that package, so the probe must look for the artifacts by role and query the
+    service manager - never `dpkg`/`rpm` on a fixed package name."""
+    module = _load_network_script("imex_service_test.py")
+
+    probe = module._probe_command("nvidia-imex.service", "nvidia-imex", "nvidia-imex-ctl")
+
+    assert "command -v nvidia-imex" in probe
+    assert "command -v nvidia-imex-ctl" in probe
+    assert "systemctl show nvidia-imex.service -p LoadState" in probe
+    assert "dpkg" not in probe and "rpm" not in probe
+    assert "/usr/lib/systemd" not in probe  # query the manager, not the filesystem
+
+
+def test_imex_service_unreachable_node_stays_in_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A node that cannot be reached must not silently drop out of the asserted
+    set - it stays in scope and is reported as an error registration."""
+    module = _load_network_script("imex_service_test.py")
+    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (255, "", "connection refused"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["imex_service_test.py", "--region", "us-west-2", "--node-ids", "n1", "--key-file", "/tmp/k.pem"],
+    )
+
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = module.main()
+    emitted: dict[str, Any] = json.loads(buf.getvalue())
+
+    assert rc == 1
+    assert emitted["nodes_checked"] == 1
+    assert emitted["nodes_validated"] == 0
+    node = emitted["nodes"][0]
+    assert node["in_nvlink_allocation"] is True
+    assert node["service_registration"] == "error"
+
+
+def test_imex_service_emits_sdn17_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script emits the SDN17-01 contract shape from the issue."""
+    module = _load_network_script("imex_service_test.py")
+    monkeypatch.setattr(module, "ssh_run", lambda *a, **k: (0, _imex_probe_output(), ""))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["imex_service_test.py", "--region", "us-west-2", "--node-ids", "n1,n2", "--key-file", "/tmp/k.pem"],
+    )
+
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = module.main()
+    emitted: dict[str, Any] = json.loads(buf.getvalue())
+
+    assert rc == 0
+    assert emitted["nodes_checked"] == 2
+    assert emitted["nodes_validated"] == 2
+    for node in emitted["nodes"]:
+        assert node["in_nvlink_allocation"] is True
+        assert node["service_present"] is True
+        assert node["control_tooling_present"] is True
+        assert node["service_registration"] == "loaded"
+        assert node["boot_disposition"] == "disabled"
+
+
+def test_imex_service_skips_when_not_configured() -> None:
+    """An unconfigured run skips cleanly instead of failing unrelated network runs."""
+    script = AWS_NETWORK_SCRIPTS / "imex_service_test.py"
+    completed = subprocess.run(
+        [sys.executable, str(script), "--region", "us-west-2"],
+        capture_output=True,
+        env={"PATH": os.environ.get("PATH", "")},
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload: dict[str, Any] = json.loads(completed.stdout)
+    assert payload["skipped"] is True
+    assert "not configured" in payload["skip_reason"]

--- a/isvtest/src/isvtest/validations/network.py
+++ b/isvtest/src/isvtest/validations/network.py
@@ -1389,6 +1389,102 @@ class ImexDomainConnectivityCheck(BaseValidation):
         )
 
 
+class ImexServicePresenceCheck(BaseValidation):
+    """Validate IMEX ships in the delivered node image (host model).
+
+    Asserts, per node, that the IMEX daemon and its control tooling are present
+    and that the service is *registered with the node's service manager* - the
+    manager reporting a loaded definition, not a unit file sitting on disk.
+
+    Scope is set by the allocation, not by the node: nodes the provider marks
+    with ``in_nvlink_allocation`` are asserted against. A node must not be able
+    to self-report its way out of scope, so the provider is responsible for
+    setting that flag from the allocation rather than from the node's own view
+    of its NVLink support.
+
+    Zero nodes asserted against is a failure, not a pass - an eight-node run
+    that asserts against none of them is a vacuous pass otherwise.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        nodes: list of {node_id, in_nvlink_allocation, service_present,
+               control_tooling_present, service_registration, boot_disposition}
+        nodes_checked / nodes_validated: counts carried for reporting
+    """
+
+    description: ClassVar[str] = "Check IMEX service and tooling ship in the node image"
+
+    #: Only a loaded definition passes. ``masked`` is a deployment-model
+    #: mismatch rather than a missing package, so it is called out separately.
+    _REGISTRATION_STATES: ClassVar[frozenset[str]] = frozenset({"loaded", "masked", "not_found", "error"})
+
+    def run(self) -> None:
+        """Check IMEX service/tooling presence and service-manager registration."""
+        step_output = self.config.get("step_output", {})
+
+        nodes = step_output.get("nodes")
+        if not isinstance(nodes, list):
+            self.set_failed("`nodes` must be a list of per-node IMEX service reports")
+            return
+
+        for index, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                self.set_failed(f"`nodes[{index}]` must be an object")
+                return
+            if not _is_non_empty_string(node.get("node_id")):
+                self.set_failed(f"`nodes[{index}].node_id` must be a non-empty string")
+                return
+
+        in_scope = [node for node in nodes if node.get("in_nvlink_allocation") is True]
+        if not in_scope:
+            # Counting examined nodes instead of asserted ones is exactly how a
+            # run that skipped everything reports a pass, so fail loudly here.
+            self.set_failed(
+                f"No nodes were asserted against: {len(nodes)} node(s) reported, none marked as part of a "
+                "multi-node NVLink allocation. Scope is set by the allocation, so zero asserted nodes is a "
+                "failure rather than a pass"
+            )
+            return
+
+        failures: list[str] = []
+        for node in in_scope:
+            node_id = node["node_id"]
+
+            if node.get("service_present") is not True:
+                failures.append(f"{node_id}: IMEX service not present in the node image")
+            if node.get("control_tooling_present") is not True:
+                failures.append(f"{node_id}: IMEX control tooling not present or not invocable")
+
+            registration = node.get("service_registration")
+            if not _is_non_empty_string(registration) or registration not in self._REGISTRATION_STATES:
+                failures.append(
+                    f"{node_id}: `service_registration` must be one of "
+                    f"{sorted(self._REGISTRATION_STATES)}, got {registration!r}"
+                )
+            elif registration == "masked":
+                failures.append(
+                    f"{node_id}: IMEX service is masked with the node's service manager - a deployment-model "
+                    "mismatch rather than a missing package"
+                )
+            elif registration != "loaded":
+                failures.append(f"{node_id}: service manager reports registration {registration!r}, expected 'loaded'")
+
+        if failures:
+            self.set_failed(f"IMEX host-model checks failed on {len(failures)} count(s): {'; '.join(failures)}")
+            return
+
+        # Boot disposition is evidence only - whether IMEX starts at boot is
+        # explicitly out of scope, so it is reported and never asserted on.
+        dispositions = sorted({str(node.get("boot_disposition")) for node in in_scope if node.get("boot_disposition")})
+        evidence = f" (boot disposition: {', '.join(dispositions)})" if dispositions else ""
+        self.set_passed(
+            f"IMEX service and control tooling present and registered on all {len(in_scope)} "
+            f"in-scope node(s) of {len(nodes)} reported{evidence}"
+        )
+
+
 class ByoipCheck(BaseValidation):
     """Validate Bring-Your-Own-IP (BYOIP) with non-conflicting custom CIDRs.
 

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -45,6 +45,7 @@ from isvtest.validations.network import (
     ByoipCheck,
     FloatingIpCheck,
     ImexDomainConnectivityCheck,
+    ImexServicePresenceCheck,
     LocalizedDnsCheck,
     NvlinkDomainCheck,
     SgPolicyPropagationTimingCheck,
@@ -1954,6 +1955,149 @@ class TestImexDomainConnectivityCheck:
         result = v.execute()
         assert result["passed"] is True
         assert "3 pair" in result["output"]
+
+
+def _imex_service_node(
+    node_id: str,
+    *,
+    in_alloc: bool = True,
+    service: bool = True,
+    tooling: bool = True,
+    registration: str = "loaded",
+    boot: str = "disabled",
+) -> dict[str, Any]:
+    """Build one per-node entry of the SDN17-01 step output contract."""
+    return {
+        "node_id": node_id,
+        "in_nvlink_allocation": in_alloc,
+        "service_present": service,
+        "control_tooling_present": tooling,
+        "service_registration": registration,
+        "boot_disposition": boot,
+    }
+
+
+def _imex_service_output(nodes: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Build a step_output dict for IMEX service presence tests."""
+    nodes = [_imex_service_node("node-a"), _imex_service_node("node-b")] if nodes is None else nodes
+    return {
+        "step_output": {
+            "success": True,
+            "platform": "network",
+            "nodes_checked": len(nodes),
+            "nodes_validated": len(nodes),
+            "nodes": nodes,
+        }
+    }
+
+
+class TestImexServicePresenceCheck:
+    """Tests for ImexServicePresenceCheck validation (SDN17-01)."""
+
+    def test_all_passed(self) -> None:
+        """Service and tooling present and registered on every in-scope node passes."""
+        v = ImexServicePresenceCheck(config=_imex_service_output())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "2 in-scope node(s)" in result["output"]
+
+    def test_zero_asserted_nodes_fails(self) -> None:
+        """An 8-node run that asserts against none of them must FAIL, not report
+        nodes_checked: 8 and pass vacuously."""
+        nodes = [_imex_service_node(f"node-{n}", in_alloc=False) for n in range(8)]
+        v = ImexServicePresenceCheck(config=_imex_service_output(nodes))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "none marked as part of a multi-node NVLink allocation" in result["error"]
+
+    def test_empty_node_list_fails(self) -> None:
+        """No nodes at all is a failure, not a pass."""
+        v = ImexServicePresenceCheck(config=_imex_service_output([]))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No nodes were asserted against" in result["error"]
+
+    def test_missing_service_fails(self) -> None:
+        """A node without the IMEX daemon in its image fails."""
+        v = ImexServicePresenceCheck(
+            config=_imex_service_output([_imex_service_node("node-a"), _imex_service_node("node-b", service=False)])
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "node-b" in result["error"]
+        assert "service not present" in result["error"]
+
+    def test_missing_control_tooling_fails(self) -> None:
+        """A node without invocable control tooling fails."""
+        v = ImexServicePresenceCheck(
+            config=_imex_service_output([_imex_service_node("node-a", tooling=False), _imex_service_node("node-b")])
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "control tooling not present" in result["error"]
+
+    def test_masked_service_fails_as_deployment_mismatch(self) -> None:
+        """A masked definition FAILS, and is reported as a deployment-model
+        mismatch rather than a missing package."""
+        v = ImexServicePresenceCheck(config=_imex_service_output([_imex_service_node("node-a", registration="masked")]))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "masked" in result["error"]
+        assert "deployment-model mismatch" in result["error"]
+
+    @pytest.mark.parametrize("registration", ["not_found", "error"])
+    def test_unregistered_service_fails(self, registration: str) -> None:
+        """Only a loaded definition passes; a unit file the manager never loaded does not."""
+        v = ImexServicePresenceCheck(
+            config=_imex_service_output([_imex_service_node("node-a", registration=registration)])
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "expected 'loaded'" in result["error"]
+
+    def test_unknown_registration_value_rejected(self) -> None:
+        """A registration value outside the normalized enum is rejected."""
+        v = ImexServicePresenceCheck(config=_imex_service_output([_imex_service_node("node-a", registration="active")]))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "service_registration" in result["error"]
+
+    def test_out_of_scope_nodes_not_asserted(self) -> None:
+        """Nodes outside the allocation are not asserted against, so their state
+        cannot fail the run as long as at least one in-scope node is checked."""
+        nodes = [
+            _imex_service_node("node-a"),
+            _imex_service_node("node-b", in_alloc=False, service=False, registration="not_found"),
+        ]
+        v = ImexServicePresenceCheck(config=_imex_service_output(nodes))
+        result = v.execute()
+        assert result["passed"] is True
+        assert "1 in-scope node(s) of 2 reported" in result["output"]
+
+    def test_boot_disposition_is_not_asserted_on(self) -> None:
+        """Boot disposition is out of scope: a disabled service still passes, and
+        the value is surfaced as evidence."""
+        nodes = [_imex_service_node("node-a", boot="disabled"), _imex_service_node("node-b", boot="static")]
+        v = ImexServicePresenceCheck(config=_imex_service_output(nodes))
+        result = v.execute()
+        assert result["passed"] is True
+        assert "boot disposition" in result["output"]
+
+    def test_malformed_nodes_rejected(self) -> None:
+        """A non-list `nodes` value is rejected rather than raising."""
+        v = ImexServicePresenceCheck(config={"step_output": {"nodes": "oops"}})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "`nodes` must be a list" in result["error"]
+
+    def test_skipped_payload_skips_instead_of_failing(self) -> None:
+        """An unconfigured run skips rather than failing the whole network run."""
+        config = _imex_service_output([])
+        config["step_output"]["skipped"] = True
+        config["step_output"]["skip_reason"] = "IMEX nodes not configured for this run (no node IDs set)"
+        v = ImexServicePresenceCheck(config=config)
+        with pytest.raises(pytest.skip.Exception, match="not configured"):
+            v.execute()
 
 
 class TestValidationResultCapture:


### PR DESCRIPTION
Closes #597

## Summary

Implements **SDN17-01** (#597): asserts IMEX ships in the delivered node image (host model) — daemon present, control tooling invocable, and the service registered with the node's service manager, without tenant installation.

Two things the check is deliberately strict about:

- **Scope comes from the allocation, not the node.** Nodes marked `in_nvlink_allocation` are asserted against, and the provider sets that from the allocation — a node cannot self-report its way out of scope.
- **Zero nodes asserted against is a FAIL.** An eight-node run that asserts against none of them fails rather than reporting `nodes_checked: 8` and passing vacuously.

Registration is read from the service manager, not the filesystem — a unit file the manager never loaded does not count. Only `loaded` passes; `masked` fails as a deployment-model mismatch rather than a missing package. Boot disposition and running state are out of scope (boot disposition is carried as evidence only).

Artifacts are probed **by role, not by package name**: the daemon ships branch-versioned and the control tool is a binary inside that package, so a fixed package name goes stale each driver branch. The control tool is invoked, not merely located. Registration uses `systemctl show -p LoadState`, which distinguishes absent from masked where a boolean would collapse both.

Step output follows the contract in the issue, registered as the `imex_service` schema. Providers: `my-isv` template/demo stub, `aws` real SSH-based reference. NICo remains a documented gap (no live host telemetry), alongside SDN21-01.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added IMEX service presence validation for supported network environments.
  - Checks IMEX daemon and control-tool availability, service registration, and node-level status.
  - Reports structured results, including allocation scope, boot state, skipped runs, and unreachable nodes.
  - Added provider-specific configuration for AWS and ISV environments.

- **Documentation**
  - Updated test labels and documented that NICo bare-metal checks cannot provide IMEX host telemetry.

- **Tests**
  - Added coverage for IMEX probing, parsing, allocation scoping, failure states, and skipped configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->