### PR TITLE
feat(k8s): verify the control plane holds the tenant's pinned size (K8S27-01)

### DIFF
--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -3699,7 +3699,7 @@ a|
 | [[K8S27-01]]K8S27-01
 | K8S27
 | https://github.com/NVIDIA/ai-cloud-validation/issues/217[#217]
-| min_req
+| kubernetes, min_req
 | tenant
 |
 | P2

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -3352,6 +3352,7 @@ domains:
                 milestone: ""
               - summary: Pin Control Plane instances to a specific count to handle a particular load-limit
                 labels:
+                  - kubernetes
                   - min_req
                 req_id: K8S27
                 test_id: K8S27-01

--- a/isvctl/configs/providers/my-isv/config/k8s.yaml
+++ b/isvctl/configs/providers/my-isv/config/k8s.yaml
@@ -54,6 +54,17 @@ commands:
         command: "../scripts/k8s/teardown.sh"
         timeout: 30
 
+      # Control-plane size pinning (K8S27-01). Drop this step if your managed
+      # offering exposes no control-plane sizing knob - K8sControlPlaneSizePinnedCheck
+      # then skips instead of reporting a pin nobody can make.
+      - name: pin_control_plane
+        phase: setup
+        command: "python3 ../scripts/k8s/pin_control_plane.py"
+        args:
+          - "--instance-count={{control_plane_instance_count}}"
+        output_schema: control_plane_size
+        timeout: 1800
+
       # Break-fix actions (BFX01). Demo stubs until real cluster APIs are wired.
       - name: reset_gpus
         phase: test
@@ -79,3 +90,6 @@ tests:
     region: ""
     machine_id: ""
     breakfix_node: "{{env.ISVTEST_BREAKFIX_NODE | default('', true)}}"
+    # Control-plane instance count to pin (K8S27-01). Set this to the size that
+    # carries the load limit you are certifying for.
+    control_plane_instance_count: 3

--- a/isvctl/configs/providers/my-isv/config/k8s.yaml
+++ b/isvctl/configs/providers/my-isv/config/k8s.yaml
@@ -63,7 +63,7 @@ commands:
         args:
           - "--instance-count={{control_plane_instance_count}}"
         output_schema: control_plane_size
-        timeout: 1800
+        timeout: 900
 
       # Break-fix actions (BFX01). Demo stubs until real cluster APIs are wired.
       - name: reset_gpus

--- a/isvctl/configs/providers/my-isv/scripts/k8s/pin_control_plane.py
+++ b/isvctl/configs/providers/my-isv/scripts/k8s/pin_control_plane.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pin the Kubernetes control plane to an instance count (K8S27-01) - my-isv template.
+
+TODO: replace the stub below with a call to your control-plane sizing API.
+
+The step has to do two things: request the pin, and report the size the cluster
+actually ended up running. Wait for the resize to settle before reporting -
+``instance_count`` is what the provider delivered, not what it accepted, and
+K8sControlPlaneSizePinnedCheck compares the two.
+
+Providers whose managed offering exposes no control-plane sizing knob should
+leave this step out of their config rather than stub it; the check then skips
+as ``step_not_configured`` instead of reporting a pin nobody can make.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow importing provider-local helpers from scripts/common/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from common.stub import emit_stub
+
+
+def main() -> int:
+    """Emit the control-plane pin template result (K8S27-01)."""
+    parser = argparse.ArgumentParser(description="Pin the control plane to an instance count (template)")
+    parser.add_argument(
+        "--instance-count",
+        type=int,
+        default=3,
+        help="Control-plane instance count to pin the cluster to",
+    )
+    args = parser.parse_args()
+
+    if args.instance_count < 1:
+        parser.error("--instance-count must be at least 1")
+
+    return emit_stub(
+        "pin_control_plane",
+        hint="control-plane sizing API",
+        requested_instance_count=args.instance_count,
+        instance_count=args.instance_count,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -150,6 +150,21 @@ tests:
           labels: ["kubernetes", "min_req"]
           step: create_test_shared_vpc_cluster
 
+    # Control-plane size pinning (K8S27-01). Only runs for providers that
+    # implement pin_control_plane and bind this check to that step; a managed
+    # offering exposing no control-plane sizing knob has nothing to wire, and
+    # the check skips as step_not_configured rather than passing.
+    #
+    # The step pins the control plane and reports requested_instance_count
+    # alongside the instance_count it delivered; the check corroborates that
+    # count against the API server endpoints the cluster itself registers.
+    k8s_control_plane_size:
+      checks:
+        K8sControlPlaneSizePinnedCheck:
+          test_id: "K8S27-01"
+          labels: ["kubernetes", "min_req"]
+          step: pin_control_plane
+
     kubernetes:
       checks:
         K8sNodeCountCheck:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -164,6 +164,10 @@ tests:
           test_id: "K8S27-01"
           labels: ["kubernetes", "min_req"]
           step: pin_control_plane
+          # The pin is a setup-phase act; hold the check back to the test phase
+          # so the endpoint count it reads is a later sample than the one the
+          # step reported, and a size that has since drifted is caught.
+          phase: test
 
     kubernetes:
       checks:

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -150,6 +150,8 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     # Multi-cluster operations
     "create_test_shared_vpc_cluster": "multi_cluster",
     "destroy_test_shared_vpc_cluster": "teardown",
+    # Control-plane size pinning
+    "pin_control_plane": "control_plane_size",
 }
 
 # Common fields present in all outputs
@@ -1114,6 +1116,32 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
                 "type": "string",
                 "enum": ["cpu", "gpu"],
                 "description": "Informational node pool flavor",
+            },
+        },
+        "additionalProperties": True,
+    },
+    # =========================================================================
+    # Control-plane size pinning schemas
+    # =========================================================================
+    "control_plane_size": {
+        "type": "object",
+        "required": [
+            "success",
+            "platform",
+            "requested_instance_count",
+            "instance_count",
+        ],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "requested_instance_count": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Control-plane instance count the tenant pinned",
+            },
+            "instance_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Control-plane instance count the provider runs after the pin",
             },
         },
         "additionalProperties": True,

--- a/isvtest/src/isvtest/validations/k8s_control_plane_size.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_size.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Control-plane size pinning checks (K8S27)."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, parse_kubectl_json
+from isvtest.core.validation import BaseValidation
+
+# The ``kubernetes`` Service in ``default`` is maintained by the API servers
+# themselves - each instance that reaches the endpoint reconciler publishes one
+# address. It is the only provider-neutral view of API server instance count a
+# tenant gets on a managed control plane.
+APISERVER_SERVICE = "kubernetes"
+APISERVER_NAMESPACE = "default"
+
+
+class K8sControlPlaneSizePinnedCheck(BaseValidation):
+    """Verify the control plane holds the instance count the tenant pinned.
+
+    A managed Kubernetes control plane is normally sized by the provider, and
+    the requirement is that a tenant can instead pin it to a chosen instance
+    count so it is guaranteed to carry a known load limit. Pinning is an act,
+    not an observation, so the bound provider step performs it and reports both
+    the count the tenant requested and the count the provider ended up running.
+
+    Taking that report at face value would let a provider certify by asserting
+    its own compliance, so the delivered count is corroborated against the
+    cluster itself: the ``kubernetes`` Service in ``default`` carries one
+    endpoint address per registered API server. Two things make that
+    corroboration worth having. It is an independent measurement, and because
+    the validation runs in the test phase it is also a *later* one - a count
+    that has drifted since the pin step reported it shows up here.
+
+    The comparison is deliberately one-sided. A provider that fronts its API
+    servers with a single load-balanced address publishes one endpoint however
+    many instances are behind it, so fewer registered endpoints than the pin is
+    expected and proves nothing either way. More registered endpoints than the
+    pin cannot be explained that way: fronting and registration can hide
+    instances, never invent them, so the count is not being held.
+
+    Step output:
+        requested_instance_count: Control-plane instance count the tenant
+            pinned. Must be at least 1.
+        instance_count: Control-plane instance count the provider runs after
+            the pin.
+    """
+
+    description: ClassVar[str] = (
+        "Verify the Kubernetes control plane is pinned to the instance count the tenant requested."
+    )
+
+    def run(self) -> None:
+        """Compare the pin the step reported against the live API server registration."""
+        step_output = self.config.get("step_output")
+        if not isinstance(step_output, dict):
+            self.set_failed("Missing step_output for control-plane size pinning validation")
+            return
+
+        if step_output.get("success") is False:
+            self.set_failed(str(step_output.get("error") or step_output.get("message") or "Pin step reported failure"))
+            return
+
+        requested = _instance_count(step_output.get("requested_instance_count"))
+        if requested is None or requested < 1:
+            self.set_failed(
+                "Step output must report requested_instance_count as an integer of at least 1, got "
+                f"{step_output.get('requested_instance_count')!r}"
+            )
+            return
+
+        delivered = _instance_count(step_output.get("instance_count"))
+        if delivered is None:
+            self.set_failed(
+                f"Step output must report instance_count as an integer, got {step_output.get('instance_count')!r}"
+            )
+            return
+
+        if delivered != requested:
+            self.set_failed(
+                f"Control plane was not pinned: the tenant requested {requested} instance(s) and the provider "
+                f"reports {delivered}"
+            )
+            return
+
+        registered = self._registered_apiservers()
+        if registered is None:
+            return
+
+        if registered > requested:
+            self.set_failed(
+                f"Control plane is not held at {requested} instance(s): {APISERVER_NAMESPACE}/{APISERVER_SERVICE} "
+                f"registers {registered} API server endpoint(s), more than the pin allows"
+            )
+            return
+
+        if registered < requested:
+            corroboration = (
+                f"{registered} API server endpoint(s) are registered, which a load-balanced API address cannot "
+                f"distinguish from {requested}"
+            )
+        else:
+            corroboration = f"{registered} API server endpoint(s) are registered, matching the pin"
+        self.set_passed(f"Control plane is pinned at {requested} instance(s); {corroboration}")
+
+    def _registered_apiservers(self) -> int | None:
+        """Return the API server endpoint count, or ``None`` after marking the check failed.
+
+        The count is the independent half of the proof, so a probe that cannot
+        be answered leaves only the provider's own report and fails rather than
+        passing on it.
+        """
+        kubectl_base = get_kubectl_base_shell()
+        result = self.run_command(f"{kubectl_base} get endpoints {APISERVER_SERVICE} -n {APISERVER_NAMESPACE} -o json")
+        if result.exit_code != 0:
+            self.set_failed(
+                f"Could not count registered API servers from {APISERVER_NAMESPACE}/{APISERVER_SERVICE}: "
+                f"{result.stderr.strip() or result.stdout.strip() or f'exit {result.exit_code}'}"
+            )
+            return None
+
+        try:
+            payload = parse_kubectl_json(result, f"{APISERVER_NAMESPACE}/{APISERVER_SERVICE} endpoints")
+        except KubectlParseError as exc:
+            self.set_failed(str(exc))
+            return None
+
+        addresses = _endpoint_addresses(payload)
+        if not addresses:
+            self.set_failed(
+                f"{APISERVER_NAMESPACE}/{APISERVER_SERVICE} registers no API server endpoints, so the pinned "
+                "control-plane size cannot be corroborated"
+            )
+            return None
+        return len(addresses)
+
+
+def _endpoint_addresses(payload: dict[str, Any]) -> set[str]:
+    """Return the distinct ready endpoint addresses across an Endpoints object's subsets."""
+    addresses: set[str] = set()
+    subsets = payload.get("subsets")
+    if not isinstance(subsets, list):
+        return addresses
+    for subset in subsets:
+        if not isinstance(subset, dict):
+            continue
+        for address in subset.get("addresses") or []:
+            if isinstance(address, dict) and isinstance(address.get("ip"), str) and address["ip"].strip():
+                addresses.add(address["ip"].strip())
+    return addresses
+
+
+def _instance_count(value: Any) -> int | None:
+    """Return ``value`` as a non-negative int, rejecting bools and non-integers.
+
+    Decimal strings are accepted so a provider script emitting ``"3"`` is not
+    treated as a broken contract.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float):
+        return int(value) if value.is_integer() and value >= 0 else None
+    if isinstance(value, str) and value.strip().isdecimal():
+        return int(value.strip())
+    return None

--- a/isvtest/src/isvtest/validations/k8s_control_plane_size.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_size.py
@@ -54,9 +54,7 @@ class K8sControlPlaneSizePinnedCheck(BaseValidation):
     its own compliance, so the delivered count is corroborated against the
     cluster itself: the ``kubernetes`` Service in ``default`` carries one
     endpoint per registered API server. That measurement is independent of the
-    provider, and the suite holds this check back to the test phase while the
-    pin runs during setup, so it is also a later sample - a size that has
-    drifted since the step reported it shows up here.
+    provider.
 
     The comparison is deliberately one-sided. A provider that fronts its API
     servers with a single load-balanced address publishes one endpoint however
@@ -120,14 +118,15 @@ class K8sControlPlaneSizePinnedCheck(BaseValidation):
             )
             return
 
-        if registered < requested:
-            corroboration = (
-                f"{registered} API server endpoint(s) are registered, which a load-balanced API address cannot "
-                f"distinguish from {requested}"
-            )
-        else:
-            corroboration = f"{registered} API server endpoint(s) are registered, matching the pin"
-        self.set_passed(f"Control plane is pinned at {requested} instance(s); {corroboration}")
+        corroboration = (
+            "matching the pin"
+            if registered == requested
+            else f"which a load-balanced API address cannot distinguish from {requested}"
+        )
+        self.set_passed(
+            f"Control plane is pinned at {requested} instance(s); "
+            f"{registered} API server endpoint(s) are registered, {corroboration}"
+        )
 
     def _registered_apiservers(self) -> int | None:
         """Return the API server endpoint count, or ``None`` after marking the check failed.
@@ -170,13 +169,10 @@ class K8sControlPlaneSizePinnedCheck(BaseValidation):
         except KubectlParseError as exc:
             return None, str(exc)
 
-        counts = _ready_endpoints_per_family(items)
-        if not counts:
+        count = _ready_endpoint_count(items)
+        if count == 0:
             return None, NO_ENDPOINTS_REASON
-        # A dual-stack Service is backed by one slice family per address type,
-        # each enumerating every API server once, so the families are
-        # alternative views of the same instances rather than additions to it.
-        return max(counts.values()), ""
+        return count, ""
 
     def _count_via_endpoints(self, kubectl_base: str) -> tuple[int | None, str]:
         """Count ready API servers from the deprecated v1 Endpoints object.
@@ -203,8 +199,8 @@ def _command_error(result: CommandResult) -> str:
     return result.stderr.strip() or result.stdout.strip() or f"exit {result.exit_code}"
 
 
-def _ready_endpoints_per_family(items: list[dict[str, Any]]) -> dict[str, int]:
-    """Return the distinct ready endpoint count per address family across EndpointSlices.
+def _ready_endpoint_count(items: list[dict[str, Any]]) -> int:
+    """Return the number of distinct ready API server endpoints across EndpointSlices.
 
     One family's endpoints can be sharded over several slices, so addresses are
     pooled per family before being counted.
@@ -221,7 +217,10 @@ def _ready_endpoints_per_family(items: list[dict[str, Any]]) -> dict[str, int]:
             address = _ready_address(endpoint)
             if address:
                 addresses.add(address)
-    return {family: len(addresses) for family, addresses in per_family.items() if addresses}
+    # A dual-stack Service is backed by one slice family per address type, each
+    # enumerating every API server once, so the families are alternative views
+    # of the same instances rather than additions to it.
+    return max((len(addresses) for addresses in per_family.values()), default=0)
 
 
 def _ready_address(endpoint: dict[str, Any]) -> str:
@@ -243,21 +242,23 @@ def _ready_address(endpoint: dict[str, Any]) -> str:
 def _endpoint_addresses(payload: dict[str, Any]) -> set[str]:
     """Return the distinct ready endpoint addresses across an Endpoints object's subsets."""
     addresses: set[str] = set()
-    subsets = payload.get("subsets")
-    if not isinstance(subsets, list):
-        return addresses
-    for subset in subsets:
+    for subset in payload.get("subsets") or []:
         if not isinstance(subset, dict):
             continue
         for address in subset.get("addresses") or []:
-            if isinstance(address, dict) and isinstance(address.get("ip"), str) and address["ip"].strip():
-                addresses.add(address["ip"].strip())
+            if not isinstance(address, dict):
+                continue
+            ip = address.get("ip")
+            if isinstance(ip, str) and ip.strip():
+                addresses.add(ip.strip())
     return addresses
 
 
 def _instance_count(value: Any) -> int | None:
     """Return ``value`` as a non-negative int, rejecting bools and non-integers.
 
+    The ``control_plane_size`` output schema already declares both counts as
+    integers, so this is a second line of defence rather than the contract.
     Decimal strings are accepted so a provider script emitting ``"3"`` is not
     treated as a broken contract.
     """
@@ -265,8 +266,6 @@ def _instance_count(value: Any) -> int | None:
         return None
     if isinstance(value, int):
         return value if value >= 0 else None
-    if isinstance(value, float):
-        return int(value) if value.is_integer() and value >= 0 else None
     if isinstance(value, str) and value.strip().isdecimal():
         return int(value.strip())
     return None

--- a/isvtest/src/isvtest/validations/k8s_control_plane_size.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_size.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, parse_kubectl_json
+from isvtest.core.k8s import (
+    KubectlParseError,
+    get_kubectl_base_shell,
+    parse_kubectl_json,
+    parse_kubectl_json_items,
+)
+from isvtest.core.runners import CommandResult
 from isvtest.core.validation import BaseValidation
 
 # The ``kubernetes`` Service in ``default`` is maintained by the API servers
@@ -28,6 +34,11 @@ from isvtest.core.validation import BaseValidation
 # tenant gets on a managed control plane.
 APISERVER_SERVICE = "kubernetes"
 APISERVER_NAMESPACE = "default"
+
+# EndpointSlices carry the name of the Service they back as a label.
+SERVICE_NAME_LABEL = "kubernetes.io/service-name"
+
+NO_ENDPOINTS_REASON = "registers no ready API server endpoints"
 
 
 class K8sControlPlaneSizePinnedCheck(BaseValidation):
@@ -42,10 +53,10 @@ class K8sControlPlaneSizePinnedCheck(BaseValidation):
     Taking that report at face value would let a provider certify by asserting
     its own compliance, so the delivered count is corroborated against the
     cluster itself: the ``kubernetes`` Service in ``default`` carries one
-    endpoint address per registered API server. That measurement is
-    independent of the provider, and the suite holds this check back to the
-    test phase while the pin runs during setup, so it is also a later sample -
-    a size that has drifted since the step reported it shows up here.
+    endpoint per registered API server. That measurement is independent of the
+    provider, and the suite holds this check back to the test phase while the
+    pin runs during setup, so it is also a later sample - a size that has
+    drifted since the step reported it shows up here.
 
     The comparison is deliberately one-sided. A provider that fronts its API
     servers with a single load-balanced address publishes one endpoint however
@@ -123,31 +134,110 @@ class K8sControlPlaneSizePinnedCheck(BaseValidation):
 
         The count is the independent half of the proof, so a probe that cannot
         be answered leaves only the provider's own report and fails rather than
-        passing on it.
+        passing on it. EndpointSlice is asked first because the v1 Endpoints
+        API is deprecated from Kubernetes 1.33; Endpoints remains the fallback
+        for clusters, or RBAC grants, that only answer there.
         """
         kubectl_base = get_kubectl_base_shell()
+        count, slice_error = self._count_via_endpoint_slices(kubectl_base)
+        if count is not None:
+            return count
+
+        count, endpoints_error = self._count_via_endpoints(kubectl_base)
+        if count is not None:
+            return count
+
+        self.set_failed(
+            f"Could not count registered API servers for {APISERVER_NAMESPACE}/{APISERVER_SERVICE} - "
+            f"EndpointSlice: {slice_error}; Endpoints: {endpoints_error}"
+        )
+        return None
+
+    def _count_via_endpoint_slices(self, kubectl_base: str) -> tuple[int | None, str]:
+        """Count ready API servers from the EndpointSlices backing the Service.
+
+        Returns the count, or ``None`` alongside the reason it is unavailable.
+        """
+        result = self.run_command(
+            f"{kubectl_base} get endpointslices -n {APISERVER_NAMESPACE} "
+            f"-l {SERVICE_NAME_LABEL}={APISERVER_SERVICE} -o json"
+        )
+        if result.exit_code != 0:
+            return None, _command_error(result)
+
+        try:
+            items = parse_kubectl_json_items(result, f"{APISERVER_NAMESPACE}/{APISERVER_SERVICE} endpointslices")
+        except KubectlParseError as exc:
+            return None, str(exc)
+
+        counts = _ready_endpoints_per_family(items)
+        if not counts:
+            return None, NO_ENDPOINTS_REASON
+        # A dual-stack Service is backed by one slice family per address type,
+        # each enumerating every API server once, so the families are
+        # alternative views of the same instances rather than additions to it.
+        return max(counts.values()), ""
+
+    def _count_via_endpoints(self, kubectl_base: str) -> tuple[int | None, str]:
+        """Count ready API servers from the deprecated v1 Endpoints object.
+
+        Returns the count, or ``None`` alongside the reason it is unavailable.
+        """
         result = self.run_command(f"{kubectl_base} get endpoints {APISERVER_SERVICE} -n {APISERVER_NAMESPACE} -o json")
         if result.exit_code != 0:
-            self.set_failed(
-                f"Could not count registered API servers from {APISERVER_NAMESPACE}/{APISERVER_SERVICE}: "
-                f"{result.stderr.strip() or result.stdout.strip() or f'exit {result.exit_code}'}"
-            )
-            return None
+            return None, _command_error(result)
 
         try:
             payload = parse_kubectl_json(result, f"{APISERVER_NAMESPACE}/{APISERVER_SERVICE} endpoints")
         except KubectlParseError as exc:
-            self.set_failed(str(exc))
-            return None
+            return None, str(exc)
 
         addresses = _endpoint_addresses(payload)
         if not addresses:
-            self.set_failed(
-                f"{APISERVER_NAMESPACE}/{APISERVER_SERVICE} registers no API server endpoints, so the pinned "
-                "control-plane size cannot be corroborated"
-            )
-            return None
-        return len(addresses)
+            return None, NO_ENDPOINTS_REASON
+        return len(addresses), ""
+
+
+def _command_error(result: CommandResult) -> str:
+    """Return the most informative line a failed kubectl invocation produced."""
+    return result.stderr.strip() or result.stdout.strip() or f"exit {result.exit_code}"
+
+
+def _ready_endpoints_per_family(items: list[dict[str, Any]]) -> dict[str, int]:
+    """Return the distinct ready endpoint count per address family across EndpointSlices.
+
+    One family's endpoints can be sharded over several slices, so addresses are
+    pooled per family before being counted.
+    """
+    per_family: dict[str, set[str]] = {}
+    for item in items:
+        family = item.get("addressType")
+        if not isinstance(family, str) or not family.strip():
+            continue
+        addresses = per_family.setdefault(family.strip(), set())
+        for endpoint in item.get("endpoints") or []:
+            if not isinstance(endpoint, dict):
+                continue
+            address = _ready_address(endpoint)
+            if address:
+                addresses.add(address)
+    return {family: len(addresses) for family, addresses in per_family.items() if addresses}
+
+
+def _ready_address(endpoint: dict[str, Any]) -> str:
+    """Return an EndpointSlice endpoint's identifying address, or ``""`` if it is not serving.
+
+    ``conditions.ready`` only withholds an endpoint when explicitly ``false`` -
+    the API defines an absent value as ready. Only the first address is
+    meaningful to consumers, so it stands for the instance.
+    """
+    conditions = endpoint.get("conditions")
+    if isinstance(conditions, dict) and conditions.get("ready") is False:
+        return ""
+    for address in endpoint.get("addresses") or []:
+        if isinstance(address, str) and address.strip():
+            return address.strip()
+    return ""
 
 
 def _endpoint_addresses(payload: dict[str, Any]) -> set[str]:

--- a/isvtest/src/isvtest/validations/k8s_control_plane_size.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_size.py
@@ -42,10 +42,10 @@ class K8sControlPlaneSizePinnedCheck(BaseValidation):
     Taking that report at face value would let a provider certify by asserting
     its own compliance, so the delivered count is corroborated against the
     cluster itself: the ``kubernetes`` Service in ``default`` carries one
-    endpoint address per registered API server. Two things make that
-    corroboration worth having. It is an independent measurement, and because
-    the validation runs in the test phase it is also a *later* one - a count
-    that has drifted since the pin step reported it shows up here.
+    endpoint address per registered API server. That measurement is
+    independent of the provider, and the suite holds this check back to the
+    test phase while the pin runs during setup, so it is also a later sample -
+    a size that has drifted since the step reported it shows up here.
 
     The comparison is deliberately one-sided. A provider that fronts its API
     servers with a single load-balanced address publishes one endpoint however

--- a/isvtest/tests/test_k8s_control_plane_size.py
+++ b/isvtest/tests/test_k8s_control_plane_size.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the control-plane size pinning validation (K8S27-01)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_control_plane_size import K8sControlPlaneSizePinnedCheck
+
+ENDPOINTS_COMMAND = "kubectl get endpoints kubernetes -n default -o json"
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult``."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Return a failed ``CommandResult``."""
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _endpoints(*ips: str) -> str:
+    """Return an Endpoints payload publishing one address per ``ips`` entry."""
+    return json.dumps({"subsets": [{"addresses": [{"ip": ip} for ip in ips]}]})
+
+
+def _step_output(**overrides: Any) -> dict[str, Any]:
+    """Return a control-plane pin step output honouring a 3-instance pin."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "kubernetes",
+        "requested_instance_count": 3,
+        "instance_count": 3,
+    }
+    output.update(overrides)
+    return output
+
+
+def _run(step_output: Any, endpoints: CommandResult | None = None) -> K8sControlPlaneSizePinnedCheck:
+    """Run the check against ``step_output``, answering the endpoints probe with ``endpoints``."""
+    check = K8sControlPlaneSizePinnedCheck(config={"step_output": step_output})
+    response = endpoints if endpoints is not None else _ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3"))
+    with (
+        patch("isvtest.validations.k8s_control_plane_size.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=response) as mock_run,
+    ):
+        check.run()
+    check.commands_run = [call[0][0] for call in mock_run.call_args_list]  # type: ignore[attr-defined]
+    return check
+
+
+def test_passes_when_registered_apiservers_match_the_pin() -> None:
+    """A pin the provider delivered and the cluster corroborates exactly passes."""
+    check = _run(_step_output())
+
+    assert check.passed, check.message
+    assert "pinned at 3 instance(s)" in check.message
+    assert "matching the pin" in check.message
+    assert check.commands_run == [ENDPOINTS_COMMAND]
+
+
+def test_passes_when_a_load_balanced_api_address_hides_instances() -> None:
+    """One endpoint behind a fronted API address cannot contradict a larger pin."""
+    check = _run(_step_output(), endpoints=_ok(_endpoints("10.0.0.1")))
+
+    assert check.passed, check.message
+    assert "load-balanced" in check.message
+
+
+def test_fails_when_more_apiservers_are_registered_than_pinned() -> None:
+    """Extra registered API servers cannot be explained by fronting, so the pin is not held."""
+    check = _run(_step_output(), endpoints=_ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4")))
+
+    assert not check.passed
+    assert "not held at 3 instance(s)" in check.message
+    assert "registers 4" in check.message
+
+
+def test_fails_when_the_provider_delivered_a_different_count() -> None:
+    """A delivered count that differs from the request is not a pin, and needs no probe."""
+    check = _run(_step_output(instance_count=2))
+
+    assert not check.passed
+    assert "requested 3 instance(s) and the provider reports 2" in check.message
+    assert check.commands_run == []
+
+
+def test_counts_distinct_addresses_across_subsets() -> None:
+    """Addresses repeated across subsets describe one API server each, not several."""
+    payload = json.dumps(
+        {
+            "subsets": [
+                {"addresses": [{"ip": "10.0.0.1"}, {"ip": "10.0.0.2"}]},
+                {"addresses": [{"ip": "10.0.0.2"}, {"ip": "10.0.0.3"}]},
+            ]
+        }
+    )
+
+    check = _run(_step_output(), endpoints=_ok(payload))
+
+    assert check.passed, check.message
+    assert "3 API server endpoint(s)" in check.message
+
+
+def test_accepts_counts_emitted_as_decimal_strings() -> None:
+    """A provider script emitting counts as strings still satisfies the contract."""
+    check = _run(_step_output(requested_instance_count="3", instance_count="3"))
+
+    assert check.passed, check.message
+
+
+def test_fails_when_the_pin_step_reported_failure() -> None:
+    """A pin that did not happen is reported with the step's own error."""
+    check = _run(_step_output(success=False, error="control-plane resize quota exceeded"))
+
+    assert not check.passed
+    assert "control-plane resize quota exceeded" in check.message
+    assert check.commands_run == []
+
+
+def test_fails_without_step_output() -> None:
+    """An unbound check has no pin to verify."""
+    check = _run(None)
+
+    assert not check.passed
+    assert "Missing step_output" in check.message
+
+
+@pytest.mark.parametrize("requested", [0, -1, True, "three", None, 2.5])
+def test_fails_on_an_unusable_requested_count(requested: Any) -> None:
+    """The requested count has to be a real instance count for the pin to mean anything."""
+    check = _run(_step_output(requested_instance_count=requested))
+
+    assert not check.passed
+    assert "requested_instance_count" in check.message
+
+
+def test_fails_when_the_delivered_count_is_missing() -> None:
+    """Without a delivered count there is nothing to compare the request against."""
+    output = _step_output()
+    output.pop("instance_count")
+
+    check = _run(output)
+
+    assert not check.passed
+    assert "instance_count" in check.message
+
+
+def test_fails_when_the_endpoints_probe_is_refused() -> None:
+    """Losing the independent measurement leaves only the provider's own report."""
+    check = _run(
+        _step_output(),
+        endpoints=_fail(stderr='Error from server (Forbidden): endpoints "kubernetes" is forbidden'),
+    )
+
+    assert not check.passed
+    assert "Could not count registered API servers" in check.message
+    assert "Forbidden" in check.message
+
+
+def test_fails_when_the_endpoints_payload_is_malformed() -> None:
+    """Unparseable probe output is inconclusive, not a pass."""
+    check = _run(_step_output(), endpoints=_ok("not json"))
+
+    assert not check.passed
+    assert "Failed to parse" in check.message
+
+
+def test_fails_when_no_apiserver_endpoints_are_registered() -> None:
+    """An Endpoints object with no addresses corroborates nothing."""
+    check = _run(_step_output(), endpoints=_ok(json.dumps({"subsets": []})))
+
+    assert not check.passed
+    assert "registers no API server endpoints" in check.message

--- a/isvtest/tests/test_k8s_control_plane_size.py
+++ b/isvtest/tests/test_k8s_control_plane_size.py
@@ -26,6 +26,7 @@ import pytest
 from isvtest.core.runners import CommandResult
 from isvtest.validations.k8s_control_plane_size import K8sControlPlaneSizePinnedCheck
 
+SLICES_COMMAND = "kubectl get endpointslices -n default -l kubernetes.io/service-name=kubernetes -o json"
 ENDPOINTS_COMMAND = "kubectl get endpoints kubernetes -n default -o json"
 
 
@@ -37,6 +38,22 @@ def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
 def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
     """Return a failed ``CommandResult``."""
     return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _slice(*ips: str, family: str = "IPv4", ready: bool | None = True) -> dict[str, Any]:
+    """Return one EndpointSlice publishing an endpoint per ``ips`` entry."""
+    endpoint: list[dict[str, Any]] = []
+    for ip in ips:
+        record: dict[str, Any] = {"addresses": [ip]}
+        if ready is not None:
+            record["conditions"] = {"ready": ready}
+        endpoint.append(record)
+    return {"addressType": family, "endpoints": endpoint}
+
+
+def _slices(*slices: dict[str, Any]) -> str:
+    """Return a kubectl EndpointSlice list payload wrapping ``slices``."""
+    return json.dumps({"items": list(slices)})
 
 
 def _endpoints(*ips: str) -> str:
@@ -56,13 +73,24 @@ def _step_output(**overrides: Any) -> dict[str, Any]:
     return output
 
 
-def _run(step_output: Any, endpoints: CommandResult | None = None) -> K8sControlPlaneSizePinnedCheck:
-    """Run the check against ``step_output``, answering the endpoints probe with ``endpoints``."""
+def _run(
+    step_output: Any,
+    slices: CommandResult | None = None,
+    endpoints: CommandResult | None = None,
+) -> K8sControlPlaneSizePinnedCheck:
+    """Run the check, answering the EndpointSlice probe and its Endpoints fallback.
+
+    The fallback defaults to a refusal so a test exercising the EndpointSlice
+    path cannot pass by silently falling through to Endpoints.
+    """
     check = K8sControlPlaneSizePinnedCheck(config={"step_output": step_output})
-    response = endpoints if endpoints is not None else _ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3"))
+    responses = {
+        SLICES_COMMAND: slices if slices is not None else _ok(_slices(_slice("10.0.0.1", "10.0.0.2", "10.0.0.3"))),
+        ENDPOINTS_COMMAND: endpoints if endpoints is not None else _fail(stderr="Endpoints was not expected"),
+    }
     with (
         patch("isvtest.validations.k8s_control_plane_size.get_kubectl_base_shell", return_value="kubectl"),
-        patch.object(check, "run_command", return_value=response) as mock_run,
+        patch.object(check, "run_command", side_effect=lambda command, **_: responses[command]) as mock_run,
     ):
         check.run()
     check.commands_run = [call[0][0] for call in mock_run.call_args_list]  # type: ignore[attr-defined]
@@ -76,12 +104,12 @@ def test_passes_when_registered_apiservers_match_the_pin() -> None:
     assert check.passed, check.message
     assert "pinned at 3 instance(s)" in check.message
     assert "matching the pin" in check.message
-    assert check.commands_run == [ENDPOINTS_COMMAND]
+    assert check.commands_run == [SLICES_COMMAND]
 
 
 def test_passes_when_a_load_balanced_api_address_hides_instances() -> None:
     """One endpoint behind a fronted API address cannot contradict a larger pin."""
-    check = _run(_step_output(), endpoints=_ok(_endpoints("10.0.0.1")))
+    check = _run(_step_output(), slices=_ok(_slices(_slice("10.0.0.1"))))
 
     assert check.passed, check.message
     assert "load-balanced" in check.message
@@ -89,7 +117,10 @@ def test_passes_when_a_load_balanced_api_address_hides_instances() -> None:
 
 def test_fails_when_more_apiservers_are_registered_than_pinned() -> None:
     """Extra registered API servers cannot be explained by fronting, so the pin is not held."""
-    check = _run(_step_output(), endpoints=_ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4")))
+    check = _run(
+        _step_output(),
+        slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"))),
+    )
 
     assert not check.passed
     assert "not held at 3 instance(s)" in check.message
@@ -105,8 +136,79 @@ def test_fails_when_the_provider_delivered_a_different_count() -> None:
     assert check.commands_run == []
 
 
-def test_counts_distinct_addresses_across_subsets() -> None:
-    """Addresses repeated across subsets describe one API server each, not several."""
+def test_counts_each_dual_stack_address_family_once() -> None:
+    """A dual-stack Service lists every API server per family, so families are not additive."""
+    check = _run(
+        _step_output(),
+        slices=_ok(
+            _slices(
+                _slice("10.0.0.1", "10.0.0.2", "10.0.0.3"),
+                _slice("fd00::1", "fd00::2", "fd00::3", family="IPv6"),
+            )
+        ),
+    )
+
+    assert check.passed, check.message
+    assert "3 API server endpoint(s)" in check.message
+
+
+def test_pools_endpoints_sharded_across_slices_of_one_family() -> None:
+    """One family's endpoints may span several slices, which together describe the instances."""
+    check = _run(
+        _step_output(),
+        slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2"), _slice("10.0.0.3"))),
+    )
+
+    assert check.passed, check.message
+    assert "3 API server endpoint(s)" in check.message
+
+
+def test_ignores_endpoints_that_are_not_ready() -> None:
+    """An API server withdrawn from service is not registered capacity."""
+    check = _run(
+        _step_output(requested_instance_count=2, instance_count=2),
+        slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2"), _slice("10.0.0.3", ready=False))),
+    )
+
+    assert check.passed, check.message
+    assert "2 API server endpoint(s)" in check.message
+
+
+def test_counts_an_endpoint_that_states_no_ready_condition() -> None:
+    """The EndpointSlice API defines an absent ready condition as ready."""
+    check = _run(_step_output(), slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2", "10.0.0.3", ready=None))))
+
+    assert check.passed, check.message
+    assert "matching the pin" in check.message
+
+
+def test_falls_back_to_endpoints_when_endpointslices_are_refused() -> None:
+    """A cluster or RBAC grant that only answers on Endpoints still yields the measurement."""
+    check = _run(
+        _step_output(),
+        slices=_fail(stderr="Error from server (Forbidden): endpointslices is forbidden"),
+        endpoints=_ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3")),
+    )
+
+    assert check.passed, check.message
+    assert "matching the pin" in check.message
+    assert check.commands_run == [SLICES_COMMAND, ENDPOINTS_COMMAND]
+
+
+def test_falls_back_to_endpoints_when_no_slices_back_the_service() -> None:
+    """An empty slice list is inconclusive rather than proof of an empty control plane."""
+    check = _run(
+        _step_output(),
+        slices=_ok(json.dumps({"items": []})),
+        endpoints=_ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3")),
+    )
+
+    assert check.passed, check.message
+    assert check.commands_run == [SLICES_COMMAND, ENDPOINTS_COMMAND]
+
+
+def test_counts_distinct_addresses_across_endpoints_subsets() -> None:
+    """On the fallback path, addresses repeated across subsets describe one API server each."""
     payload = json.dumps(
         {
             "subsets": [
@@ -116,7 +218,7 @@ def test_counts_distinct_addresses_across_subsets() -> None:
         }
     )
 
-    check = _run(_step_output(), endpoints=_ok(payload))
+    check = _run(_step_output(), slices=_fail(stderr="no EndpointSlice support"), endpoints=_ok(payload))
 
     assert check.passed, check.message
     assert "3 API server endpoint(s)" in check.message
@@ -166,29 +268,35 @@ def test_fails_when_the_delivered_count_is_missing() -> None:
     assert "instance_count" in check.message
 
 
-def test_fails_when_the_endpoints_probe_is_refused() -> None:
+def test_fails_when_both_endpoint_probes_are_refused() -> None:
     """Losing the independent measurement leaves only the provider's own report."""
     check = _run(
         _step_output(),
+        slices=_fail(stderr="Error from server (Forbidden): endpointslices is forbidden"),
         endpoints=_fail(stderr='Error from server (Forbidden): endpoints "kubernetes" is forbidden'),
     )
 
     assert not check.passed
     assert "Could not count registered API servers" in check.message
-    assert "Forbidden" in check.message
+    assert "endpointslices is forbidden" in check.message
+    assert 'endpoints "kubernetes" is forbidden' in check.message
 
 
-def test_fails_when_the_endpoints_payload_is_malformed() -> None:
+def test_fails_when_both_endpoint_payloads_are_malformed() -> None:
     """Unparseable probe output is inconclusive, not a pass."""
-    check = _run(_step_output(), endpoints=_ok("not json"))
+    check = _run(_step_output(), slices=_ok("not json"), endpoints=_ok("not json"))
 
     assert not check.passed
     assert "Failed to parse" in check.message
 
 
-def test_fails_when_no_apiserver_endpoints_are_registered() -> None:
-    """An Endpoints object with no addresses corroborates nothing."""
-    check = _run(_step_output(), endpoints=_ok(json.dumps({"subsets": []})))
+def test_fails_when_no_apiserver_endpoints_are_registered_anywhere() -> None:
+    """A Service backing no ready endpoints corroborates nothing."""
+    check = _run(
+        _step_output(),
+        slices=_ok(_slices(_slice())),
+        endpoints=_ok(json.dumps({"subsets": []})),
+    )
 
     assert not check.passed
-    assert "registers no API server endpoints" in check.message
+    assert "registers no ready API server endpoints" in check.message

--- a/isvtest/tests/test_k8s_control_plane_size.py
+++ b/isvtest/tests/test_k8s_control_plane_size.py
@@ -77,11 +77,13 @@ def _run(
     step_output: Any,
     slices: CommandResult | None = None,
     endpoints: CommandResult | None = None,
-) -> K8sControlPlaneSizePinnedCheck:
+) -> tuple[K8sControlPlaneSizePinnedCheck, list[str]]:
     """Run the check, answering the EndpointSlice probe and its Endpoints fallback.
 
-    The fallback defaults to a refusal so a test exercising the EndpointSlice
-    path cannot pass by silently falling through to Endpoints.
+    Returns the check alongside the kubectl commands it issued, so a test can
+    assert which probes ran. The fallback defaults to a refusal so a test
+    exercising the EndpointSlice path cannot pass by silently falling through
+    to Endpoints.
     """
     check = K8sControlPlaneSizePinnedCheck(config={"step_output": step_output})
     responses = {
@@ -93,23 +95,22 @@ def _run(
         patch.object(check, "run_command", side_effect=lambda command, **_: responses[command]) as mock_run,
     ):
         check.run()
-    check.commands_run = [call[0][0] for call in mock_run.call_args_list]  # type: ignore[attr-defined]
-    return check
+    return check, [call[0][0] for call in mock_run.call_args_list]
 
 
 def test_passes_when_registered_apiservers_match_the_pin() -> None:
     """A pin the provider delivered and the cluster corroborates exactly passes."""
-    check = _run(_step_output())
+    check, commands = _run(_step_output())
 
     assert check.passed, check.message
     assert "pinned at 3 instance(s)" in check.message
     assert "matching the pin" in check.message
-    assert check.commands_run == [SLICES_COMMAND]
+    assert commands == [SLICES_COMMAND]
 
 
 def test_passes_when_a_load_balanced_api_address_hides_instances() -> None:
     """One endpoint behind a fronted API address cannot contradict a larger pin."""
-    check = _run(_step_output(), slices=_ok(_slices(_slice("10.0.0.1"))))
+    check, _ = _run(_step_output(), slices=_ok(_slices(_slice("10.0.0.1"))))
 
     assert check.passed, check.message
     assert "load-balanced" in check.message
@@ -117,7 +118,7 @@ def test_passes_when_a_load_balanced_api_address_hides_instances() -> None:
 
 def test_fails_when_more_apiservers_are_registered_than_pinned() -> None:
     """Extra registered API servers cannot be explained by fronting, so the pin is not held."""
-    check = _run(
+    check, _ = _run(
         _step_output(),
         slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"))),
     )
@@ -129,16 +130,16 @@ def test_fails_when_more_apiservers_are_registered_than_pinned() -> None:
 
 def test_fails_when_the_provider_delivered_a_different_count() -> None:
     """A delivered count that differs from the request is not a pin, and needs no probe."""
-    check = _run(_step_output(instance_count=2))
+    check, commands = _run(_step_output(instance_count=2))
 
     assert not check.passed
     assert "requested 3 instance(s) and the provider reports 2" in check.message
-    assert check.commands_run == []
+    assert commands == []
 
 
 def test_counts_each_dual_stack_address_family_once() -> None:
     """A dual-stack Service lists every API server per family, so families are not additive."""
-    check = _run(
+    check, _ = _run(
         _step_output(),
         slices=_ok(
             _slices(
@@ -154,7 +155,7 @@ def test_counts_each_dual_stack_address_family_once() -> None:
 
 def test_pools_endpoints_sharded_across_slices_of_one_family() -> None:
     """One family's endpoints may span several slices, which together describe the instances."""
-    check = _run(
+    check, _ = _run(
         _step_output(),
         slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2"), _slice("10.0.0.3"))),
     )
@@ -165,7 +166,7 @@ def test_pools_endpoints_sharded_across_slices_of_one_family() -> None:
 
 def test_ignores_endpoints_that_are_not_ready() -> None:
     """An API server withdrawn from service is not registered capacity."""
-    check = _run(
+    check, _ = _run(
         _step_output(requested_instance_count=2, instance_count=2),
         slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2"), _slice("10.0.0.3", ready=False))),
     )
@@ -176,7 +177,7 @@ def test_ignores_endpoints_that_are_not_ready() -> None:
 
 def test_counts_an_endpoint_that_states_no_ready_condition() -> None:
     """The EndpointSlice API defines an absent ready condition as ready."""
-    check = _run(_step_output(), slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2", "10.0.0.3", ready=None))))
+    check, _ = _run(_step_output(), slices=_ok(_slices(_slice("10.0.0.1", "10.0.0.2", "10.0.0.3", ready=None))))
 
     assert check.passed, check.message
     assert "matching the pin" in check.message
@@ -184,7 +185,7 @@ def test_counts_an_endpoint_that_states_no_ready_condition() -> None:
 
 def test_falls_back_to_endpoints_when_endpointslices_are_refused() -> None:
     """A cluster or RBAC grant that only answers on Endpoints still yields the measurement."""
-    check = _run(
+    check, commands = _run(
         _step_output(),
         slices=_fail(stderr="Error from server (Forbidden): endpointslices is forbidden"),
         endpoints=_ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3")),
@@ -192,19 +193,19 @@ def test_falls_back_to_endpoints_when_endpointslices_are_refused() -> None:
 
     assert check.passed, check.message
     assert "matching the pin" in check.message
-    assert check.commands_run == [SLICES_COMMAND, ENDPOINTS_COMMAND]
+    assert commands == [SLICES_COMMAND, ENDPOINTS_COMMAND]
 
 
 def test_falls_back_to_endpoints_when_no_slices_back_the_service() -> None:
     """An empty slice list is inconclusive rather than proof of an empty control plane."""
-    check = _run(
+    check, commands = _run(
         _step_output(),
         slices=_ok(json.dumps({"items": []})),
         endpoints=_ok(_endpoints("10.0.0.1", "10.0.0.2", "10.0.0.3")),
     )
 
     assert check.passed, check.message
-    assert check.commands_run == [SLICES_COMMAND, ENDPOINTS_COMMAND]
+    assert commands == [SLICES_COMMAND, ENDPOINTS_COMMAND]
 
 
 def test_counts_distinct_addresses_across_endpoints_subsets() -> None:
@@ -218,7 +219,7 @@ def test_counts_distinct_addresses_across_endpoints_subsets() -> None:
         }
     )
 
-    check = _run(_step_output(), slices=_fail(stderr="no EndpointSlice support"), endpoints=_ok(payload))
+    check, _ = _run(_step_output(), slices=_fail(stderr="no EndpointSlice support"), endpoints=_ok(payload))
 
     assert check.passed, check.message
     assert "3 API server endpoint(s)" in check.message
@@ -226,23 +227,23 @@ def test_counts_distinct_addresses_across_endpoints_subsets() -> None:
 
 def test_accepts_counts_emitted_as_decimal_strings() -> None:
     """A provider script emitting counts as strings still satisfies the contract."""
-    check = _run(_step_output(requested_instance_count="3", instance_count="3"))
+    check, _ = _run(_step_output(requested_instance_count="3", instance_count="3"))
 
     assert check.passed, check.message
 
 
 def test_fails_when_the_pin_step_reported_failure() -> None:
     """A pin that did not happen is reported with the step's own error."""
-    check = _run(_step_output(success=False, error="control-plane resize quota exceeded"))
+    check, commands = _run(_step_output(success=False, error="control-plane resize quota exceeded"))
 
     assert not check.passed
     assert "control-plane resize quota exceeded" in check.message
-    assert check.commands_run == []
+    assert commands == []
 
 
 def test_fails_without_step_output() -> None:
     """An unbound check has no pin to verify."""
-    check = _run(None)
+    check, _ = _run(None)
 
     assert not check.passed
     assert "Missing step_output" in check.message
@@ -251,7 +252,7 @@ def test_fails_without_step_output() -> None:
 @pytest.mark.parametrize("requested", [0, -1, True, "three", None, 2.5])
 def test_fails_on_an_unusable_requested_count(requested: Any) -> None:
     """The requested count has to be a real instance count for the pin to mean anything."""
-    check = _run(_step_output(requested_instance_count=requested))
+    check, _ = _run(_step_output(requested_instance_count=requested))
 
     assert not check.passed
     assert "requested_instance_count" in check.message
@@ -262,7 +263,7 @@ def test_fails_when_the_delivered_count_is_missing() -> None:
     output = _step_output()
     output.pop("instance_count")
 
-    check = _run(output)
+    check, _ = _run(output)
 
     assert not check.passed
     assert "instance_count" in check.message
@@ -270,7 +271,7 @@ def test_fails_when_the_delivered_count_is_missing() -> None:
 
 def test_fails_when_both_endpoint_probes_are_refused() -> None:
     """Losing the independent measurement leaves only the provider's own report."""
-    check = _run(
+    check, _ = _run(
         _step_output(),
         slices=_fail(stderr="Error from server (Forbidden): endpointslices is forbidden"),
         endpoints=_fail(stderr='Error from server (Forbidden): endpoints "kubernetes" is forbidden'),
@@ -284,7 +285,7 @@ def test_fails_when_both_endpoint_probes_are_refused() -> None:
 
 def test_fails_when_both_endpoint_payloads_are_malformed() -> None:
     """Unparseable probe output is inconclusive, not a pass."""
-    check = _run(_step_output(), slices=_ok("not json"), endpoints=_ok("not json"))
+    check, _ = _run(_step_output(), slices=_ok("not json"), endpoints=_ok("not json"))
 
     assert not check.passed
     assert "Failed to parse" in check.message
@@ -292,7 +293,7 @@ def test_fails_when_both_endpoint_payloads_are_malformed() -> None:
 
 def test_fails_when_no_apiserver_endpoints_are_registered_anywhere() -> None:
     """A Service backing no ready endpoints corroborates nothing."""
-    check = _run(
+    check, _ = _run(
         _step_output(),
         slices=_ok(_slices(_slice())),
         endpoints=_ok(json.dumps({"subsets": []})),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #217

## What

`K8S27` had a plan entry but no validation class and no wiring.

Pinning is an act, not an observation, so a bound `pin_control_plane` step performs the pin and reports `requested_instance_count` alongside the `instance_count` it delivered. `K8sControlPlaneSizePinnedCheck` asserts over that, then corroborates it against the cluster: the EndpointSlices backing `default/kubernetes` carry one ready endpoint per registered API server. The check is held in the test phase while the pin runs in setup, so that reading is also a *later* sample.

The comparison is one-sided on purpose. A provider fronting its API servers behind one load-balanced address publishes a single endpoint however many sit behind it, so **fewer** endpoints than the pin proves nothing. **More** cannot be explained that way, so it fails. An unanswerable probe (RBAC refusal, malformed payload, no ready endpoints) fails rather than falling back to the provider's word.

`discovery.k8s.io/v1` is the primary read with the deprecated v1 Endpoints API as fallback. Dual-stack slice families each enumerate every API server, so families are compared rather than summed; a family's endpoints may be sharded, so they are pooled before counting.

**AWS is left unwired** — EKS exposes no control-plane sizing knob, so there is no pin to make. The check skips as `step_not_configured`; stubbing it would manufacture the vacuous pass the corroboration exists to prevent.

## Verification

Run end-to-end through `isvctl` against two real clusters, since the corroboration can only be trusted against a live API server and its endpoint reconciler.

| Cluster | API servers | Pin | Result |
| --- | --- | --- | --- |
| minikube (v1.35.1) | 1 | 1 | PASS |
| minikube | 1 | 3 | PASS — indistinguishable from a fronted address |
| managed 3-CP (v1.34.11) | 3 | 3 | PASS |
| managed 3-CP | 3 | 2 | **FAIL** — registers 3, more than the pin allows |
| managed 3-CP, EndpointSlice denied | 3 | 3 | PASS via the Endpoints fallback |

The fourth row is the one that matters: the check rejected a pin the cluster was not holding using only its own measurement. Failure paths a healthy cluster never produces are covered by 24 unit tests with a mocked kubectl. `make test`, `make lint`, `make demo-test`, `uvx pre-commit run -a` and the `plan-coverage` / `validate-suites` guardrails all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86147471-5038-4ec2-b87f-ed41119f27fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86147471-5038-4ec2-b87f-ed41119f27fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes control-plane sizing configuration with a customizable instance count, defaulting to three.
  * Added validation comparing the requested size with the reported count and ready API-server endpoints.
  * Added control-plane sizing results and sizing API guidance.
  * Providers without control-plane sizing support can skip this validation.

* **Documentation**
  * Updated the K8S27-01 test plan with Kubernetes labeling and control-plane pinning coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
